### PR TITLE
yurt-tunnel-agent add necessary RBAC resource

### DIFF
--- a/config/setup/yurt-tunnel-agent.yaml
+++ b/config/setup/yurt-tunnel-agent.yaml
@@ -1,3 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yurt-tunnel-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yurt-tunnel-agent
+subjects:
+  - kind: ServiceAccount
+    name: yurt-tunnel-agent
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: yurt-tunnel-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: yurt-tunnel-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - "certificates.k8s.io"
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create 
+  - list
+  - watch
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -23,6 +71,7 @@ spec:
         args:
         - --node-name=$(NODE_NAME)
         - --node-ip=$(POD_IP)
+        - --apiserver-addr=__kubernetes_service_host__:__kubernetes_service_port_https__
         - --v=2
         image: openyurt/yurt-tunnel-agent:latest
         imagePullPolicy: IfNotPresent
@@ -49,6 +98,7 @@ spec:
               fieldPath: status.hostIP
       hostNetwork: true
       restartPolicy: Always
+      serviceAccountName: yurt-tunnel-agent
       tolerations:
         - operator: Exists
       volumes:

--- a/config/setup/yurthub.yaml
+++ b/config/setup/yurthub.yaml
@@ -19,6 +19,10 @@ spec:
     hostPath:
       path: /var/lib/kubelet/pki
       type: Directory
+  - name: hub-dir
+    hostPath:
+      path: /var/lib/yurthub/pki
+      type: Directory
   containers:
   - name: yurt-hub
     image: openyurt/yurthub:latest
@@ -30,9 +34,13 @@ spec:
       mountPath: /etc/kubernetes/pki
     - name: pem-dir
       mountPath: /var/lib/kubelet/pki
+    - name: hub-dir
+      mountPath: /var/lib/yurthub/pki
     command:
     - yurthub
     - --v=2
+    # if you use bootstrap token, please uncomment this and replace __kubernetes_botstrap_token__ with your kubelet bootstrap token
+    #- --join-token=__kubernetes_bootstrap_token__
     - --server-addr=https://__kubernetes_service_host__:__kubernetes_service_port_https__
     - --node-name=$(NODE_NAME)
     livenessProbe:

--- a/docs/tutorial/manually-setup.md
+++ b/docs/tutorial/manually-setup.md
@@ -84,6 +84,8 @@ s|__kubernetes_service_host__|1.2.3.4|;
 s|__kubernetes_service_port_https__|5678|' > /tmp/yurthub-ack.yaml &&
 scp -i <yourt-ssh-identity-file> /tmp/yurthub-ack.yaml root@us-west-1.192.168.0.88:/etc/kubernetes/manifests
 ```
+If you use bootstrap token, You should add `--join-token` parameters and set the value same as your bootstrap token.
+If you kubernetes `CA` is sign by yourself, you should place your `CA` file in the host path `/var/lib/yurthub/pki/ca.crt`.
 and the Yurthub will be ready in minutes.
 
 ## Setup Yurt-tunnel (Optional)

--- a/docs/tutorial/yurt-tunnel.md
+++ b/docs/tutorial/yurt-tunnel.md
@@ -113,7 +113,8 @@ edge node, which allows the yurt-tunnel-agent to be run on the edge node:
 kubectl label nodes minikube-m02 openyurt.io/is-edge-worker=true
 ```
 
-And, apply the yurt-tunnel-agent yaml:
+And, replace `__kubernetes_service_host__`, `__kubernetes_service_port_https__` with your `kube-apiserver` server address and port, then  apply the yurt-tunnel-agent yaml:
+
 ```bash
 kubectl apply -f config/setup/yurt-tunnel-agent.yaml
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
1. `yurthub` should use `daemonset` instead of `pod`
2. If user use bootstrap token create a new cluster, user should add `--join-token` and set the value with `bootstraptoken`
3. Add note if user create a cluster with self sign `CA`, user should place the ca file in `/var/lib/yurthub/pki/ca.crt`
4. If user chose manual install `openyurt`, The default yurt-tunnel-agent.yaml is invalid, it lacks of `RBAC` configuration. 
5. It also needs to use `--apiserver-addr` default. Because pod can't use `inCluster` configuration to making connection with `kube-apiserver` on `hostNetwork` mode. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #382
Fixes #384 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
