### PR TITLE
bugfix: keep image tar file name consistent with image name

### DIFF
--- a/hack/lib/release-images.sh
+++ b/hack/lib/release-images.sh
@@ -90,11 +90,11 @@ function build_docker_image() {
                local docker_file_path=${docker_build_path}/Dockerfile.${binary_name}-${arch}
                mkdir -p ${docker_build_path}
 
-               local yurt_component_image
+               local yurt_component_name
                local base_image
                if [[ ${binary} =~ yurtctl ]]
                then
-                 yurt_component_image=$REPO/yurtctl-servant:$TAG-$arch
+                 yurt_component_name="yurtctl-servant"
                  case $arch in
                   amd64)
                       base_image="amd64/alpine:3.9"
@@ -114,7 +114,7 @@ FROM ${base_image}
 ADD ${binary_name} /usr/local/bin/yurtctl
 EOF
                else
-                 yurt_component_image="${REPO}/${binary_name}:${TAG}-${arch}"
+                 yurt_component_name=${binary_name}
                  base_image="k8s.gcr.io/debian-iptables-${arch}:v11.0.2"
                  cat <<EOF > "${docker_file_path}"
 FROM ${base_image}
@@ -123,9 +123,10 @@ ENTRYPOINT ["/usr/local/bin/${binary_name}"]
 EOF
                fi
 
+               yurt_component_image="${REPO}/${yurt_component_name}:${TAG}-${arch}"
                ln "${binary_path}" "${docker_build_path}/${binary_name}"
                docker build --no-cache -t "${yurt_component_image}" -f "${docker_file_path}" ${docker_build_path}
-               docker save ${yurt_component_image} > ${YURT_IMAGE_DIR}/${binary_name}-${SUPPORTED_OS}-${arch}.tar
+               docker save ${yurt_component_image} > ${YURT_IMAGE_DIR}/${yurt_component_name}-${SUPPORTED_OS}-${arch}.tar
                rm -rf ${docker_build_path}
             fi
         done


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
bugfix: keep image tar file name consistent with image name.

For example, the image `openyurt/yurtctl-servant:v0.3.0-amd64` should be saved as `yurtctl-servant-linux-amd64.tar` instead of `yurtctl-linux-amd64.tar`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
make release

### Ⅴ. Special notes for reviews


