### PR TITLE
Followup #386: update the ClusterRole for yurt-controller-manager

### DIFF
--- a/config/setup/yurt-controller-manager.yaml
+++ b/config/setup/yurt-controller-manager.yaml
@@ -72,7 +72,32 @@ rules:
     verbs:
       - list
       - watch
-
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/approval
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - signers
+    resourceNames:
+      - "kubernetes.io/legacy-unknown"
+    verbs:
+      - approve
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/yaml-template/yurt-controller-manager.yaml
+++ b/config/yaml-template/yurt-controller-manager.yaml
@@ -72,6 +72,32 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/approval
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - signers
+    resourceNames:
+      - "kubernetes.io/legacy-unknown"
+    verbs:
+      - approve
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/yurtctl/constants/constants.go
+++ b/pkg/yurtctl/constants/constants.go
@@ -108,6 +108,32 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - "kubernetes.io/legacy-unknown"
+  verbs:
+  - approve
 `
 	YurtControllerManagerClusterRoleBinding = `
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug



#### What this PR does / why we need it:

Followup #386: update the ClusterRole for yurt-controller-manager

Fix the following errors:
```sh
yurtcontroller-manager version: projectinfo.Info{GitVersion:"v0.4.0", GitCommit:"131c435", BuildDate:"2021-08-06T05:44:31Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
W0806 07:24:33.917457       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0806 07:24:33.921118       1 controllermanager.go:141] Version: v0.0.0-master+$Format:%h$
I0806 07:24:33.921856       1 leaderelection.go:242] attempting to acquire leader lease  kube-system/yurt-controller-manager...
I0806 07:24:33.941093       1 leaderelection.go:252] successfully acquired lease kube-system/yurt-controller-manager
I0806 07:24:33.941970       1 event.go:278] Event(v1.ObjectReference{Kind:"Lease", Namespace:"kube-system", Name:"yurt-controller-manager", UID:"fb92234f-f1bf-40e5-9b64-cdc28ee8e5e1", APIVersion:"coordination.k8s.io/v1", ResourceVersion:"4869", FieldPath:""}): type: 'Normal' reason: 'LeaderElection' yurt-controller-manager-b856b7f79-2fmbj_026128d6-72a8-49ea-98a5-498de7a7bcac became leader
I0806 07:24:33.970116       1 csrapprover.go:59] starting the crsapprover
I0806 07:24:33.970262       1 controllermanager.go:344] Started "yurthubcsrapprover"
I0806 07:24:33.973253       1 node_lifecycle_controller.go:385] Sending events to api server.
I0806 07:24:33.974898       1 taint_manager.go:168] Sending events to api server.
I0806 07:24:33.975845       1 node_lifecycle_controller.go:513] Controller will reconcile labels.
I0806 07:24:33.975960       1 controllermanager.go:344] Started "nodelifecycle"
I0806 07:24:33.977082       1 node_lifecycle_controller.go:547] Starting node controller
I0806 07:24:33.977104       1 shared_informer.go:223] Waiting for caches to sync for taint
E0806 07:24:33.994306       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
I0806 07:24:34.077866       1 shared_informer.go:230] Caches are synced for taint 
I0806 07:24:34.078167       1 node_lifecycle_controller.go:1434] Initializing eviction metric for zone: 
W0806 07:24:34.078529       1 node_lifecycle_controller.go:1049] Missing timestamp for Node kind-worker2. Assuming now as a timestamp.
I0806 07:24:34.079197       1 taint_manager.go:192] Starting NoExecuteTaintManager
I0806 07:24:34.079269       1 event.go:278] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"kind-worker2", UID:"dfa9737f-4d50-40dc-8d38-b83482cc6c71", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'RegisteredNode' Node kind-worker2 event: Registered Node kind-worker2 in Controller
I0806 07:24:34.079782       1 event.go:278] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"kind-worker", UID:"f68b44c1-ae67-4416-8b7d-5258d5175d13", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'RegisteredNode' Node kind-worker event: Registered Node kind-worker in Controller
I0806 07:24:34.079812       1 event.go:278] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"kind-control-plane", UID:"80dd6679-cc6b-4fee-9d3c-cd77213bc4c1", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'RegisteredNode' Node kind-control-plane event: Registered Node kind-control-plane in Controller
I0806 07:24:34.079963       1 event.go:278] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"kind-worker3", UID:"d7c3cd96-94b1-44a6-9a85-0f2d78c05574", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'RegisteredNode' Node kind-worker3 event: Registered Node kind-worker3 in Controller
W0806 07:24:34.079439       1 node_lifecycle_controller.go:1049] Missing timestamp for Node kind-control-plane. Assuming now as a timestamp.
W0806 07:24:34.081548       1 node_lifecycle_controller.go:1049] Missing timestamp for Node kind-worker3. Assuming now as a timestamp.
W0806 07:24:34.082856       1 node_lifecycle_controller.go:1049] Missing timestamp for Node kind-worker. Assuming now as a timestamp.
I0806 07:24:34.083261       1 node_lifecycle_controller.go:1250] Controller detected that zone  is now in state Normal.
E0806 07:24:35.085377       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:24:38.220201       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:24:44.298675       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:24:57.051524       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:25:19.600795       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:26:10.152656       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:26:45.418166       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:27:39.678756       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:28:25.111798       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:29:07.067993       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:29:44.372375       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
E0806 07:30:42.369670       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.8/tools/cache/reflector.go:125: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:kube-system:yurt-controller-manager" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
