### PR TITLE
Add yurt-tunnel-server graceful shut down

### DIFF
--- a/cmd/yurt-tunnel-server/server.go
+++ b/cmd/yurt-tunnel-server/server.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"flag"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/openyurtio/openyurt/cmd/yurt-tunnel-server/app"
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
@@ -30,7 +32,16 @@ func main() {
 	klog.InitFlags(nil)
 	defer klog.Flush()
 
-	cmd := app.NewYurttunnelServerCommand(wait.NeverStop)
+	s := make(chan os.Signal)
+	signal.Notify(s, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM,
+		syscall.SIGQUIT, syscall.SIGILL, syscall.SIGTRAP, syscall.SIGABRT)
+	stop := make(chan struct{})
+	go func() {
+		<-s
+		close(stop)
+	}()
+
+	cmd := app.NewYurttunnelServerCommand(stop)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {
 		klog.Fatalf("%s failed: %s", projectinfo.GetServerName(), err)

--- a/pkg/yurttunnel/iptables/iptables_test.go
+++ b/pkg/yurttunnel/iptables/iptables_test.go
@@ -1,0 +1,133 @@
+package iptables
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	coreinformer "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/util/iptables"
+	"k8s.io/utils/exec"
+	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/util"
+)
+
+var (
+	ListenAddrForMaster         = net.JoinHostPort("0.0.0.0", constants.YurttunnelServerMasterPort)
+	ListenInsecureAddrForMaster = net.JoinHostPort("127.0.0.1", constants.YurttunnelServerMasterInsecurePort)
+	IptablesSyncPeriod          = 60
+)
+
+func newFakeIptablesManager(client clientset.Interface,
+	nodeInformer coreinformer.NodeInformer,
+	listenAddr string,
+	listenInsecureAddr string,
+	syncPeriod int,
+	execer exec.Interface) *iptablesManager {
+
+	protocol := iptables.ProtocolIpv4
+	iptInterface := iptables.New(execer, protocol)
+
+	if syncPeriod < defaultSyncPeriod {
+		syncPeriod = defaultSyncPeriod
+	}
+
+	_, insecurePort, err := net.SplitHostPort(listenInsecureAddr)
+	if err != nil {
+		return nil
+	}
+
+	im := &iptablesManager{
+		kubeClient:       client,
+		iptables:         iptInterface,
+		execer:           execer,
+		nodeInformer:     nodeInformer,
+		secureDnatDest:   listenAddr,
+		insecureDnatDest: listenInsecureAddr,
+		insecurePort:     insecurePort,
+		lastNodesIP:      make([]string, 0),
+		lastDnatPorts:    make([]string, 0),
+		syncPeriod:       syncPeriod,
+	}
+	return im
+}
+
+func TestCleanupIptableSettingAllExists(t *testing.T) {
+	//1. create iptabeleMgr
+	fakeClient := &fake.Clientset{}
+	fakeInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0*time.Second)
+	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeAction{
+			// iptables version check
+			func() ([]byte, []byte, error) { return []byte("iptables v1.9.22"), nil, nil },
+			// DeleteRule Success
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil }, // success on the first call
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil }, // success on the second call
+
+			// FlushChain Success
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil },
+			// DeleteChain Success
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil },
+
+			// FlushChain Success
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil },
+			// DeleteChain Success
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil },
+
+			// FlushChain Success
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil },
+			// DeleteChain Success
+			func() ([]byte, []byte, error) { return []byte{}, nil, nil },
+		},
+	}
+	fexec := fakeexec.FakeExec{
+		CommandScript: []fakeexec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+
+	iptablesMgr := newFakeIptablesManager(fakeClient,
+		fakeInformerFactory.Core().V1().Nodes(),
+		ListenAddrForMaster,
+		ListenInsecureAddrForMaster,
+		IptablesSyncPeriod,
+		&fexec)
+
+	if iptablesMgr == nil {
+		t.Errorf("fail to create a new IptableManager")
+	}
+
+	//2. create configmap
+	configmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.YurttunnelServerDnatConfigMapName,
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"dnat-ports-pair": "",
+		},
+	}
+	fakeInformerFactory.Core().V1().ConfigMaps().Informer().GetStore().Add(configmap)
+
+	//3. call cleanupIptableSetting
+	iptablesMgr.cleanupIptableSetting()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind enhancement


#### What this PR does / why we need it:
After `yurtctl revert` or delete deployment ` yurt-tunnel-server`, the iptables rules created by `yurt-tunnel-server` still exist and have not been deleted. So the request `kubectl exec/logs` cannot be sent correctly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #337

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->


#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
The  ` yurt-tunnel-server`  image needs to be recompiled locally and used during testing.
