### PR TITLE
bugfix: remove yurt-app-manager from the build targets

### DIFF
--- a/hack/lib/release-images.sh
+++ b/hack/lib/release-images.sh
@@ -29,7 +29,6 @@ readonly -a YURT_BIN_TARGETS=(
     yurtctl
     yurt-tunnel-server
     yurt-tunnel-agent
-    yurt-app-manager
 )
 
 readonly -a SUPPORTED_ARCH=(


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Since we have migrated `yurt-app-manager` to a independent repository, `make release` will now produce the following error：
```shell
can't load package: package /opt/src/cmd/yurt-app-manager: cannot find package
make: *** [release] Error 1
```

This PR removes `yurt-app-manager` from the build targets to fix this bug.

Ref: #280 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
make release

### Ⅴ. Special notes for reviews


