### PR TITLE
bugfix: fix querying local empty list error

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/masterservice"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/servicetopology"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
 	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/factory"
 	yurtclientset "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/clientset/versioned"
@@ -68,6 +69,7 @@ type YurtHubConfiguration struct {
 	HubAgentDummyIfName               string
 	StorageWrapper                    cachemanager.StorageWrapper
 	SerializerManager                 *serializer.SerializerManager
+	RESTMapperManager                 *meta.RESTMapperManager
 	TLSConfig                         *tls.Config
 	MutatedMasterServiceAddr          string
 	Filters                           *filter.Filters
@@ -89,6 +91,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 	}
 	storageWrapper := cachemanager.NewStorageWrapper(storageManager)
 	serializerManager := serializer.NewSerializerManager()
+	restMapperManager := meta.NewRESTMapperManager(storageManager)
 
 	hubServerAddr := net.JoinHostPort(options.YurtHubHost, options.YurtHubPort)
 	proxyServerAddr := net.JoinHostPort(options.YurtHubHost, options.YurtHubProxyPort)
@@ -141,6 +144,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		HubAgentDummyIfName:               options.HubAgentDummyIfName,
 		StorageWrapper:                    storageWrapper,
 		SerializerManager:                 serializerManager,
+		RESTMapperManager:                 restMapperManager,
 		MutatedMasterServiceAddr:          mutatedMasterServiceAddr,
 		Filters:                           filters,
 		SharedFactory:                     sharedFactory,

