### PR TITLE
feature: add promtheus metrics for yurthub

### DIFF
--- a/pkg/yurthub/metrics/metrics.go
+++ b/pkg/yurthub/metrics/metrics.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	namespace = "node"
+	subsystem = strings.ReplaceAll(projectinfo.GetHubName(), "-", "_")
+)
+
+var (
+	// Metrics provides access to all hub agent metrics.
+	Metrics = newHubMetrics()
+)
+
+type HubMetrics struct {
+	serversHealthyCollector   *prometheus.GaugeVec
+	inFlightRequestsCollector *prometheus.GaugeVec
+	inFlightRequestsGauge     prometheus.Gauge
+	rejectedRequestsCounter   prometheus.Counter
+	closableConnsCollector    *prometheus.GaugeVec
+}
+
+func newHubMetrics() *HubMetrics {
+	serversHealthyCollector := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "server_healthy_status",
+			Help:      "healthy status of remote servers. 1: healthy, 0: unhealthy",
+		},
+		[]string{"server"})
+	inFlightRequestsCollector := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "in_flight_requests_collector",
+			Help:      "collector of in flight requests handling by hub agent",
+		},
+		[]string{"verb", "resource", "subresources", "client"})
+	inFlightRequestsGauge := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "in_flight_requests_total",
+			Help:      "total of in flight requests handling by hub agent",
+		})
+	rejectedRequestsCounter := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rejected_requests_counter",
+			Help:      "counter of rejected requests for exceeding in flight limit in hub agent",
+		})
+	closableConnsCollector := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "closable_conns_collector",
+			Help:      "collector of underlay tcp connection from hub agent to remote server",
+		},
+		[]string{"server"})
+	prometheus.MustRegister(serversHealthyCollector)
+	prometheus.MustRegister(inFlightRequestsCollector)
+	prometheus.MustRegister(inFlightRequestsGauge)
+	prometheus.MustRegister(rejectedRequestsCounter)
+	prometheus.MustRegister(closableConnsCollector)
+	return &HubMetrics{
+		serversHealthyCollector:   serversHealthyCollector,
+		inFlightRequestsCollector: inFlightRequestsCollector,
+		inFlightRequestsGauge:     inFlightRequestsGauge,
+		rejectedRequestsCounter:   rejectedRequestsCounter,
+		closableConnsCollector:    closableConnsCollector,
+	}
+}
+
+func (hm *HubMetrics) Reset() {
+	hm.serversHealthyCollector.Reset()
+	hm.inFlightRequestsCollector.Reset()
+	hm.inFlightRequestsGauge.Set(float64(0))
+	hm.closableConnsCollector.Reset()
+}
+
+func (hm *HubMetrics) ObserveServerHealthy(server string, status int) {
+	hm.serversHealthyCollector.WithLabelValues(server).Set(float64(status))
+}
+
+func (hm *HubMetrics) IncInFlightRequests(verb, resource, subresource, client string) {
+	hm.inFlightRequestsCollector.WithLabelValues(verb, resource, subresource, client).Inc()
+	hm.inFlightRequestsGauge.Inc()
+}
+
+func (hm *HubMetrics) DecInFlightRequests(verb, resource, subresource, client string) {
+	hm.inFlightRequestsCollector.WithLabelValues(verb, resource, subresource, client).Dec()
+	hm.inFlightRequestsGauge.Dec()
+}
+
+func (hm *HubMetrics) IncRejectedRequestCounter() {
+	hm.rejectedRequestsCounter.Inc()
+}
+
+func (hm *HubMetrics) IncClosableConns(server string) {
+	hm.closableConnsCollector.WithLabelValues(server).Inc()
+}
+
+func (hm *HubMetrics) DecClosableConns(server string) {
+	hm.closableConnsCollector.WithLabelValues(server).Dec()
+}
+
+func (hm *HubMetrics) SetClosableConns(server string, cnt int) {
+	hm.closableConnsCollector.WithLabelValues(server).Set(float64(cnt))
+}

--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/openyurtio/openyurt/cmd/yurthub/app/config"
 	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/interfaces"
 	"github.com/openyurtio/openyurt/pkg/yurthub/profile"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Server is an interface for providing http service for yurthub
@@ -90,6 +92,9 @@ func registerHandlers(c *mux.Router, cfg *config.YurtHubConfiguration, certifica
 	if cfg.EnableProfiling {
 		profile.Install(c)
 	}
+
+	// register handler for metrics
+	c.Handle("/metrics", promhttp.Handler())
 }
 
 // healthz returns ok for healthz request


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
add prometheus metrics for yurthub as following:
- server_healthy_status: healthy status of remote server. 1: healthy, 0: unhealthy
- in_flight_requests: how many in flight requests are handled by hub agent
- in_flight_request_counter: counter of in flight requests handled by hub agent
- closable_conn_counter: counter of underlay tcp connection for hub agent to remote server
- rejected_request_counter:  counter of rejected requests for exceeding in flight limit in hub agent

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
- `make release WHAT=cmd/yurthub ARCH=amd64` to build yurthub image
- run new yurthub image
- on the edge node, curl http://127.0.0.1:10267/metrics to verify metrics for yurthub, and the metrics output as following:
```
# HELP node_yurthub_closable_conns_collector collector of underlay tcp connection from hub agent to remote server
# TYPE node_yurthub_closable_conns_collector gauge
node_yurthub_closable_conns_collector{server="xx.xx.xx.xx:6443"} 2
# HELP node_yurthub_in_flight_requests_collector collector of in flight requests handling by hub agent
# TYPE node_yurthub_in_flight_requests_collector gauge
node_yurthub_in_flight_requests_collector{client="kube-proxy",resource="endpoints",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kube-proxy",resource="nodes",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kube-proxy",resource="services",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kubelet",resource="configmaps",subresources="",verb="watch"} 5
node_yurthub_in_flight_requests_collector{client="kubelet",resource="csidrivers",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kubelet",resource="events",subresources="",verb="create"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="events",subresources="",verb="patch"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="leases",subresources="",verb="get"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="leases",subresources="",verb="update"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="nodes",subresources="",verb="get"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="nodes",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kubelet",resource="nodes",subresources="status",verb="patch"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="pods",subresources="",verb="create"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="pods",subresources="",verb="delete"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="pods",subresources="",verb="get"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="pods",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kubelet",resource="pods",subresources="status",verb="patch"} 0
node_yurthub_in_flight_requests_collector{client="kubelet",resource="runtimeclasses",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kubelet",resource="secrets",subresources="",verb="watch"} 5
node_yurthub_in_flight_requests_collector{client="kubelet",resource="services",subresources="",verb="watch"} 1
node_yurthub_in_flight_requests_collector{client="kubelet",resource="subjectaccessreviews",subresources="",verb="create"} 0
# HELP node_yurthub_in_flight_requests_total total of in flight requests handling by hub agent
# TYPE node_yurthub_in_flight_requests_total gauge
node_yurthub_in_flight_requests_total 18
# HELP node_yurthub_rejected_requests_counter counter of rejected requests for exceeding in flight limit in hub agent
# TYPE node_yurthub_rejected_requests_counter counter
node_yurthub_rejected_requests_counter 0
# HELP node_yurthub_server_healthy_status healthy status of remote servers. 1: healthy, 0: unhealthy
# TYPE node_yurthub_server_healthy_status gauge
node_yurthub_server_healthy_status{server="xx.xx.xx.xx:6443"} 1
```

### Ⅴ. Special notes for reviews


