### PR TITLE
feature: transform hostname to nodeIP for request.

### DIFF
--- a/pkg/yurttunnel/constants/constants.go
+++ b/pkg/yurttunnel/constants/constants.go
@@ -43,6 +43,9 @@ const (
 	// name of the environment variables used in pod
 	YurttunnelAgentPodIPEnv = "POD_IP"
 
+	// name of the environment for selecting backend agent used in yurt-tunnel-server
+	ProxyHostHeaderKey = "X-Tunnel-Proxy-Host"
+
 	// The timeout seconds of reading a complete request from the apiserver
 	YurttunnelANPInterceptorReadTimeoutSec = 10
 	// The period between two keep-alive probes

--- a/pkg/yurttunnel/handlerwrapper/tracerequest/tracereq.go
+++ b/pkg/yurttunnel/handlerwrapper/tracerequest/tracereq.go
@@ -17,29 +17,55 @@ limitations under the License.
 package tracerequest
 
 import (
+	"errors"
+	"net"
 	"net/http"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
 	hw "github.com/openyurtio/openyurt/pkg/yurttunnel/handlerwrapper"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/server/metrics"
 )
 
 // TraceReqMiddleware prints request information when start/stop
 // handling the request
-type traceReqMiddleware struct{}
+type traceReqMiddleware struct {
+	nodeLister      corelisters.NodeLister
+	informersSynced []cache.InformerSynced
+}
 
 // NewTraceReqMiddleware returns an middleware object
 func NewTraceReqMiddleware() hw.Middleware {
-	return &traceReqMiddleware{}
+	return &traceReqMiddleware{
+		informersSynced: make([]cache.InformerSynced, 0),
+	}
 }
 
 func (trm *traceReqMiddleware) Name() string {
 	return "TraceReqMiddleware"
 }
 
+// SetSharedInformerFactory set nodeLister and nodeSynced for WrapHandler
+func (trm *traceReqMiddleware) SetSharedInformerFactory(factory informers.SharedInformerFactory) error {
+	trm.nodeLister = factory.Core().V1().Nodes().Lister()
+	trm.informersSynced = append(trm.informersSynced, factory.Core().V1().Nodes().Informer().HasSynced)
+	return nil
+}
+
 func (trm *traceReqMiddleware) WrapHandler(handler http.Handler) http.Handler {
+	klog.Infof("%d informer synced in traceReqMiddleware", len(trm.informersSynced))
+	if !cache.WaitForCacheSync(wait.NeverStop, trm.informersSynced...) {
+		klog.Error("failed to sync node cache for trace request middleware")
+		return handler
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		scheme := "https"
 		if req.TLS == nil {
@@ -48,6 +74,23 @@ func (trm *traceReqMiddleware) WrapHandler(handler http.Handler) http.Handler {
 
 		req.URL.Scheme = scheme
 		req.URL.Host = req.Host
+
+		host, port, err := net.SplitHostPort(req.Host)
+		if err != nil {
+			klog.Errorf("request host(%s) is invalid, %v", req.Host, err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// host for accessing edge component(like kubelet) is hostname, not node ip.
+		if ip := net.ParseIP(host); ip == nil {
+			// 1. transform hostname to nodeIP for request in order to send request to nodeIP address at tunnel-agent
+			// 2. put hostname into X-Tunnel-Proxy-Host request header in order to select the correct backend agent.
+			if err := trm.modifyRequest(req, host, port); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
 
 		// observe metrics
 		metrics.Metrics.IncInFlightRequests(req.Method, req.URL.Path)
@@ -60,4 +103,46 @@ func (trm *traceReqMiddleware) WrapHandler(handler http.Handler) http.Handler {
 		klog.V(2).Infof("stop handling request %s %s, request handling lasts %v",
 			req.Method, req.URL.String(), time.Now().Sub(start))
 	})
+}
+
+// modifyRequest transform hostname to node ip in request and
+// add X-Tunnel-Proxy-Host header in request if not set
+func (trm *traceReqMiddleware) modifyRequest(req *http.Request, host, port string) error {
+	node, err := trm.nodeLister.Get(host)
+	if err != nil {
+		klog.Errorf("failed to get node(%s), %v", host, err)
+		return err
+	}
+
+	nodeIP := getNodeIP(node)
+	if nodeIP == "" {
+		klog.Errorf("failed to get node(%s) ip", host)
+		return errors.New("failed to get node ip")
+	}
+
+	// transform hostname to node ip in request
+	proxyDest := net.JoinHostPort(nodeIP, port)
+	req.Host = proxyDest
+	req.Header.Set("Host", proxyDest)
+	req.URL.Host = proxyDest
+
+	// add X-Tunnel-Proxy-Host header in request
+	if len(req.Header.Get(constants.ProxyHostHeaderKey)) == 0 {
+		req.Header.Set(constants.ProxyHostHeaderKey, host)
+	}
+	return nil
+}
+
+// getNodeIP get internal ip for node
+func getNodeIP(node *corev1.Node) string {
+	var nodeIP string
+	if node != nil {
+		for _, nodeAddr := range node.Status.Addresses {
+			if nodeAddr.Type == corev1.NodeInternalIP {
+				nodeIP = nodeAddr.Address
+				break
+			}
+		}
+	}
+	return nodeIP
 }

--- a/pkg/yurttunnel/server/interceptor.go
+++ b/pkg/yurttunnel/server/interceptor.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
+
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apiserver/pkg/util/flushwriter"
 	"k8s.io/apiserver/pkg/util/wsstream"
@@ -34,8 +36,7 @@ import (
 )
 
 var (
-	proxyHostHeaderKey     = "X-Tunnel-Proxy-Host"
-	supportedHeaders       = []string{proxyHostHeaderKey, "User-Agent"}
+	supportedHeaders       = []string{constants.ProxyHostHeaderKey, "User-Agent"}
 	HeaderTransferEncoding = "Transfer-Encoding"
 	HeaderChunked          = "chunked"
 )
@@ -278,7 +279,7 @@ func serveRequest(tunnelConn net.Conn, w http.ResponseWriter, r *http.Request) {
 			case <-stopCh:
 				klog.V(3).Infof("chunked request(%s) normally exit", r.URL.String())
 			case <-ctx.Done():
-				klog.V(2).Infof("chunked request(%s) to agent(%s) closed by cloud client, %v", r.URL.String(), r.Header.Get(proxyHostHeaderKey), ctx.Err())
+				klog.V(2).Infof("chunked request(%s) to agent(%s) closed by cloud client, %v", r.URL.String(), r.Header.Get(constants.ProxyHostHeaderKey), ctx.Err())
 				// close connection with tunnel
 				conn.Close()
 			}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- background:
when Host of request to yurt-tunnel-server for accessing edge component(like kubelet) is hostname, not node ip,
yurt-tunnel-agent can not proxy the request to edge component(like kubelet) because edge component listen on
ip address not hostname.

- solution:
before proxy request to yurt-tunnel-agent in yurt-tunnel-server, we can modify request in `tracerequest handlerWrapper`. and we add the following two routine:
    1. transform hostname to nodeIP for request in order to send request to nodeIP address at tunnel-agent
    2. put hostname into X-Tunnel-Proxy-Host request header in order to select the correct backend agent.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
make all
and run yurt-tunnel in k8s cluster and make sure it work correctly.  @SataQiu  

### Ⅴ. Special notes for reviews


