### PR TITLE
auto open the autonomous when convert edgenode

### DIFF
--- a/pkg/yurtctl/cmd/convert/edgenode.go
+++ b/pkg/yurtctl/cmd/convert/edgenode.go
@@ -38,6 +38,7 @@ import (
 	nodeutil "k8s.io/kubernetes/pkg/controller/util/node"
 
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/yurtctl/constants"
 	enutil "github.com/openyurtio/openyurt/pkg/yurtctl/util/edgenode"
 	kubeutil "github.com/openyurtio/openyurt/pkg/yurtctl/util/kubernetes"
 	strutil "github.com/openyurtio/openyurt/pkg/yurtctl/util/strings"
@@ -284,6 +285,13 @@ func (c *ConvertEdgeNodeOptions) RunConvertEdgeNode() (err error) {
 			return err
 		}
 		_, err = kubeutil.LabelNode(c.clientSet, node, projectinfo.GetEdgeWorkerLabelKey(), "true")
+		if err != nil {
+			return err
+		}
+
+		// 3.6. open the autonomous
+		klog.Infof("open the %s autonomous", nodeName)
+		_, err = kubeutil.AnnotateNode(c.clientSet, node, constants.AnnotationAutonomy, "true")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
 /kind feature


#### What this PR does / why we need it:
When i use yurtctl to convert k8s cluster, I wish the edgenode can auto open the autonomous, not do the extra work, And it is usually unfriendly to beginners.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
