### PR TITLE
Enhance YurtHub's caching ability

### DIFF
--- a/pkg/yurthub/kubernetes/serializer/serializer.go
+++ b/pkg/yurthub/kubernetes/serializer/serializer.go
@@ -20,11 +20,16 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -35,30 +40,174 @@ import (
 // YurtHubSerializer is a global serializer manager for yurthub
 var YurtHubSerializer = NewSerializerManager()
 
+// UnsafeDefaultRESTMapper is only used to check whether the GVK is in the scheme according to the GVR information
+var UnsafeDefaultRESTMapper = NewDefaultRESTMapperFromScheme()
+
+func NewDefaultRESTMapperFromScheme() *meta.DefaultRESTMapper {
+	scheme := scheme.Scheme
+	defaultGroupVersions := scheme.PrioritizedVersionsAllGroups()
+	mapper := meta.NewDefaultRESTMapper(defaultGroupVersions)
+	// enumerate all supported versions, get the kinds, and register with the mapper how to address
+	// our resources.
+	for _, gv := range defaultGroupVersions {
+		for kind := range scheme.KnownTypes(gv) {
+			//Since RESTMapper is only used for mapping GVR to GVK information,
+			//the scope field is not involved in actual use, so all scope are currently set to meta.RESTScopeNamespace
+			scope := meta.RESTScopeNamespace
+			mapper.Add(gv.WithKind(kind), scope)
+		}
+	}
+	return mapper
+}
+
 // SerializerManager is responsible for managing *rest.Serializers
 type SerializerManager struct {
 	// NegotiatedSerializer is used for obtaining encoders and decoders for multiple
 	// supported media types.
 	NegotiatedSerializer runtime.NegotiatedSerializer
+	// UnstructuredNegotiatedSerializer is used to obtain encoders and decoders
+	// for resources not registered in the scheme
+	UnstructuredNegotiatedSerializer runtime.NegotiatedSerializer
 }
 
 // NewSerializerManager creates a *SerializerManager object with no version conversion
 func NewSerializerManager() *SerializerManager {
 	return &SerializerManager{
-		NegotiatedSerializer: serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}, // do not need version conversion
+		// do not need version conversion, and keep the gvk information
+		NegotiatedSerializer:             WithVersionCodecFactory{CodecFactory: scheme.Codecs},
+		UnstructuredNegotiatedSerializer: NewUnstructuredNegotiatedSerializer(),
+	}
+}
+
+// WithVersionCodecFactory is a CodecFactory that will explicitly ignore requests to perform conversion.
+// It keeps the gvk during deserialization.
+// This wrapper is used while code migrates away from using conversion (such as external clients)
+type WithVersionCodecFactory struct {
+	serializer.CodecFactory
+}
+
+// EncoderForVersion returns an encoder that does not do conversion, but does set the group version kind of the object
+// when serialized.
+func (f WithVersionCodecFactory) EncoderForVersion(serializer runtime.Encoder, version runtime.GroupVersioner) runtime.Encoder {
+	return runtime.WithVersionEncoder{
+		Version:     version,
+		Encoder:     serializer,
+		ObjectTyper: scheme.Scheme,
+	}
+}
+
+// DecoderToVersion returns an decoder that does not do conversion, and keeps the gvk information
+func (f WithVersionCodecFactory) DecoderToVersion(serializer runtime.Decoder, _ runtime.GroupVersioner) runtime.Decoder {
+	return WithVersionDecoder{
+		Decoder: serializer,
+	}
+}
+
+// WithVersionDecoder keeps the group version kind of a deserialized object.
+type WithVersionDecoder struct {
+	runtime.Decoder
+}
+
+// Decode does not do conversion. It keeps the gvk during deserialization.
+func (d WithVersionDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	return d.Decoder.Decode(data, defaults, into)
+}
+
+type UnstructuredNegotiatedSerializer struct {
+	scheme  *runtime.Scheme
+	typer   runtime.ObjectTyper
+	creator runtime.ObjectCreater
+}
+
+// NewUnstructuredNegotiatedSerializer returns a negotiated serializer for Unstructured resources
+func NewUnstructuredNegotiatedSerializer() runtime.NegotiatedSerializer {
+	return UnstructuredNegotiatedSerializer{
+		scheme:  scheme.Scheme,
+		typer:   unstructuredscheme.NewUnstructuredObjectTyper(),
+		creator: NewUnstructuredCreator(),
+	}
+}
+
+func (s UnstructuredNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, s.creator, s.typer, json.SerializerOptions{}),
+			PrettySerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, s.creator, s.typer, json.SerializerOptions{Pretty: true}),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializerWithOptions(json.DefaultMetaFactory, s.creator, s.typer, json.SerializerOptions{}),
+				Framer:        json.Framer,
+			},
+		},
+		{
+			MediaType:        "application/yaml",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "yaml",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, s.creator, s.typer, json.SerializerOptions{Yaml: true}),
+		},
+	}
+}
+
+//EncoderForVersion do nothing, but returns a encoder,
+//if the object is unstructured, the encoder will encode object without conversion
+func (s UnstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return encoder
+}
+
+//DecoderToVersion do nothing, and returns a decoder that does not do conversion
+func (s UnstructuredNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, _ runtime.GroupVersioner) runtime.Decoder {
+	return WithVersionDecoder{
+		Decoder: decoder,
+	}
+}
+
+type unstructuredCreator struct{}
+
+// NewUnstructuredCreator returns a simple object creator that always returns an Unstructured or UnstructuredList
+func NewUnstructuredCreator() runtime.ObjectCreater {
+	return unstructuredCreator{}
+}
+
+func (c unstructuredCreator) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	if strings.HasSuffix(kind.Kind, "List") {
+		ret := &unstructured.UnstructuredList{}
+		ret.SetGroupVersionKind(kind)
+		return ret, nil
+	} else {
+		ret := &unstructured.Unstructured{}
+		ret.SetGroupVersionKind(kind)
+		return ret, nil
 	}
 }
 
 // CreateSerializers create a *rest.Serializers for encoding or decoding runtime object
