### PR TITLE
feature: add traffic(from cloud to edge) collector metrics for yurthub

### DIFF
--- a/pkg/yurthub/proxy/local/local.go
+++ b/pkg/yurthub/proxy/local/local.go
@@ -116,7 +116,7 @@ func (lp *LocalProxy) localPost(w http.ResponseWriter, req *http.Request) error 
 		ctx = util.WithRespContentType(ctx, reqContentType)
 		req = req.WithContext(ctx)
 		stopCh := make(chan struct{})
-		rc, prc := util.NewDualReadCloser(req.Body, false)
+		rc, prc := util.NewDualReadCloser(req, req.Body, false)
 		go func(req *http.Request, prc io.ReadCloser, stopCh <-chan struct{}) {
 			klog.V(2).Infof("cache events when cluster is unhealthy, %v", lp.cacheMgr.CacheResponse(req, prc, stopCh))
 		}(req, prc, stopCh)

--- a/pkg/yurthub/proxy/remote/remote.go
+++ b/pkg/yurthub/proxy/remote/remote.go
@@ -132,7 +132,7 @@ func (rp *RemoteProxy) modifyResponse(resp *http.Response) error {
 				}
 			}
 
-			rc, prc := util.NewDualReadCloser(resp.Body, true)
+			rc, prc := util.NewDualReadCloser(req, resp.Body, true)
 			go func(req *http.Request, prc io.ReadCloser, stopCh <-chan struct{}) {
 				err := rp.cacheMgr.CacheResponse(req, prc, stopCh)
 				if err != nil && err != io.EOF && err != context.Canceled {

--- a/pkg/yurthub/util/util_test.go
+++ b/pkg/yurthub/util/util_test.go
@@ -27,7 +27,7 @@ func TestDualReader(t *testing.T) {
 	src := []byte("hello, world")
 	rb := bytes.NewBuffer(src)
 	rc := ioutil.NopCloser(rb)
-	drc, prc := NewDualReadCloser(rc, true)
+	drc, prc := NewDualReadCloser(nil, rc, true)
 	rc = drc
 	dst1 := make([]byte, len(src))
 	dst2 := make([]byte, len(src))
@@ -67,7 +67,7 @@ func TestDualReaderByPreClose(t *testing.T) {
 	src := []byte("hello, world")
 	rb := bytes.NewBuffer(src)
 	rc := ioutil.NopCloser(rb)
-	drc, prc := NewDualReadCloser(rc, true)
+	drc, prc := NewDualReadCloser(nil, rc, true)
 	rc = drc
 	dst := make([]byte, len(src))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind feature

#### What this PR does / why we need it:
Add traffic metrics in order to collect the traffic statics from cloud to edge, so we can easily determine which component consumes the most traffic for which type of request.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