--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -132,7 +132,7 @@ func Run(cfg *config.YurtHubConfiguration, stopCh <-chan struct{}) error {
 	trace++
 
 	klog.Infof("%d. new cache manager with storage wrapper and serializer manager", trace)
-	cacheMgr, err := cachemanager.NewCacheManager(cfg.StorageWrapper, cfg.SerializerManager)
+	cacheMgr, err := cachemanager.NewCacheManager(cfg.StorageWrapper, cfg.SerializerManager, cfg.RESTMapperManager)
 	if err != nil {
 		klog.Errorf("could not new cache manager, %v", err)
 		return err

--- a/pkg/yurthub/cachemanager/cache_agent_test.go
+++ b/pkg/yurthub/cachemanager/cache_agent_test.go
@@ -32,7 +32,7 @@ func TestInitCacheAgents(t *testing.T) {
 		t.Errorf("failed to create disk storage, %v", err)
 	}
 	s := NewStorageWrapper(dStorage)
-	m, _ := NewCacheManager(s, nil)
+	m, _ := NewCacheManager(s, nil, nil)
 
 	// default cache agents in fake store
 	b, err := s.GetRaw(cacheAgentsKey)
@@ -52,7 +52,7 @@ func TestInitCacheAgents(t *testing.T) {
 	// add agents for next init cache
 	_ = m.UpdateCacheAgents([]string{"agent1"})
 
-	_, _ = NewCacheManager(s, nil)
+	_, _ = NewCacheManager(s, nil, nil)
 
 	b2, err := s.GetRaw(cacheAgentsKey)
 	if err != nil {
@@ -81,7 +81,7 @@ func TestUpdateCacheAgents(t *testing.T) {
 		t.Errorf("failed to create disk storage, %v", err)
 	}
 	s := NewStorageWrapper(dStorage)
-	m, _ := NewCacheManager(s, nil)
+	m, _ := NewCacheManager(s, nil, nil)
 
 	testcases := map[string]struct {
 		desc         string

--- a/pkg/yurthub/kubernetes/meta/restmapper.go
+++ b/pkg/yurthub/kubernetes/meta/restmapper.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog"
+)
+
+const (
+	CacheDynamicRESTMapperKey = "_internal/restmapper/cache-crd-restmapper.conf"
+	SepForGVR                 = "/"
+)
+
+var (
+	// unsafeSchemeRESTMapper is used to store the mapping relationship between GVK and GVR in scheme
+	// It is not updatable and is only used for the judgment of scheme resources
+	unsafeSchemeRESTMapper = NewDefaultRESTMapperFromScheme()
+	ErrGVRNotRecognized    = errors.New("GroupVersionResource is not recognized")
+)
+
+// RESTMapperManager is responsible for managing different kind of RESTMapper
+type RESTMapperManager struct {
+	sync.RWMutex
+	storage storage.Store
+	// UnsafeDefaultRESTMapper is used to save the GVK and GVR mapping relationships of built-in resources
+	unsafeDefaultRESTMapper *meta.DefaultRESTMapper
+	// dynamicRESTMapper is used to save the GVK and GVR mapping relationships of Custom Resources
+	dynamicRESTMapper map[schema.GroupVersionResource]schema.GroupVersionKind
+}
+
+func NewDefaultRESTMapperFromScheme() *meta.DefaultRESTMapper {
+	s := scheme.Scheme
+	defaultGroupVersions := s.PrioritizedVersionsAllGroups()
+	mapper := meta.NewDefaultRESTMapper(defaultGroupVersions)
+	// enumerate all supported versions, get the kinds, and register with the mapper how to address
+	// our resources.
+	for _, gv := range defaultGroupVersions {
+		for kind := range s.KnownTypes(gv) {
+			// Only need to process non-list resources
+			if !strings.HasSuffix(kind, "List") {
+				// Since RESTMapper is only used for mapping GVR to GVK information,
+				// the scope field is not involved in actual use,
+				// so all scope are currently set to meta.RESTScopeNamespace
+				scope := meta.RESTScopeNamespace
+				mapper.Add(gv.WithKind(kind), scope)
+			}
+		}
+	}
+	return mapper
+}
+
+func NewRESTMapperManager(storage storage.Store) *RESTMapperManager {
+	var dm map[schema.GroupVersionResource]schema.GroupVersionKind
+	// Recover the mapping relationship between GVR and GVK from the hard disk
+	b, err := storage.Get(CacheDynamicRESTMapperKey)
+	if err == nil && len(b) != 0 {
+		dm = unmarshalDynamicRESTMapper(b)
+		klog.Infof("reset DynamicRESTMapper to %v", dm)
+	} else {
+		dm = make(map[schema.GroupVersionResource]schema.GroupVersionKind)
+		klog.Infof("initialize an empty DynamicRESTMapper")
+	}
+
+	return &RESTMapperManager{
+		unsafeDefaultRESTMapper: unsafeSchemeRESTMapper,
+		dynamicRESTMapper:       dm,
+		storage:                 storage,
+	}
+}
+
+// Obtain gvk according to gvr in dynamicRESTMapper
+func (rm *RESTMapperManager) dynamicKindFor(gvr schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	hasResource := len(gvr.Resource) > 0
+	hasGroup := len(gvr.Group) > 0
+	hasVersion := len(gvr.Version) > 0
+
+	if !hasResource || !hasGroup {
+		return schema.GroupVersionKind{}, fmt.Errorf("a resource and group must be present, got: %v", gvr)
+	}
+
+	rm.RLock()
+	defer rm.RUnlock()
+	if hasVersion {
+		// fully qualified. Find the exact match
+		kind, exists := rm.dynamicRESTMapper[gvr]
+		if exists {
+			return kind, nil
+		}
+	} else {
+		requestedGroupResource := gvr.GroupResource()
+		for currResource, currKind := range rm.dynamicRESTMapper {
+			if currResource.GroupResource() == requestedGroupResource {
+				return currKind, nil
+			}
+		}
+	}
+	return schema.GroupVersionKind{}, fmt.Errorf("no matches for %v", gvr)
+}
+
+// Used to delete the mapping relationship between GVR and GVK in dynamicRESTMapper
+func (rm *RESTMapperManager) deleteKind(gvk schema.GroupVersionKind) error {
+	kindName := strings.TrimSuffix(gvk.Kind, "List")
+	plural, singular := meta.UnsafeGuessKindToResource(gvk.GroupVersion().WithKind(kindName))
+	rm.Lock()
+	delete(rm.dynamicRESTMapper, plural)
+	delete(rm.dynamicRESTMapper, singular)
+	rm.Unlock()
+	return rm.updateCachedDynamicRESTMapper()
+}
+
+// Used to update local files saved on disk
+func (rm *RESTMapperManager) updateCachedDynamicRESTMapper() error {
+	if rm.storage == nil {
+		return nil
+	}
+	rm.RLock()
+	d, err := marshalDynamicRESTMapper(rm.dynamicRESTMapper)
+	rm.RUnlock()
+	if err != nil {
+		return err
+	}
+	return rm.storage.Update(CacheDynamicRESTMapperKey, d)
+}
+
+// KindFor is used to find GVK based on GVR information.
+// 1. return true means the GVR is a built-in resource in shceme.
+// 2.1 return false and non-empty GVK means the GVR is custom resource
+// 2.2 return false and empty GVK means the GVR is unknown resource.
+func (rm *RESTMapperManager) KindFor(gvr schema.GroupVersionResource) (bool, schema.GroupVersionKind) {
+	gvk, kindErr := rm.unsafeDefaultRESTMapper.KindFor(gvr)
+	if kindErr != nil {
+		gvk, kindErr = rm.dynamicKindFor(gvr)
+		if kindErr != nil {
+			return false, schema.GroupVersionKind{}
+		}
+		return false, gvk
+	}
+	return true, gvk
+}
+
+// DeleteKindFor is used to delete the GVK information related to the incoming gvr
+func (rm *RESTMapperManager) DeleteKindFor(gvr schema.GroupVersionResource) error {
+	isScheme, gvk := rm.KindFor(gvr)
+	if !isScheme && !gvk.Empty() {
+		return rm.deleteKind(gvk)
+	}
+	return nil
+}
+
+// UpdateKind is used to verify and add the GVK and GVR mapping relationships of new Custom Resource
+func (rm *RESTMapperManager) UpdateKind(gvk schema.GroupVersionKind) error {
+	kindName := strings.TrimSuffix(gvk.Kind, "List")
+	gvk = gvk.GroupVersion().WithKind(kindName)
+	plural, singular := meta.UnsafeGuessKindToResource(gvk.GroupVersion().WithKind(kindName))
+	// If it is not a built-in resource and it is not stored in DynamicRESTMapper, add it to DynamicRESTMapper
+	isScheme, t := rm.KindFor(singular)
+	if !isScheme && t.Empty() {
+		rm.Lock()
+		rm.dynamicRESTMapper[singular] = gvk
+		rm.dynamicRESTMapper[plural] = gvk
+		rm.Unlock()
+		return rm.updateCachedDynamicRESTMapper()
+	}
+	return nil
+}
+
+// ResetRESTMapper is used to clean up all cached GVR/GVK information in DynamicRESTMapper,
+// and delete the corresponding file in the disk (cache-crd-restmapper.conf), it should be used carefully.
+func (rm *RESTMapperManager) ResetRESTMapper() error {
+	rm.dynamicRESTMapper = make(map[schema.GroupVersionResource]schema.GroupVersionKind)
+	err := rm.storage.DeleteCollection(CacheDynamicRESTMapperKey)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// marshalDynamicRESTMapper converts dynamicRESTMapper to the []byte format, which is used to save data to disk
+func marshalDynamicRESTMapper(dynamicRESTMapper map[schema.GroupVersionResource]schema.GroupVersionKind) ([]byte, error) {
+	cacheMapper := make(map[string]string, len(dynamicRESTMapper))
+	for currResource, currKind := range dynamicRESTMapper {
+		//key: Group/Version/Resource, value: Kind
+		k := strings.Join([]string{currResource.Group, currResource.Version, currResource.Resource}, SepForGVR)
+		cacheMapper[k] = currKind.Kind
+	}
+	return json.Marshal(cacheMapper)
+}
+
+// unmarshalDynamicRESTMapper converts bytes of data to map[schema.GroupVersionResource]schema.GroupVersionKind format, used to recover data from disk
+func unmarshalDynamicRESTMapper(data []byte) map[schema.GroupVersionResource]schema.GroupVersionKind {
+	dm := make(map[schema.GroupVersionResource]schema.GroupVersionKind)
+	cacheMapper := make(map[string]string)
+	err := json.Unmarshal(data, &cacheMapper)
+	if err != nil {
+		klog.Errorf("failed to get cached CRDRESTMapper, %v", err)
+	}
+
+	for gvrString, kindString := range cacheMapper {
+		localInfo := strings.Split(gvrString, SepForGVR)
+		if len(localInfo) != 3 {
+			klog.Errorf("This %s is not standardized, ignore this gvk", gvrString)
+			continue
+		}
+		gvr := schema.GroupVersionResource{
+			Group:    localInfo[0],
+			Version:  localInfo[1],
+			Resource: localInfo[2],
+		}
+		gvk := schema.GroupVersionKind{
+			Group:   localInfo[0],
+			Version: localInfo[1],
+			Kind:    kindString,
+		}
+		dm[gvr] = gvk
+	}
+	return dm
+}
+
+// IsSchemeResource is used to determine whether gvr is a built-in resource
+func IsSchemeResource(gvr schema.GroupVersionResource) bool {
+	_, kindErr := unsafeSchemeRESTMapper.KindFor(gvr)
+	if kindErr != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/yurthub/kubernetes/meta/restmapper_test.go
+++ b/pkg/yurthub/kubernetes/meta/restmapper_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var rootDir = "/tmp/restmapper"
+
+func TestCreateRESTMapperManager(t *testing.T) {
+	dStorage, err := disk.NewDiskStorage(rootDir)
+	if err != nil {
+		t.Errorf("failed to create disk storage, %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(rootDir); err != nil {
+			t.Errorf("Unable to clean up test directory %q: %v", rootDir, err)
+		}
+	}()
+
+	// initialize an empty DynamicRESTMapper
+	yurtHubRESTMapperManager := NewRESTMapperManager(dStorage)
+	if yurtHubRESTMapperManager.dynamicRESTMapper == nil || len(yurtHubRESTMapperManager.dynamicRESTMapper) != 0 {
+		t.Errorf("failed to initialize an empty dynamicRESTMapper, %v", err)
+	}
+
+	// reset yurtHubRESTMapperManager
+	if err := yurtHubRESTMapperManager.ResetRESTMapper(); err != nil {
+		t.Fatalf("failed to reset yurtHubRESTMapperManager , %v", err)
+	}
+
+	// initialize an Non-empty DynamicRESTMapper
+	// pre-cache the CRD information to the hard disk
+	cachedDynamicRESTMapper := map[string]string{
+		"samplecontroller.k8s.io/v1alpha1/foo":  "Foo",
+		"samplecontroller.k8s.io/v1alpha1/foos": "Foo",
+	}
+	d, err := json.Marshal(cachedDynamicRESTMapper)
+	if err != nil {
+		t.Errorf("failed to serialize dynamicRESTMapper, %v", err)
+	}
+	err = dStorage.Update(CacheDynamicRESTMapperKey, d)
+	if err != nil {
+		t.Fatalf("failed to stored dynamicRESTMapper, %v", err)
+	}
+
+	// Determine whether the restmapper in the memory is the same as the information written to the disk
+	yurtHubRESTMapperManager = NewRESTMapperManager(dStorage)
+	// get the CRD information in memory
+	m := yurtHubRESTMapperManager.dynamicRESTMapper
+	gotMapper := dynamicRESTMapperToString(m)
+
+	if !compareDynamicRESTMapper(gotMapper, cachedDynamicRESTMapper) {
+		t.Errorf("Got mapper: %v, expect mapper: %v", gotMapper, cachedDynamicRESTMapper)
+	}
+
+	if err := yurtHubRESTMapperManager.ResetRESTMapper(); err != nil {
+		t.Fatalf("failed to reset yurtHubRESTMapperManager , %v", err)
+	}
+}
+
+func TestUpdateRESTMapper(t *testing.T) {
+	dStorage, err := disk.NewDiskStorage(rootDir)
+	if err != nil {
+		t.Errorf("failed to create disk storage, %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(rootDir); err != nil {
+			t.Errorf("Unable to clean up test directory %q: %v", rootDir, err)
+		}
+	}()
+	yurtHubRESTMapperManager := NewRESTMapperManager(dStorage)
+	testcases := map[string]struct {
+		cachedCRD        []schema.GroupVersionKind
+		addCRD           schema.GroupVersionKind
+		deleteCRD        schema.GroupVersionResource
+		expectRESTMapper map[string]string
+	}{
+		"add the first CRD": {
+			cachedCRD: []schema.GroupVersionKind{},
+			addCRD:    schema.GroupVersionKind{Group: "samplecontroller.k8s.io", Version: "v1alpha1", Kind: "Foo"},
+			expectRESTMapper: map[string]string{
+				"samplecontroller.k8s.io/v1alpha1/foo":  "Foo",
+				"samplecontroller.k8s.io/v1alpha1/foos": "Foo",
+			},
+		},
+
+		"update with another CRD": {
+			cachedCRD: []schema.GroupVersionKind{{Group: "samplecontroller.k8s.io", Version: "v1alpha1", Kind: "Foo"}},
+			addCRD:    schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTab"},
+			expectRESTMapper: map[string]string{
+				"samplecontroller.k8s.io/v1alpha1/foo":  "Foo",
+				"samplecontroller.k8s.io/v1alpha1/foos": "Foo",
+				"stable.example.com/v1/crontab":         "CronTab",
+				"stable.example.com/v1/crontabs":        "CronTab",
+			},
+		},
+		"delete one CRD": {
+			cachedCRD: []schema.GroupVersionKind{
+				{Group: "samplecontroller.k8s.io", Version: "v1alpha1", Kind: "Foo"},
+				{Group: "stable.example.com", Version: "v1", Kind: "CronTab"},
+			},
+			deleteCRD: schema.GroupVersionResource{Group: "stable.example.com", Version: "v1", Resource: "crontabs"},
+			expectRESTMapper: map[string]string{
+				"samplecontroller.k8s.io/v1alpha1/foo":  "Foo",
+				"samplecontroller.k8s.io/v1alpha1/foos": "Foo",
+			},
+		},
+	}
+	for k, tt := range testcases {
+		t.Run(k, func(t *testing.T) {
+			// initialize the cache CRD
+			for _, gvk := range tt.cachedCRD {
+				err := yurtHubRESTMapperManager.UpdateKind(gvk)
+				if err != nil {
+					t.Errorf("failed to initialize the restmapper, %v", err)
+				}
+			}
+			// add CRD information
+			if !tt.addCRD.Empty() {
+				err := yurtHubRESTMapperManager.UpdateKind(tt.addCRD)
+				if err != nil {
+					t.Errorf("failed to add CRD information, %v", err)
+				}
+			} else {
+				// delete CRD information
+				err := yurtHubRESTMapperManager.DeleteKindFor(tt.deleteCRD)
+				if err != nil {
+					t.Errorf("failed to delete CRD information, %v", err)
+				}
+			}
+
+			// verify the CRD information in memory
+			m := yurtHubRESTMapperManager.dynamicRESTMapper
+			memoryMapper := dynamicRESTMapperToString(m)
+
+			if !compareDynamicRESTMapper(memoryMapper, tt.expectRESTMapper) {
+				t.Errorf("Got mapper: %v, expect mapper: %v", memoryMapper, tt.expectRESTMapper)
+			}
+
+			// verify the CRD information in disk
+			b, err := dStorage.Get(CacheDynamicRESTMapperKey)
+			if err != nil {
+				t.Fatalf("failed to get cached CRD information, %v", err)
+			}
+			cacheMapper := make(map[string]string)
+			err = json.Unmarshal(b, &cacheMapper)
+			if err != nil {
+				t.Errorf("failed to decode the cached dynamicRESTMapper, %v", err)
+			}
+
+			if !compareDynamicRESTMapper(cacheMapper, tt.expectRESTMapper) {
+				t.Errorf("cached mapper: %v, expect mapper: %v", cacheMapper, tt.expectRESTMapper)
+			}
+		})
+	}
+	if err := yurtHubRESTMapperManager.ResetRESTMapper(); err != nil {
+		t.Fatalf("failed to reset yurtHubRESTMapperManager , %v", err)
+	}
+}
+
+func TestResetRESTMapper(t *testing.T) {
+	dStorage, err := disk.NewDiskStorage(rootDir)
+	if err != nil {
+		t.Errorf("failed to create disk storage, %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(rootDir); err != nil {
+			t.Errorf("Unable to clean up test directory %q: %v", rootDir, err)
+		}
+	}()
+	// initialize the RESTMapperManager
+	yurtHubRESTMapperManager := NewRESTMapperManager(dStorage)
+	err = yurtHubRESTMapperManager.UpdateKind(schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTab"})
+	if err != nil {
+		t.Errorf("failed to initialize the restmapper, %v", err)
+	}
+
+	// reset the RESTMapperManager
+	if err := yurtHubRESTMapperManager.ResetRESTMapper(); err != nil {
+		t.Errorf("failed to reset the restmapper, %v", err)
+	}
+
+	// Verify reset result
+	if len(yurtHubRESTMapperManager.dynamicRESTMapper) != 0 {
+		t.Error("The cached GVR/GVK information in memory is not cleaned up.")
+	} else if _, err := os.Stat(filepath.Join(rootDir, CacheDynamicRESTMapperKey)); !os.IsNotExist(err) {
+		t.Error("The cached GVR/GVK information in disk is not deleted.")
+	}
+}
+
+func compareDynamicRESTMapper(gotMapper map[string]string, expectedMapper map[string]string) bool {
+	if len(gotMapper) != len(expectedMapper) {
+		return false
+	}
+
+	for gvr, kind := range gotMapper {
+		k, exists := expectedMapper[gvr]
+		if !exists || k != kind {
+			return false
+		}
+	}
+
+	return true
+}
+
+func dynamicRESTMapperToString(m map[schema.GroupVersionResource]schema.GroupVersionKind) map[string]string {
+	resultMapper := make(map[string]string, len(m))
+	for currResource, currKind := range m {
+		//key: Group/Version/Resource, value: Kind
+		k := strings.Join([]string{currResource.Group, currResource.Version, currResource.Resource}, SepForGVR)
+		resultMapper[k] = currKind.Kind
+	}
+	return resultMapper
+}

--- a/pkg/yurthub/kubernetes/serializer/serializer.go
+++ b/pkg/yurthub/kubernetes/serializer/serializer.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/api/meta"
+	hubmeta "github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
@@ -41,26 +41,6 @@ import (
 
 // YurtHubSerializer is a global serializer manager for yurthub
 var YurtHubSerializer = NewSerializerManager()
-
-// UnsafeDefaultRESTMapper is only used to check whether the GVK is in the scheme according to the GVR information
-var UnsafeDefaultRESTMapper = NewDefaultRESTMapperFromScheme()
-
-func NewDefaultRESTMapperFromScheme() *meta.DefaultRESTMapper {
-	s := scheme.Scheme
-	defaultGroupVersions := s.PrioritizedVersionsAllGroups()
-	mapper := meta.NewDefaultRESTMapper(defaultGroupVersions)
-	// enumerate all supported versions, get the kinds, and register with the mapper how to address
-	// our resources.
-	for _, gv := range defaultGroupVersions {
-		for kind := range s.KnownTypes(gv) {
-			//Since RESTMapper is only used for mapping GVR to GVK information,
-			//the scope field is not involved in actual use, so all scope are currently set to meta.RESTScopeNamespace
-			scope := meta.RESTScopeNamespace
-			mapper.Add(gv.WithKind(kind), scope)
-		}
-	}
-	return mapper
-}
 
 type yurtClientNegotiator struct {
 	recognized bool
@@ -99,11 +79,9 @@ func NewSerializerManager() *SerializerManager {
 
 // GetNegotiatedSerializer returns an NegotiatedSerializer object based on GroupVersionResource
 func (sm *SerializerManager) GetNegotiatedSerializer(gvr schema.GroupVersionResource) runtime.NegotiatedSerializer {
-	_, kindErr := UnsafeDefaultRESTMapper.KindFor(gvr)
-	if kindErr == nil {
+	if isScheme := hubmeta.IsSchemeResource(gvr); isScheme {
 		return sm.NegotiatedSerializer
 	}
-
 	return sm.UnstructuredNegotiatedSerializer
 }
 
@@ -183,7 +161,7 @@ func (s UnstructuredNegotiatedSerializer) SupportedMediaTypes() []runtime.Serial
 
 //EncoderForVersion do nothing, but returns a encoder,
 //if the object is unstructured, the encoder will encode object without conversion
-func (s UnstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+func (s UnstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, _ runtime.GroupVersioner) runtime.Encoder {
 	return encoder
 }
 
@@ -215,13 +193,11 @@ func (c unstructuredCreator) New(kind schema.GroupVersionKind) (runtime.Object, 
 
 // genClientNegotiator creates a ClientNegotiator for specified GroupVersionResource and gvr is recognized or not
 func (sm *SerializerManager) genClientNegotiator(gvr schema.GroupVersionResource) (runtime.ClientNegotiator, bool) {
-	_, kindErr := UnsafeDefaultRESTMapper.KindFor(gvr)
-	if kindErr == nil {
+	if isScheme := hubmeta.IsSchemeResource(gvr); isScheme {
 		return runtime.NewClientNegotiator(sm.NegotiatedSerializer, gvr.GroupVersion()), true
 	}
 	klog.Infof("%#+v is not found in client-go runtime scheme", gvr)
 	return runtime.NewClientNegotiator(sm.UnstructuredNegotiatedSerializer, gvr.GroupVersion()), false
-
 }
 
 // Serializer is used for transforming objects into a serialized format and back for cache manager of hub agent.
@@ -287,7 +263,6 @@ func (s *Serializer) Decode(b []byte) (runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return out, nil
 }
 

--- a/pkg/yurthub/proxy/local/local.go
+++ b/pkg/yurthub/proxy/local/local.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	manager "github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+	hubmeta "github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
 	"github.com/openyurtio/openyurt/pkg/yurthub/util"
 
@@ -204,7 +205,7 @@ func (lp *LocalProxy) localReqCache(w http.ResponseWriter, req *http.Request) er
 	}
 
 	obj, err := lp.cacheMgr.QueryCache(req)
-	if err == storage.ErrStorageNotFound {
+	if err == storage.ErrStorageNotFound || err == hubmeta.ErrGVRNotRecognized {
 		klog.Errorf("object not found for %s", util.ReqString(req))
 		reqInfo, _ := apirequest.RequestInfoFrom(req.Context())
 		return errors.NewNotFound(schema.GroupResource{Group: reqInfo.APIGroup, Resource: reqInfo.Resource}, reqInfo.Name)

--- a/pkg/yurthub/proxy/local/local_test.go
+++ b/pkg/yurthub/proxy/local/local_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+	hubmeta "github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
 	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
 	proxyutil "github.com/openyurtio/openyurt/pkg/yurthub/proxy/util"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -57,7 +59,7 @@ func TestServeHTTPForWatch(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
 
 	fn := func() bool {
 		return false
@@ -145,7 +147,7 @@ func TestServeHTTPForWatchWithHealthyChange(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
 
 	cnt := 0
 	fn := func() bool {
@@ -227,7 +229,7 @@ func TestServeHTTPForPost(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
 
 	fn := func() bool {
 		return false
@@ -303,7 +305,7 @@ func TestServeHTTPForDelete(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
 
 	fn := func() bool {
 		return false
@@ -366,7 +368,7 @@ func TestServeHTTPForGetReqCache(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
 
 	fn := func() bool {
 		return false
@@ -501,7 +503,8 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM)
+	restRESTMapperMgr := hubmeta.NewRESTMapperManager(dStorage)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, restRESTMapperMgr)
 
 	fn := func() bool {
 		return false
@@ -510,15 +513,16 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 	lp := NewLocalProxy(cacheM, fn)
 
 	testcases := map[string]struct {
-		userAgent string
-		keyPrefix string
-		inputObj  []runtime.Object
-		accept    string
-		verb      string
-		path      string
-		resource  string
-		code      int
-		expectD   struct {
+		userAgent    string
+		keyPrefix    string
+		preCachedObj []runtime.Object
+		accept       string
+		verb         string
+		path         string
+		resource     string
+		gvr          schema.GroupVersionResource
+		code         int
+		expectD      struct {
 			rv   string
 			data map[string]struct{}
 		}
@@ -526,7 +530,7 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 		"list pods request": {
 			userAgent: "kubelet",
 			keyPrefix: "kubelet/pods/default",
-			inputObj: []runtime.Object{
+			preCachedObj: []runtime.Object{
 				&v1.Pod{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "v1",
@@ -578,6 +582,23 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 				},
 			},
 		},
+		"list unregistered resource(Foo) request": {
+			userAgent:    "kubelet",
+			keyPrefix:    "kubelet/foos",
+			preCachedObj: []runtime.Object{},
+			accept:       "application/json",
+			verb:         "GET",
+			path:         "/api/samplecontroller.k8s.io/v1/foos",
+			resource:     "foos",
+			gvr:          schema.GroupVersionResource{Group: "samplecontroller.k8s.io", Version: "v1", Resource: "foo"},
+			code:         http.StatusNotFound,
+			expectD: struct {
+				rv   string
+				data map[string]struct{}
+			}{
+				data: map[string]struct{}{},
+			},
+		},
 	}
 
 	resolver := newTestRequestInfoResolver()
@@ -585,10 +606,10 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			s := serializerM.CreateSerializer(tt.accept, "", "v1", tt.resource)
 			accessor := meta.NewAccessor()
-			for i := range tt.inputObj {
-				name, _ := accessor.Name(tt.inputObj[i])
+			for i := range tt.preCachedObj {
+				name, _ := accessor.Name(tt.preCachedObj[i])
 				key := filepath.Join(tt.keyPrefix, name)
-				_ = sWrapper.Update(key, tt.inputObj[i])
+				_ = sWrapper.Update(key, tt.preCachedObj[i])
 			}
 
 			req, _ := http.NewRequest(tt.verb, tt.path, nil)
@@ -612,6 +633,13 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
 			result := resp.Result()
+			// For unregistered resources, server should return 404 not found
+			if result.StatusCode == http.StatusNotFound {
+				if _, gvk := restRESTMapperMgr.KindFor(tt.gvr); !gvk.Empty() {
+					t.Errorf("this resources %v is registered, but it should return 404 for unregistered resource", tt.gvr)
+				}
+				return
+			}
 			if result.StatusCode != tt.code {
 				t.Errorf("got status code %d, but expect %d", result.StatusCode, tt.code)
 			}

--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -345,11 +345,10 @@ func (ds *diskStorage) Update(key string, contents []byte) error {
 }
 
 // Replace will delete all files under rootKey dir and create new files with contents.
+// Note: when the contents are empty and the dir already exists, the create function will clean the current dir
 func (ds *diskStorage) Replace(rootKey string, contents map[string][]byte) error {
 	if rootKey == "" {
 		return storage.ErrKeyIsEmpty
-	} else if len(contents) == 0 {
-		return storage.ErrKeyHasNoContent
 	}
 
 	for key := range contents {
@@ -380,11 +379,13 @@ func (ds *diskStorage) Replace(rootKey string, contents map[string][]byte) error
 
 	// 2. create new file with contents
 	// TODO: if error happens, we may need retry mechanism, or add some mechanism to do consistency check.
-	for key, data := range contents {
-		err := ds.create(key, data)
-		if err != nil {
-			klog.Errorf("failed to create %s in replace, %v", key, err)
-			continue
+	if len(contents) != 0 {
+		for key, data := range contents {
+			err := ds.create(key, data)
+			if err != nil {
+				klog.Errorf("failed to create %s in replace, %v", key, err)
+				continue
+			}
 		}
 	}
 

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -648,6 +648,95 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestReplace(t *testing.T) {
+	testcases := map[string]struct {
+		listKey        string
+		preCreatedKeys map[string]string
+		replaceKeys    map[string]string
+		result         map[string]string
+		replaceErr     error
+	}{
+		"replace old files with contents": {
+			listKey: "kubelet/pods/default",
+			preCreatedKeys: map[string]string{
+				"kubelet/pods/default/foo1": "test-pod1",
+				"kubelet/pods/default/foo2": "test-pod2",
+			},
+			replaceKeys: map[string]string{
+				"kubelet/pods/default/foo3": "test-pod3",
+			},
+			result: map[string]string{
+				"kubelet/pods/default/foo3": "test-pod3",
+			},
+		},
+		"replace old files with empty contents": {
+			listKey: "kubelet/pods/default",
+			preCreatedKeys: map[string]string{
+				"kubelet/pods/default/foo1": "test-pod11",
+				"kubelet/pods/default/foo2": "test-pod21",
+			},
+			replaceKeys: map[string]string{},
+			result:      map[string]string{},
+		},
+	}
+	s, err := NewDiskStorage(testDir)
+	if err != nil {
+		t.Fatalf("unable to new disk storage, %v", err)
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			for key, data := range tc.preCreatedKeys {
+				err = s.Create(key, []byte(data))
+				if err != nil {
+					t.Errorf("%s: Got error %v, wanted successful create %s", k, err, key)
+				}
+			}
+
+			contents := make(map[string][]byte, len(tc.replaceKeys))
+			for key, data := range tc.replaceKeys {
+				contents[key] = []byte(data)
+			}
+
+			err = s.Replace(tc.listKey, contents)
+			if err != nil {
+				if tc.replaceErr != err {
+					t.Errorf("%s: expect error %v, but got %v", k, tc.replaceErr, err)
+				}
+			}
+
+			if keys, err := s.ListKeys(tc.listKey); err == nil {
+				if len(keys) != len(tc.result) {
+					t.Errorf("expect the number of keys: %v, but got %v", len(tc.result), len(keys))
+				}
+			} else {
+				t.Errorf("unable to list keys in the path of %s: %v", tc.listKey, err)
+			}
+
+			for key, data := range tc.result {
+				b, err := s.Get(key)
+				if err != nil {
+					t.Errorf("%s: Got error %v, unable get key %s", k, err, key)
+				}
+
+				if data != string(b) {
+					t.Errorf("%s: expect updated data %s, but got %s", k, data, string(b))
+				}
+			}
+
+			for key := range tc.result {
+				if err = s.Delete(key); err != nil {
+					t.Errorf("%s failed to delete key %s, %v", k, key, err)
+				}
+			}
+		})
+	}
+
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
+	}
+}
+
 func TestLockKey(t *testing.T) {
 	testcases := map[string]struct {
 		preLockedKeys    []string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
1. Add DynamicRESTMapper to store GVK and GVR mappings for non-built-in resources, while providing dynamic update function.
2. Fix error: when the cloud and edge are disconnected, and a List request is made for a registered CR, if the number of this custom resource is zero, edge return the wrong message.
3. Add unit tests to verify new feature

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #325 

#### Special notes for your reviewer:

/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
