### PR TITLE
feature: add discard cloud service filter in yurthub

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter/discardcloudservice"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/masterservice"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/servicetopology"
 	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
@@ -208,4 +209,5 @@ func createSharedInformers(proxyAddr string) (informers.SharedInformerFactory, y
 func registerAllFilters(filters *filter.Filters) {
 	servicetopology.Register(filters)
 	masterservice.Register(filters)
+	discardcloudservice.Register(filters)
 }

--- a/pkg/yurthub/filter/discardcloudservice/filter.go
+++ b/pkg/yurthub/filter/discardcloudservice/filter.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discardcloudservice
+
+import (
+	"io"
+	"net/http"
+
+	"k8s.io/klog"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+	filterutil "github.com/openyurtio/openyurt/pkg/yurthub/filter/util"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
+)
+
+// discardcloudservice filter is used to discard cloud service(like loadBalancer service)
+// on kube-proxy list/watch service request from edge nodes.
+const FilterName = "discardcloudservice"
+
+// Register registers a filter
+func Register(filters *filter.Filters) {
+	filters.Register(FilterName, func() (filter.Interface, error) {
+		return NewFilter(), nil
+	})
+}
+
+func NewFilter() *discardCloudServiceFilter {
+	return &discardCloudServiceFilter{
+		Approver: filter.NewApprover("kube-proxy", "services", []string{"list", "watch"}...),
+	}
+}
+
+type discardCloudServiceFilter struct {
+	*filter.Approver
+	serializerManager *serializer.SerializerManager
+}
+
+func (sf *discardCloudServiceFilter) SetSerializerManager(s *serializer.SerializerManager) error {
+	sf.serializerManager = s
+	return nil
+}
+
+func (sf *discardCloudServiceFilter) Filter(req *http.Request, rc io.ReadCloser, stopCh <-chan struct{}) (int, io.ReadCloser, error) {
+	s := filterutil.CreateSerializer(req, sf.serializerManager)
+	if s == nil {
+		klog.Errorf("skip filter, failed to create serializer in discardCloudServiceFilter")
+		return 0, rc, nil
+	}
+
+	handler := NewDiscardCloudServiceFilterHandler(s)
+	return filter.NewFilterReadCloser(req, rc, handler, s, stopCh)
+}

--- a/pkg/yurthub/filter/discardcloudservice/handler.go
+++ b/pkg/yurthub/filter/discardcloudservice/handler.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discardcloudservice
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog"
+)
+
+var (
+	cloudClusterIPService = map[string]struct{}{
+		"kube-system/x-tunnel-server-internal-svc": {},
+	}
+)
+
+type discardCloudServiceFilterHandler struct {
+	serializer *serializer.Serializer
+}
+
+func NewDiscardCloudServiceFilterHandler(serializer *serializer.Serializer) filter.Handler {
+	return &discardCloudServiceFilterHandler{
+		serializer: serializer,
+	}
+}
+
+// ObjectResponseFilter remove the cloud service(like LoadBalancer service) from response object
+func (fh *discardCloudServiceFilterHandler) ObjectResponseFilter(b []byte) ([]byte, error) {
+	list, err := fh.serializer.Decode(b)
+	if err != nil || list == nil {
+		klog.Errorf("skip filter, failed to decode response in ObjectResponseFilter of discardCloudServiceFilterHandler %v", err)
+		return b, nil
+	}
+
+	serviceList, ok := list.(*v1.ServiceList)
+	if ok {
+		var svcNew []v1.Service
+		for i := range serviceList.Items {
+			nsName := fmt.Sprintf("%s/%s", serviceList.Items[i].Namespace, serviceList.Items[i].Name)
+			// remove lb service
+			if serviceList.Items[i].Spec.Type == v1.ServiceTypeLoadBalancer {
+				klog.V(2).Infof("load balancer service(%s) is discarded in ObjectResponseFilter of discardCloudServiceFilterHandler", nsName)
+				continue
+			}
+
+			// remove cloud clusterIP service
+			if _, ok := cloudClusterIPService[nsName]; ok {
+				klog.V(2).Infof("clusterIP service(%s) is discarded in ObjectResponseFilter of discardCloudServiceFilterHandler", nsName)
+				continue
+			}
+
+			svcNew = append(svcNew, serviceList.Items[i])
+		}
+		serviceList.Items = svcNew
+		return fh.serializer.Encode(serviceList)
+	}
+
+	return b, nil
+}
+
+// StreamResponseFilter filter the cloud service(like LoadBalancer service) from watch stream response
+func (fh *discardCloudServiceFilterHandler) StreamResponseFilter(rc io.ReadCloser, ch chan watch.Event) error {
+	defer func() {
+		close(ch)
+	}()
+
+	d, err := fh.serializer.WatchDecoder(rc)
+	if err != nil {
+		klog.Errorf("StreamResponseFilter for discardCloudServiceFilterHandler ended with error, %v", err)
+		return err
+	}
+
+	for {
+		watchType, obj, err := d.Decode()
+		if err != nil {
+			return err
+		}
+
+		service, ok := obj.(*v1.Service)
+		if ok {
+			nsName := fmt.Sprintf("%s/%s", service.Namespace, service.Name)
+			// remove cloud LoadBalancer service
+			if service.Spec.Type == v1.ServiceTypeLoadBalancer {
+				klog.V(2).Infof("load balancer service(%s) is discarded in StreamResponseFilter of discardCloudServiceFilterHandler", nsName)
+				continue
+			}
+
+			// remove cloud clusterIP service
+			if _, ok := cloudClusterIPService[nsName]; ok {
+				klog.V(2).Infof("clusterIP service(%s) is discarded in StreamResponseFilter of discardCloudServiceFilterHandler", nsName)
+				continue
+			}
+		}
+
+		var wEvent watch.Event
+		wEvent.Type = watchType
+		wEvent.Object = obj
+		ch <- wEvent
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind feature

#### What this PR does / why we need it:
- background:
    Kube-proxy(ipvs mode) will configure ipvs rules for `LoadBalancer` service on the edge node, so if pods(like yurt-tunnel-agent) on edge nodes use ingress ip of `LoadBalancer` service to access the cloud pods(like yurt-tunnel-server),  the connection will be refused for ipvs rule will dnat the ingress ip to pod ip on the edge node.
    And  end user have come across the same error that yurt-tunnel-agent failed to use ingress ip of `x-tunnel-server-svc` service to access yurt-tunnel-server. the detailed info is here: https://github.com/openyurtio/openyurt/issues/447

- solution:
    In order to make sure pods on edge nodes can use LoadBalancer service to access pods on cloud nodes, we need disable the kube-proxy dnat rule for LoadBalancer service. so we add a filter named `discardCloudService` for yurthub to discard LoadBalancer service for kube-proxy component.
At the same time, some ClusterIP services(like kube-system/x-tunnel-server-internal-svc) are not need to aware by edge nodes, so we also discard these ClusterIP service in the new filter.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
