### PR TITLE
refactor: divide the yurthubServer into hubServer and proxyServert

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
@@ -15,8 +16,8 @@ import (
 type YurtHubConfiguration struct {
 	LBMode                    string
 	RemoteServers             []*url.URL
-	YurtHubHost               string
-	YurtHubPort               int
+	YurtHubServerAddr         string
+	YurtHubProxyServerAddr    string
 	GCFrequency               int
 	CertMgrMode               string
 	NodeName                  string
@@ -26,6 +27,7 @@ type YurtHubConfiguration struct {
 	MaxRequestInFlight        int
 	JoinToken                 string
 	RootDir                   string
+	EnableProfiling           bool
 }
 
 // Complete converts *options.YurtHubOptions to *YurtHubConfiguration
@@ -35,11 +37,13 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		return nil, err
 	}
 
+	hubServerAddr := net.JoinHostPort(options.YurtHubHost, options.YurtHubPort)
+	proxyServerAddr := net.JoinHostPort(options.YurtHubHost, options.YurtHubProxyPort)
 	cfg := &YurtHubConfiguration{
 		LBMode:                    options.LBMode,
 		RemoteServers:             us,
-		YurtHubHost:               options.YurtHubHost,
-		YurtHubPort:               options.YurtHubPort,
+		YurtHubServerAddr:         hubServerAddr,
+		YurtHubProxyServerAddr:    proxyServerAddr,
 		GCFrequency:               options.GCFrequency,
 		CertMgrMode:               options.CertMgrMode,
 		NodeName:                  options.NodeName,
@@ -49,6 +53,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		MaxRequestInFlight:        options.MaxRequestInFlight,
 		JoinToken:                 options.JoinToken,
 		RootDir:                   options.RootDir,
+		EnableProfiling:           options.EnableProfiling,
 	}
 
 	return cfg, nil

--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -13,7 +13,8 @@ import (
 type YurtHubOptions struct {
 	ServerAddr                string
 	YurtHubHost               string
-	YurtHubPort               int
+	YurtHubPort               string
+	YurtHubProxyPort          string
 	GCFrequency               int
 	CertMgrMode               string
 	NodeName                  string
@@ -25,13 +26,15 @@ type YurtHubOptions struct {
 	JoinToken                 string
 	RootDir                   string
 	Version                   bool
+	EnableProfiling           bool
 }
 
 // NewYurtHubOptions creates a new YurtHubOptions with a default config.
 func NewYurtHubOptions() *YurtHubOptions {
 	o := &YurtHubOptions{
 		YurtHubHost:               "127.0.0.1",
-		YurtHubPort:               10261,
+		YurtHubProxyPort:          "10261",
+		YurtHubPort:               "10267",
 		GCFrequency:               120,
 		CertMgrMode:               "hubself",
 		LBMode:                    "rr",
@@ -40,6 +43,7 @@ func NewYurtHubOptions() *YurtHubOptions {
 		HeartbeatTimeoutSeconds:   2,
 		MaxRequestInFlight:        250,
 		RootDir:                   filepath.Join("/var/lib/", projectinfo.GetHubName()),
+		EnableProfiling:           true,
 	}
 
 	return o
@@ -69,7 +73,8 @@ func ValidateOptions(options *YurtHubOptions) error {
 // AddFlags returns flags for a specific yurthub by section name
 func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.YurtHubHost, "bind-address", o.YurtHubHost, "the IP address on which to listen for the --serve-port port.")
-	fs.IntVar(&o.YurtHubPort, "serve-port", o.YurtHubPort, "the port on which to serve HTTP.")
+	fs.StringVar(&o.YurtHubPort, "serve-port", o.YurtHubPort, "the port on which to serve HTTP requests(like profiling, metrics) for hub agent.")
+	fs.StringVar(&o.YurtHubProxyPort, "proxy-port", o.YurtHubProxyPort, "the port on which to proxy HTTP requests to kube-apiserver")
 	fs.StringVar(&o.ServerAddr, "server-addr", o.ServerAddr, "the address of Kubernetes kube-apiserver,the format is: \"server1,server2,...\"")
 	fs.StringVar(&o.CertMgrMode, "cert-mgr-mode", o.CertMgrMode, "the cert manager mode, kubelet: use certificates that belongs to kubelet, hubself: auto generate client cert for hub agent.")
 	fs.IntVar(&o.GCFrequency, "gc-frequency", o.GCFrequency, "the frequency to gc cache in storage(unit: minute).")
@@ -82,4 +87,5 @@ func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.JoinToken, "join-token", o.JoinToken, "the Join token for bootstrapping hub agent when --cert-mgr-mode=hubself.")
 	fs.StringVar(&o.RootDir, "root-dir", o.RootDir, "directory path for managing hub agent files(pki, cache etc).")
 	fs.BoolVar(&o.Version, "version", o.Version, "print the version information.")
+	fs.BoolVar(&o.EnableProfiling, "profiling", o.EnableProfiling, "Enable profiling via web interface host:port/debug/pprof/")
 }

--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -145,7 +145,7 @@ func Run(cfg *config.YurtHubConfiguration, stopCh <-chan struct{}) error {
 	}
 	trace++
 
-	klog.Infof("%d. new %s server and begin to serve", trace, projectinfo.GetHubName())
+	klog.Infof("%d. new %s server and begin to serve, proxy server: %s, hub server: %s", trace, projectinfo.GetHubName(), cfg.YurtHubProxyServerAddr, cfg.YurtHubServerAddr)
 	s := server.NewYurtHubServer(cfg, certManager, yurtProxyHandler)
 	s.Run()
 	<-stopCh

--- a/config/yaml-template/yurthub.yaml
+++ b/config/yaml-template/yurthub.yaml
@@ -31,7 +31,7 @@ spec:
     - name: pem-dir
       mountPath: /var/lib/kubelet/pki
     command:
-    - __project_prefix__hub 
+    - __project_prefix__hub
     - --v=2
     - --server-addr=__server_addr__
     - --node-name=$(NODE_NAME)
@@ -39,7 +39,7 @@ spec:
       httpGet:
         host: 127.0.0.1
         path: /v1/healthz
-        port: 10261
+        port: 10267
       initialDelaySeconds: 300
       periodSeconds: 5
       failureThreshold: 3

--- a/pkg/yurtctl/util/edgenode/common.go
+++ b/pkg/yurtctl/util/edgenode/common.go
@@ -87,7 +87,7 @@ spec:
       httpGet:
         host: 127.0.0.1
         path: /v1/healthz
-        port: 10261
+        port: 10267
       initialDelaySeconds: 300
       periodSeconds: 5
       failureThreshold: 3

--- a/pkg/yurthub/profile/profile.go
+++ b/pkg/yurthub/profile/profile.go
@@ -25,11 +25,11 @@ import (
 
 // Install adds the Profiling webservice to the given mux.
 func Install(c *mux.Router) {
-	c.HandleFunc("/debug/pprof", redirectTo("/debug/pprof/"))
-	c.HandleFunc("/debug/pprof/", http.HandlerFunc(pprof.Index))
 	c.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	c.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	c.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	c.HandleFunc("/debug/pprof", redirectTo("/debug/pprof/"))
+	c.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 }
 
 // redirectTo redirects request to a certain destination.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Initially, yurtHubServer that listen on 127.0.0.1:10261 handle all requests from clients on edge node, so request can not be proxied to kube-apiserver but instead  handled by yurthub itself when path of request is conflict with local yurthub requests.

in order to solve the above conflict, we divide the yurtHubServer into hubServer and porxyServer, and they listen on different port.
- proxyServer listens on 127.0.0.1:10261,  keep the same port as before
- hubServer listen on 127.0.0.1:10267,  can handle requests like pprof, token update, healthz, metrics etc. 

by the way, we add a parameter `--profiling` to enable/disable debug pprof yurthub, default is enable pprof.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


