### PR TITLE
bugfix: the same prefix key lock error

### DIFF
--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -460,16 +460,19 @@ func (ds *diskStorage) lockKey(key string) bool {
 	ds.Lock()
 	defer ds.Unlock()
 	if _, ok := ds.keyPendingStatus[key]; ok {
+		klog.Infof("key(%s) storage is pending, just skip it", key)
 		return false
 	}
 
 	for pendingKey := range ds.keyPendingStatus {
 		if len(key) > len(pendingKey) {
-			if strings.Contains(key, pendingKey) {
+			if strings.Contains(key, fmt.Sprintf("%s/", pendingKey)) {
+				klog.Infof("key(%s) storage is pending, skip to store key(%s)", pendingKey, key)
 				return false
 			}
 		} else {
-			if strings.Contains(pendingKey, key) {
+			if strings.Contains(pendingKey, fmt.Sprintf("%s/", key)) {
+				klog.Infof("key(%s) storage is pending, skip to store key(%s)", pendingKey, key)
 				return false
 			}
 		}

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -685,6 +685,12 @@ func TestLockKey(t *testing.T) {
 			lockResult:       true,
 			lockVerifyResult: false,
 		},
+		"lock same prefix key with pre-locked key ": {
+			preLockedKeys:    []string{"kubelet/pods/kube-system/foo"},
+			lockKey:          "kubelet/pods/kube-system/foo2",
+			lockResult:       true,
+			lockVerifyResult: false,
+		},
 	}
 
 	s := &diskStorage{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
fix the deadlock of storage when the keys have the same prefix string. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
