### PR TITLE
bugfix: move MaxInFlightLimit handler chain after RequestClientComponent

### DIFF
--- a/pkg/yurthub/proxy/proxy.go
+++ b/pkg/yurthub/proxy/proxy.go
@@ -91,9 +91,9 @@ func (p *yurtReverseProxy) buildHandlerChain(handler http.Handler) http.Handler 
 	handler = util.WithCacheHeaderCheck(handler)
 	handler = util.WithRequestTimeout(handler)
 	handler = util.WithListRequestSelector(handler)
+	handler = util.WithMaxInFlightLimit(handler, p.maxRequestsInFlight)
 	handler = util.WithRequestClientComponent(handler)
 	handler = filters.WithRequestInfo(handler, p.resolver)
-	handler = util.WithMaxInFlightLimit(handler, p.maxRequestsInFlight)
 	return handler
 }
 


### PR DESCRIPTION
Signed-off-by: SataQiu <shidaqiu2018@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
`MaxInFlightLimit` wants to show the client component, but the client component info is available only after `RequestClientComponent` chain executed.

https://github.com/openyurtio/openyurt/blob/b7bef6d0f1268b98826f840a5aaceb585516b394/pkg/yurthub/proxy/util/util.go#L235

https://github.com/openyurtio/openyurt/blob/b7bef6d0f1268b98826f840a5aaceb585516b394/pkg/yurthub/util/util.go#L131

This PR move `MaxInFlightLimit` handler chain after `RequestClientComponent`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
-->
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
bugfix: move 'MaxInFlightLimit' handler chain after 'RequestClientComponent'
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
