### PR TITLE
bugfix: fix incomplete data copy of resource filter

### DIFF
--- a/pkg/yurthub/cachemanager/cache_manager.go
+++ b/pkg/yurthub/cachemanager/cache_manager.go
@@ -347,7 +347,7 @@ func (cm *cacheManager) saveListObject(ctx context.Context, info *apirequest.Req
 
 	list, err := s.Decode(b)
 	if err != nil || list == nil {
-		klog.Errorf("failed to decode response in saveOneObject %v", err)
+		klog.Errorf("failed to decode response in saveListObject %v", err)
 		return err
 	}
 

--- a/pkg/yurthub/filter/filter.go
+++ b/pkg/yurthub/filter/filter.go
@@ -191,8 +191,7 @@ func (dr *filterReadCloser) Read(p []byte) (int, error) {
 			return n, nil
 		}
 	} else {
-		n := copy(p, dr.data.Bytes())
-		return n, io.EOF
+		return dr.data.Read(p)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: SataQiu <shidaqiu2018@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
```
// The copy built-in function copies elements from a source slice into a
// destination slice. (As a special case, it also will copy bytes from a
// string to a slice of bytes.) The source and destination may overlap. Copy
// returns the number of elements copied, which will be the minimum of
// len(src) and len(dst).
func copy(dst, src []Type) int
```

`func (dr *filterReadCloser) Read(p []byte) (int, error)` will return incomplete data when the data size is larger than the default size of `p` (32768). 
The `Read` function can be called multi times, we should just use `dr.data.Read(p)` instead of `copy`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #426 #432

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer

-->

/assign @rambohe-ch 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
bugfix: fix incomplete data copy of resource filter
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