-func (sm *SerializerManager) CreateSerializers(contentType, group, version string) (*rest.Serializers, error) {
-	mediaTypes := sm.NegotiatedSerializer.SupportedMediaTypes()
+func (sm *SerializerManager) CreateSerializers(contentType, group, version, resource string) (*rest.Serializers, error) {
+	var mediaTypes []runtime.SerializerInfo
+	gvr := schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: resource,
+	}
+	_, kindErr := UnsafeDefaultRESTMapper.KindFor(gvr)
+	if kindErr == nil || resource == "WatchEvent" {
+		mediaTypes = sm.NegotiatedSerializer.SupportedMediaTypes()
+	} else {
+		mediaTypes = sm.UnstructuredNegotiatedSerializer.SupportedMediaTypes()
+	}
 	mediaType, _, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		return nil, fmt.Errorf("the content type(%s) specified in the request is not recognized: %v", contentType, err)
 	}
-
 	info, ok := runtime.SerializerInfoForMediaType(mediaTypes, mediaType)
 	if !ok {
+		if mediaType == "application/vnd.kubernetes.protobuf" && kindErr != nil {
+			return nil, fmt.Errorf("*unstructured.Unstructured(%s/%s) does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message", group, version)
+		}
 		if len(contentType) != 0 || len(mediaTypes) == 0 {
 			return nil, fmt.Errorf("no serializers registered for %s", contentType)
 		}
@@ -80,17 +229,30 @@ func (sm *SerializerManager) CreateSerializers(contentType, group, version strin
 		Group:   group,
 		Version: version,
 	}
+	var encoder runtime.Encoder
+	var decoder runtime.Decoder
+	if kindErr == nil {
+		encoder = sm.NegotiatedSerializer.EncoderForVersion(info.Serializer, &reqGroupVersion)
+		decoder = sm.NegotiatedSerializer.DecoderToVersion(info.Serializer, internalGV)
+	} else {
+		encoder = sm.UnstructuredNegotiatedSerializer.EncoderForVersion(info.Serializer, &reqGroupVersion)
+		decoder = sm.UnstructuredNegotiatedSerializer.DecoderToVersion(info.Serializer, &reqGroupVersion)
+	}
 
 	s := &rest.Serializers{
-		Encoder: sm.NegotiatedSerializer.EncoderForVersion(info.Serializer, &reqGroupVersion),
-		Decoder: sm.NegotiatedSerializer.DecoderToVersion(info.Serializer, internalGV),
+		Encoder: encoder,
+		Decoder: decoder,
 
 		RenegotiatedDecoder: func(contentType string, params map[string]string) (runtime.Decoder, error) {
 			info, ok := runtime.SerializerInfoForMediaType(mediaTypes, contentType)
 			if !ok {
 				return nil, fmt.Errorf("serializer for %s not registered", contentType)
 			}
-			return sm.NegotiatedSerializer.DecoderToVersion(info.Serializer, internalGV), nil
+			if kindErr == nil {
+				return sm.NegotiatedSerializer.DecoderToVersion(info.Serializer, internalGV), nil
+			} else {
+				return sm.UnstructuredNegotiatedSerializer.DecoderToVersion(info.Serializer, &reqGroupVersion), nil
+			}
 		},
 	}
 	if info.StreamSerializer != nil {
@@ -129,14 +291,28 @@ func DecodeResp(serializers *rest.Serializers, b []byte, reqContentType, respCon
 	switch out.(type) {
 	case *metav1.Status:
 		// it's not need to cache for status
-		return nil, nil
+		return out, nil
 	}
 	return out, nil
 }
 
-// WatchDecoder generates a Decoder for watch response
-func WatchDecoder(serializers *rest.Serializers, body io.ReadCloser) (*restclientwatch.Decoder, error) {
+// CreateWatchDecoder generates a Decoder for watch response
+func CreateWatchDecoder(contentType, group, version, resource string, body io.ReadCloser) (*restclientwatch.Decoder, error) {
+	//get the general serializers to decode the watch event
+	serializers, err := YurtHubSerializer.CreateSerializers(contentType, group, version, "WatchEvent")
+	if err != nil {
+		klog.Errorf("failed to create serializers in saveWatchObject, %v", err)
+		return nil, err
+	}
+
+	//get the serializers to decode the embedded object inside watch event according to the GVR of embedded object
+	embeddedSerializers, err := YurtHubSerializer.CreateSerializers(contentType, group, version, resource)
+	if err != nil {
+		klog.Errorf("failed to create serializers in saveWatchObject, %v", err)
+		return nil, err
+	}
+
 	framer := serializers.Framer.NewFrameReader(body)
 	streamingDecoder := streaming.NewDecoder(framer, serializers.StreamingSerializer)
-	return restclientwatch.NewDecoder(streamingDecoder, serializers.Decoder), nil
+	return restclientwatch.NewDecoder(streamingDecoder, embeddedSerializers.Decoder), nil
 }

--- a/pkg/yurthub/proxy/local/local_test.go
+++ b/pkg/yurthub/proxy/local/local_test.go
@@ -371,6 +371,7 @@ func TestServeHTTPForGetReqCache(t *testing.T) {
 		accept    string
 		verb      string
 		path      string
+		resource  string
 		code      int
 		data      expectData
 	}{
@@ -391,10 +392,11 @@ func TestServeHTTPForGetReqCache(t *testing.T) {
 					},
 				},
 			},
-			accept: "application/json",
-			verb:   "GET",
-			path:   "/api/v1/namespaces/default/pods/mypod1",
-			code:   http.StatusOK,
+			accept:   "application/json",
+			verb:     "GET",
+			path:     "/api/v1/namespaces/default/pods/mypod1",
+			resource: "pods",
+			code:     http.StatusOK,
 			data: expectData{
 				ns:   "default",
 				name: "mypod1",
@@ -407,7 +409,7 @@ func TestServeHTTPForGetReqCache(t *testing.T) {
 
 	for _, tt := range testcases {
 		t.Run(tt.desc, func(t *testing.T) {
-			jsonDecoder, _ := serializerM.CreateSerializers(tt.accept, "", "v1")
+			jsonDecoder, _ := serializerM.CreateSerializers(tt.accept, "", "v1", tt.resource)
 			accessor := meta.NewAccessor()
 			for i := range tt.inputObj {
 				name, _ := accessor.Name(tt.inputObj[i])
@@ -495,6 +497,7 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 		accept    string
 		verb      string
 		path      string
+		resource  string
 		code      int
 		expectD   expectData
 	}{
@@ -537,10 +540,11 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 					},
 				},
 			},
-			accept: "application/json",
-			verb:   "GET",
-			path:   "/api/v1/namespaces/default/pods",
-			code:   http.StatusOK,
+			accept:   "application/json",
+			verb:     "GET",
+			path:     "/api/v1/namespaces/default/pods",
+			resource: "pods",
+			code:     http.StatusOK,
 			expectD: expectData{
 				rv: "6",
 				data: map[string]struct{}{
@@ -556,7 +560,7 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 
 	for _, tt := range testcases {
 		t.Run(tt.desc, func(t *testing.T) {
-			jsonDecoder, _ := serializerM.CreateSerializers(tt.accept, "", "v1")
+			jsonDecoder, _ := serializerM.CreateSerializers(tt.accept, "", "v1", tt.resource)
 			accessor := meta.NewAccessor()
 			for i := range tt.inputObj {
 				name, _ := accessor.Name(tt.inputObj[i])


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
1. Replace the original [serializer.WithoutConversionCodecFactory](https://github.com/alibaba/openyurt/blob/7095962687e2666a27d14e436b96ef893b228beb/pkg/yurthub/kubernetes/serializer/serializer.go#L48) with a custom WithVersionCodecFactory so that the GVK information can be preserved during deserialization. 
2. Delete both the [resourceToKindMap](https://github.com/openyurtio/openyurt/blob/4d7463a40801c29d09c4f7d10ba46b73cb019915/pkg/yurthub/cachemanager/cache_manager.go#L46) and the [resourceToListKindMap](https://github.com/openyurtio/openyurt/blob/4d7463a40801c29d09c4f7d10ba46b73cb019915/pkg/yurthub/cachemanager/cache_manager.go#L62)
3. On the basis of the existing NegotiatedSerializer increase a new [unstructuredNegotiatedSerializer](https://github.com/qclc/openyurt/blob/8e464566f0bd0403c3e1c95fe7ce17d64a5aaba6/pkg/yurthub/kubernetes/serializer/serializer.go#L58), used to decode the structure of the unregistered Custom Resources.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #162 
This PR extends the ability to cache CR resources, removing the restriction that only resources in [resourceToKindMap](https://github.com/openyurtio/openyurt/blob/4d7463a40801c29d09c4f7d10ba46b73cb019915/pkg/yurthub/cachemanager/cache_manager.go#L46) and [resourceToListKindMap](https://github.com/openyurtio/openyurt/blob/4d7463a40801c29d09c4f7d10ba46b73cb019915/pkg/yurthub/cachemanager/cache_manager.go#L62) can be cached.
### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
1. Unit tests for CR caching and getting have been added to cache_manager_test.go;

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews