### PR TITLE
bugfix: prepare yurthub server tls config panic

### DIFF
--- a/pkg/yurthub/gc/gc.go
+++ b/pkg/yurthub/gc/gc.go
@@ -73,7 +73,7 @@ func (m *GCManager) Run() {
 	go wait.JitterUntil(func() {
 		klog.V(2).Infof("start gc events after waiting %v from previous gc", time.Since(m.lastTime))
 		m.lastTime = time.Now()
-		cfg := m.restConfigManager.GetRestConfig()
+		cfg := m.restConfigManager.GetRestConfig(true)
 		if cfg == nil {
 			klog.Errorf("could not get rest config, so skip gc")
 			return
@@ -96,7 +96,7 @@ func (m *GCManager) gcPodsWhenRestart() error {
 	}
 	klog.Infof("list pod keys from storage, total: %d", len(localPodKeys))
 
-	cfg := m.restConfigManager.GetRestConfig()
+	cfg := m.restConfigManager.GetRestConfig(true)
 	if cfg == nil {
 		klog.Errorf("could not get rest config, so skip gc pods when restart")
 		return err

--- a/pkg/yurthub/kubernetes/rest/config.go
+++ b/pkg/yurthub/kubernetes/rest/config.go
@@ -52,25 +52,29 @@ func NewRestConfigManager(cfg *config.YurtHubConfiguration, certMgr interfaces.Y
 }
 
 // GetRestConfig gets rest client config according to the mode of certificateManager
-func (rcm *RestConfigManager) GetRestConfig() *rest.Config {
+func (rcm *RestConfigManager) GetRestConfig(needHealthyServer bool) *rest.Config {
 	certMgrMode := rcm.certMgrMode
 	switch certMgrMode {
 	case util.YurtHubCertificateManagerName:
-		return rcm.getHubselfRestConfig()
+		return rcm.getHubselfRestConfig(needHealthyServer)
 	case util.KubeletCertificateManagerName:
-		return rcm.getKubeletRestConfig(rcm.kubeletRootCAFilePath, rcm.kubeletPairFilePath)
+		return rcm.getKubeletRestConfig(rcm.kubeletRootCAFilePath, rcm.kubeletPairFilePath, needHealthyServer)
 	default:
 		return nil
 	}
 }
 
 // getKubeletRestConfig gets rest client config from kubelet.conf
-func (rcm *RestConfigManager) getKubeletRestConfig(kubeletRootCAFilePath, kubeletPairFilePath string) *rest.Config {
-	healthyServer := rcm.getHealthyServer()
-	if healthyServer == nil {
-		klog.Infof("all of remote servers are unhealthy, so return nil for rest config")
-		return nil
+func (rcm *RestConfigManager) getKubeletRestConfig(kubeletRootCAFilePath, kubeletPairFilePath string, needHealthyServer bool) *rest.Config {
+	healthyServer := rcm.remoteServers[0]
+	if needHealthyServer {
+		healthyServer = rcm.getHealthyServer()
+		if healthyServer == nil {
+			klog.Infof("all of remote servers are unhealthy, so return nil for rest config")
+			return nil
+		}
 	}
+
 	cfg, err := util.LoadKubeletRestClientConfig(healthyServer, kubeletRootCAFilePath, kubeletPairFilePath)
 	if err != nil {
 		klog.Errorf("could not load kubelet rest client config, %v", err)
@@ -80,11 +84,14 @@ func (rcm *RestConfigManager) getKubeletRestConfig(kubeletRootCAFilePath, kubele
 }
 
 // getHubselfRestConfig gets rest client config from hub agent conf file.
-func (rcm *RestConfigManager) getHubselfRestConfig() *rest.Config {
-	healthyServer := rcm.getHealthyServer()
-	if healthyServer == nil {
-		klog.Infof("all of remote servers are unhealthy, so return nil for rest config")
-		return nil
+func (rcm *RestConfigManager) getHubselfRestConfig(needHealthyServer bool) *rest.Config {
+	healthyServer := rcm.remoteServers[0]
+	if needHealthyServer {
+		healthyServer = rcm.getHealthyServer()
+		if healthyServer == nil {
+			klog.Infof("all of remote servers are unhealthy, so return nil for rest config")
+			return nil
+		}
 	}
 
 	// certificate expired, rest config can not be used to connect remote server,

--- a/pkg/yurthub/kubernetes/rest/config_test.go
+++ b/pkg/yurthub/kubernetes/rest/config_test.go
@@ -134,7 +134,7 @@ func TestGetRestConfig(t *testing.T) {
 			}
 
 			var rc *rest.Config
-			rc = rcm.GetRestConfig()
+			rc = rcm.GetRestConfig(true)
 			if tt.mode == "hubself" {
 				if rc.Host != u.String() || rc.TLSClientConfig.CertFile != yurthubCurrent || rc.TLSClientConfig.KeyFile != yurthubCurrent {
 					t.Errorf("The information in rest.Config is not correct: %s", tt.mode)

--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -172,7 +172,12 @@ func healthz(w http.ResponseWriter, _ *http.Request) {
 // create a certificate manager for the yurthub server and run the csr approver for both yurthub
 // and generate a TLS configuration
 func GenUseCertMgrAndTLSConfig(restConfigMgr *rest.RestConfigManager, certificateMgr interfaces.YurtCertificateManager, certDir, proxyServerSecureDummyAddr string, stopCh <-chan struct{}) (*tls.Config, error) {
-	clientSet, err := kubernetes.NewForConfig(restConfigMgr.GetRestConfig())
+	cfg := restConfigMgr.GetRestConfig(false)
+	if cfg == nil {
+		return nil, fmt.Errorf("failed to prepare rest config based ong hub agent client certificate")
+	}
+
+	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
- bug:
   if yurthub re-startup when network between cloud and edge disconnected, a panic will happen for preparing server tls config. and the panic like as following:
  
![image](https://user-images.githubusercontent.com/57081505/132520651-9bee2b35-6799-4d62-9a3d-078a26752d9e.png)

- reason:
  yurthub will use healthy server address and certificate under `/var/lib/yurthub/pki` dir to create `rest.Config` for https server. the code is here: https://github.com/openyurtio/openyurt/blob/master/pkg/yurthub/kubernetes/rest/config.go#L83-113
  and when cloud-edge network breaks down, healthy server will become true, so `rest.Config` will be nil, then panic happened.

- solution:
  we only need to prepare for `rest.Config`, and not need to connect remote server, so healthy server is not a requirement, so we add a `needHealthyServer` parameter for  `GetRestConfig()` to create `rest.Config` whether healthy server should be set or not. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
