### PR TITLE
bugfix: list runtimeclass and csidriver from cache error when cloud-edge network disconnected

### DIFF
--- a/pkg/yurthub/cachemanager/cache_manager.go
+++ b/pkg/yurthub/cachemanager/cache_manager.go
@@ -370,6 +370,15 @@ func (cm *cacheManager) saveListObject(ctx context.Context, info *apirequest.Req
 	accessor := meta.NewAccessor()
 
 	comp, _ := util.ClientComponentFrom(ctx)
+	// even if no objects in cloud cluster, we need to
+	// make up a storage that represents the no resources
+	// in local disk, so when cloud-edge network disconnected,
+	// yurthub can return empty objects instead of 404 code(not found)
+	if len(items) == 0 {
+		key, _ := util.KeyFunc(comp, info.Resource, info.Namespace, "")
+		return cm.storage.Create(key, nil)
+	}
+
 	var errs []error
 	for i := range items {
 		name, err := accessor.Name(items[i])

--- a/pkg/yurthub/cachemanager/fake_storage_wrapper.go
+++ b/pkg/yurthub/cachemanager/fake_storage_wrapper.go
@@ -76,7 +76,7 @@ func (fsw *fakeStorageWrapper) ListKeys(key string) ([]string, error) {
 func (fsw *fakeStorageWrapper) List(key string) ([]runtime.Object, error) {
 	objs := make([]runtime.Object, 0, len(fsw.data))
 	for k, obj := range fsw.data {
-		if strings.HasPrefix(k, key) {
+		if strings.HasPrefix(k, key) && obj != nil {
 			objs = append(objs, obj)
 		}
 	}

--- a/pkg/yurthub/storage/store.go
+++ b/pkg/yurthub/storage/store.go
@@ -26,6 +26,12 @@ var ErrStorageAccessConflict = errors.New("specified key is under accessing")
 // ErrStorageNotFound is an error for not found accessing key
 var ErrStorageNotFound = errors.New("specified key is not found")
 
+// ErrorKeyHasNoContent is an error for file key that has no contents
+var ErrKeyHasNoContent = errors.New("specified key has no contents")
+
+// ErrorKeyWithoutContent is an error for key is empty
+var ErrKeyIsEmpty = errors.New("specified key is empty")
+
 // Store is an interface for caching data into backend storage
 type Store interface {
 	Create(key string, contents []byte) error


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- background:
1. At present, we use `component/resource/namespace/name` as file path to store response objects from kube-apiserver on local disk.
2.  If response objects from kube-apiserver are empty(like kubelet list runtimeclass, csidriver), cache info will not be created on local disk.
3. when cloud-edge network becomes disconnected, kubelet will list runtimeclass, csidriver from local disk cache, and yurthub return 404 to kubele. so kubelet will re-list runtimeclass and csidriver frequently.

- solution:
 1. if response objects from kube-apiserver are empty(like kubelet list runtimeclass, csidriver), yurthub can create key info `component/resource` in local disk with `nil` data. 
 2. so when kubelet list runtimeclass, csidriver from local disk cache, yurthub will return empty list to kubelet.
 3. and when pods cache data on local disk is deleted by accident,  yurthub will return 404 error(not empty list) to kubelet in order to prevent killing pods on node.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
=== RUN   TestCacheResponseForList/cache_response_for_list_nodes_with_fieldselector
=== RUN   TestCacheResponseForList/cache_response_for_list_runtimeclasses_with_no_objects
=== RUN   TestCreate/create_dir_key_with_no_data
=== RUN   TestCreate/create_dir_key_that_already_exists

### Ⅳ. Describe how to verify it
make all
and make sure when cloud-edge networ disconnected, kubelet list runtimeclass and no error has happened.

### Ⅴ. Special notes for reviews


