### PR TITLE
fix pod access yurthub https endpoint error

### DIFF
--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -124,7 +124,7 @@ func Run(cfg *config.YurtHubConfiguration, stopCh <-chan struct{}) error {
 	trace++
 
 	klog.Infof("%d. create tls config for secure servers ", trace)
-	cfg.TLSConfig, err = server.GenUseCertMgrAndTLSConfig(restConfigMgr, certManager, filepath.Join(cfg.RootDir, "pki"), stopCh)
+	cfg.TLSConfig, err = server.GenUseCertMgrAndTLSConfig(restConfigMgr, certManager, filepath.Join(cfg.RootDir, "pki"), cfg.YurtHubProxyServerSecureDummyAddr, stopCh)
 	if err != nil {
 		klog.Errorf("could not create tls config, %v", err)
 		return err

--- a/pkg/controller/certificates/csrapprover.go
+++ b/pkg/controller/certificates/csrapprover.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
-	"github.com/openyurtio/openyurt/pkg/yurthub/pki/certmanager"
+	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/server"
 )
 
 const (
@@ -210,7 +210,7 @@ func isYurtHubCSR(csr *certificates.CertificateSigningRequest) bool {
 		return false
 	}
 	for i, org := range x509cr.Subject.Organization {
-		if org == certmanager.YurtHubCSROrg {
+		if org == server.YurtHubCSROrg {
 			break
 		}
 		if i == len(x509cr.Subject.Organization)-1 {

--- a/pkg/yurthub/certificate/pki.go
+++ b/pkg/yurthub/certificate/pki.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pki
+package certificate
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
1. If pods access dummy ip address of yurthub https server, pods get the error info: x509: certificate is valid for 127.0.0.1, not 169.254.2.1, so we need to add ip address of dummy network interface into server certificate of yurthub.

2. Move server certificate dir and files under `pkg/yurthub/certificate` dir,  so all certificates(include both server and client certificate) can be managed under same dir. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
