### PR TITLE
Yurtctl modify  kube-controllersetting to close the nodelifecycle-controller

### DIFF
--- a/docs/tutorial/yurtctl.md
+++ b/docs/tutorial/yurtctl.md
@@ -188,18 +188,6 @@ I0831 12:36:22.109368   77322 convert.go:292] the yurt-hub is deployed
 To verify that the yurttunnel works as expected, please refer to
 the [yurttunnel tutorial](https://github.com/openyurtio/openyurt/blob/master/docs/tutorial/yurt-tunnel.md)
 
-## Set the path of configuration
-Sometimes the configuration of the node may be different. Users can set the path of the kubelet service configuration
-by the option `--kubeadm-conf-path`, which is used by kubelet component to join the cluster on the edge node.
-```
-$ _output/bin/yurtctl convert --kubeadm-conf-path /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-```
-The path of the directory on edge node containing static pod files can be set by the
-option `--pod-manifest-path`.
-```
-$ _output/bin/yurtctl convert --pod-manifest-path /etc/kubernetes/manifests
-```
-
 ## Revert/Uninstall OpenYurt
 
 Using `yurtctl` to revert an OpenYurt cluster can be done by doing the following:
@@ -228,6 +216,28 @@ $ _output/bin/yurtctl join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-t
 Using `yurtctl` to join a Cloud-Node to OpenYurt cluster can be by doing the following:
 ```
 $ _output/bin/yurtctl join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud-node --discovery-token-unsafe-skip-ca-verification --v=5
+```
+
+## Note
+### Disable the default nodelifecycle controller
+`yurtctl convert`  will turn off the default nodelifecycle controller to allow the yurt-controller-mamanger to work properly.
+If kube-controller-manager is deployed as a static pod, yurtctl can modify the `kube-controller-manager.yaml`
+according the parameter `--pod-manifest-path` with default value `/etc/kubernetes/manifests`.
+It is also suitable for kube-controller-manager high-availability scenarios.
+
+But for kube-controller-manager deployed in other ways, the user needs to turn off the default nodelifecycle controller manually.
+Please refer to the [Disable the default nodelifecycle controller](https://github.com/openyurtio/openyurt/blob/master/docs/tutorial/manually-setup.md#disable-the-default-nodelifecycle-controller) section. In addition, when using `yurtctl revert`, if kube-controller-manager is not deployed through static file, the user also needs to restore manually.
+
+### Set the path of configuration
+Sometimes the configuration of the node may be different. Users can set the path of the kubelet service configuration
+by the option `--kubeadm-conf-path`, which is used by kubelet component to join the cluster on the edge node.
+```
+$ _output/bin/yurtctl convert --kubeadm-conf-path /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+```
+The path of the directory on edge node containing static pod files can be set by the
+option `--pod-manifest-path`.
+```
+$ _output/bin/yurtctl convert --pod-manifest-path /etc/kubernetes/manifests
 ```
 
 ## Subcommand

--- a/pkg/yurtctl/cmd/convert/edgenode.go
+++ b/pkg/yurtctl/cmd/convert/edgenode.go
@@ -237,7 +237,7 @@ func (c *ConvertEdgeNodeOptions) RunConvertEdgeNode() (err error) {
 			ctx["yurthub_healthcheck_timeout"] = c.YurthubHealthCheckTimeout.String()
 		}
 
-		if err = kubeutil.RunServantJobs(c.clientSet, ctx, c.EdgeNodes, true); err != nil {
+		if err = kubeutil.RunServantJobs(c.clientSet, ctx, c.EdgeNodes); err != nil {
 			klog.Errorf("fail to run ServantJobs: %s", err)
 			return err
 		}

--- a/pkg/yurtctl/cmd/revert/edgenode.go
+++ b/pkg/yurtctl/cmd/revert/edgenode.go
@@ -189,7 +189,7 @@ func (r *RevertEdgeNodeOptions) RunRevertEdgeNode() (err error) {
 				"pod_manifest_path":     r.PodMainfestPath,
 				"kubeadm_conf_path":     r.KubeadmConfPath,
 			},
-			r.EdgeNodes, false); err != nil {
+			r.EdgeNodes); err != nil {
 			klog.Errorf("fail to revert edge node: %s", err)
 			return err
 		}

--- a/pkg/yurtctl/constants/constants.go
+++ b/pkg/yurtctl/constants/constants.go
@@ -184,7 +184,7 @@ spec:
       containers:
       - name: yurtctl-servant
         image: {{.yurtctl_servant_image}}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - /bin/sh
         - -c
@@ -229,7 +229,7 @@ spec:
       containers:
       - name: yurtctl-servant
         image: {{.yurtctl_servant_image}}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - /bin/sh
         - -c
@@ -251,5 +251,57 @@ spec:
         - name: KUBELET_SVC
           value: {{.kubeadm_conf_path}}
           {{end}}
+`
+	// DisableNodeControllerJobTemplate defines the node-controller disable job in yaml format
+	DisableNodeControllerJobTemplate = `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.jobName}}
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      hostPID: true
+      hostNetwork: true
+      restartPolicy: OnFailure
+      nodeName: {{.nodeName}}
+      containers:
+      - name: yurtctl-disable-node-controller
+        image: {{.yurtctl_servant_image}}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - "nsenter -t 1 -m -u -n -i -- sed -i 's/--controllers=/--controllers=-nodelifecycle,/g' {{.pod_manifest_path}}/kube-controller-manager.yaml"
+        securityContext:
+          privileged: true
+`
+	// EnableNodeControllerJobTemplate defines the node-controller enable job in yaml format
+	EnableNodeControllerJobTemplate = `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.jobName}}
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      hostPID: true
+      hostNetwork: true
+      restartPolicy: OnFailure
+      nodeName: {{.nodeName}}
+      containers:
+      - name: yurtctl-enable-node-controller
+        image: {{.yurtctl_servant_image}}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - "nsenter -t 1 -m -u -n -i -- sed -i 's/--controllers=-nodelifecycle,/--controllers=/g' {{.pod_manifest_path}}/kube-controller-manager.yaml"
+        securityContext:
+          privileged: true
 `
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
If kube-controlller-manager is deployed as a static pod, `yurtctl convert` turn off `nodelifecycle controller` by modifying `kube-controller-manager.yaml` instead of deleting clusterrolebinding `system:controller:node-controller`. So OpenYurt cluster created by yurtctl can run normally and support the high availability of `kube-controller-manager`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #391

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
