### PR TITLE
feature: set tunnel server count dynamically when --server-count flag is not explicitly specified by the user

### DIFF
--- a/config/setup/yurt-tunnel-server.yaml
+++ b/config/setup/yurt-tunnel-server.yaml
@@ -29,6 +29,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
   - endpoints
   verbs:
   - get
@@ -65,6 +66,12 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -177,6 +184,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         securityContext:
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]

--- a/pkg/yurttunnel/constants/constants.go
+++ b/pkg/yurttunnel/constants/constants.go
@@ -42,7 +42,9 @@ const (
 	YurttunnelCSRApproverThreadiness = 2
 
 	// name of the environment variables used in pod
-	YurttunnelAgentPodIPEnv = "POD_IP"
+	YurttunnelAgentPodIPEnv      = "POD_IP"
+	YurttunnelServerPodName      = "POD_NAME"
+	YurttunnelServerPodNamespace = "POD_NAMESPACE"
 
 	// name of the environment for selecting backend agent used in yurt-tunnel-server
 	ProxyHostHeaderKey = "X-Tunnel-Proxy-Host"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
feature: set tunnel server count dynamically when --server-count flag is not explicitly specified by the user

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
feature: set tunnel server count dynamically when --server-count flag is not explicitly specified by the user
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
