### PR TITLE
feat: Add --feature-gate flag to yurt-controller-manager

### DIFF
--- a/cmd/yurt-controller-manager/app/options/options.go
+++ b/cmd/yurt-controller-manager/app/options/options.go
@@ -22,24 +22,26 @@ package options
 import (
 	"time"
 
-	yurtcontrollerconfig "github.com/openyurtio/openyurt/cmd/yurt-controller-manager/app/config"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	clientgokubescheme "k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	cliflag "k8s.io/component-base/cli/flag"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/klog"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	nodelifecycleconfig "k8s.io/kubernetes/pkg/controller/nodelifecycle/config"
 
+	yurtcontrollerconfig "github.com/openyurtio/openyurt/cmd/yurt-controller-manager/app/config"
 	// add the kubernetes feature gates
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	componentbaseconfig "k8s.io/component-base/config"
-	"k8s.io/klog"
+	_ "k8s.io/kubernetes/pkg/features"
 )
 
 const (
@@ -102,7 +104,7 @@ func (s *YurtControllerManagerOptions) Flags(allControllers []string, disabledBy
 	fs := fss.FlagSet("misc")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-	//utilfeature.DefaultMutableFeatureGate.AddFlag(fss.FlagSet("generic"))
+	utilfeature.DefaultMutableFeatureGate.AddFlag(fss.FlagSet("generic"))
 	fs.BoolVar(&s.Version, "version", s.Version, "print the version information.")
 
 	return fss


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add `--feature-gates ` flag to yurt-controller-manager.

Reference:
https://github.com/kubernetes/kubernetes/blob/v1.16.15/cmd/kube-controller-manager/app/options/options.go#L251

### Ⅱ. Does this pull request fix one issue?
fixes #212
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
**step1**
Start a 2 nodes Kubernetes cluster, name the master node as `master`  and  the worker node as `worker`:
```
$ kubectl get nodes
NAME     STATUS   ROLES    AGE   VERSION
master   Ready    master   30h   v1.16.15
worker   Ready    <none>   30h   v1.16.15
```
Install and run `yurt-controller-manager` with the following `--feature-gates` flags:
```
./yurt-controller-manager  --kubeconfig $your-kubeconfig --feature-gates=LegacyNodeRoleBehavior=false
```

**step2**
Stop the `kubelet` on the worker node.

**step3**
Watch the output log of `yurt-controller-manager` and wait for the `NodeNotReady` event to be observed by the controller. After observing the event, if there is not showing “Entering master disruption mode”,  then the `--feature-gates` is working as intended.

### Ⅴ. Special notes for reviews


