### PR TITLE
enhancement: add configmap to configure user agents for specify response cache.

### DIFF
--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -126,7 +126,7 @@ func Run(cfg *config.YurtHubConfiguration, stopCh <-chan struct{}) error {
 	trace++
 
 	klog.Infof("%d. new cache manager with storage wrapper and serializer manager", trace)
-	cacheMgr, err := cachemanager.NewCacheManager(cfg.StorageWrapper, cfg.SerializerManager, cfg.RESTMapperManager)
+	cacheMgr, err := cachemanager.NewCacheManager(cfg.StorageWrapper, cfg.SerializerManager, cfg.RESTMapperManager, cfg.SharedFactory)
 	if err != nil {
 		return fmt.Errorf("could not new cache manager, %v", err)
 	}

--- a/config/setup/yurthub-cfg.yaml
+++ b/config/setup/yurthub-cfg.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yurt-hub-cfg
+  namespace: kube-system
+data:
+  cache_agents: ""

--- a/pkg/yurthub/cachemanager/cache_manager_test.go
+++ b/pkg/yurthub/cachemanager/cache_manager_test.go
@@ -43,8 +43,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/filters"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 var (
@@ -62,7 +64,7 @@ func TestCacheGetResponse(t *testing.T) {
 	yurtCM := &cacheManager{
 		storage:           sWrapper,
 		serializerManager: serializerM,
-		cacheAgents:       make(map[string]bool),
+		cacheAgents:       sets.String{},
 		restMapperManager: restRESTMapperMgr,
 	}
 
@@ -550,7 +552,7 @@ func TestCacheWatchResponse(t *testing.T) {
 	yurtCM := &cacheManager{
 		storage:           sWrapper,
 		serializerManager: serializerM,
-		cacheAgents:       make(map[string]bool),
+		cacheAgents:       sets.String{},
 		restMapperManager: restRESTMapperMgr,
 	}
 
@@ -855,7 +857,7 @@ func TestCacheListResponse(t *testing.T) {
 	yurtCM := &cacheManager{
 		storage:           sWrapper,
 		serializerManager: serializerM,
-		cacheAgents:       make(map[string]bool),
+		cacheAgents:       sets.String{},
 		restMapperManager: restRESTMapperMgr,
 	}
 
@@ -1342,7 +1344,7 @@ func TestQueryCacheForGet(t *testing.T) {
 	yurtCM := &cacheManager{
 		storage:           sWrapper,
 		serializerManager: serializerM,
-		cacheAgents:       make(map[string]bool),
+		cacheAgents:       sets.String{},
 		restMapperManager: restRESTMapperMgr,
 	}
 
@@ -1874,7 +1876,7 @@ func TestQueryCacheForList(t *testing.T) {
 	yurtCM := &cacheManager{
 		storage:           sWrapper,
 		serializerManager: serializerM,
-		cacheAgents:       make(map[string]bool),
+		cacheAgents:       sets.String{},
 		restMapperManager: restRESTMapperMgr,
 	}
 
@@ -2353,7 +2355,7 @@ func TestCanCacheFor(t *testing.T) {
 		t.Errorf("failed to create disk storage, %v", err)
 	}
 	s := NewStorageWrapper(dStorage)
-	m, _ := NewCacheManager(s, nil, nil)
+	m, _ := NewCacheManager(s, nil, nil, nil)
 
 	type proxyRequest struct {
 		userAgent string
@@ -2606,4 +2608,11 @@ func checkReqCanCache(m CacheManager, userAgent, verb, path string, header map[s
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
 	return reqCanCache
+}
+
+func newTestRequestInfoResolver() *request.RequestInfoFactory {
+	return &request.RequestInfoFactory{
+		APIPrefixes:          sets.NewString("api", "apis"),
+		GrouplessAPIPrefixes: sets.NewString("api"),
+	}
 }

--- a/pkg/yurthub/proxy/local/local_test.go
+++ b/pkg/yurthub/proxy/local/local_test.go
@@ -59,7 +59,7 @@ func TestServeHTTPForWatch(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil, nil)
 
 	fn := func() bool {
 		return false
@@ -147,7 +147,7 @@ func TestServeHTTPForWatchWithHealthyChange(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil, nil)
 
 	cnt := 0
 	fn := func() bool {
@@ -229,7 +229,7 @@ func TestServeHTTPForPost(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil, nil)
 
 	fn := func() bool {
 		return false
@@ -305,7 +305,7 @@ func TestServeHTTPForDelete(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil, nil)
 
 	fn := func() bool {
 		return false
@@ -368,7 +368,7 @@ func TestServeHTTPForGetReqCache(t *testing.T) {
 	}
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, nil, nil)
 
 	fn := func() bool {
 		return false
@@ -504,7 +504,7 @@ func TestServeHTTPForListReqCache(t *testing.T) {
 	sWrapper := cachemanager.NewStorageWrapper(dStorage)
 	serializerM := serializer.NewSerializerManager()
 	restRESTMapperMgr := hubmeta.NewRESTMapperManager(dStorage)
-	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, restRESTMapperMgr)
+	cacheM, _ := cachemanager.NewCacheManager(sWrapper, serializerM, restRESTMapperMgr, nil)
 
 	fn := func() bool {
 		return false

--- a/pkg/yurthub/util/util.go
+++ b/pkg/yurthub/util/util.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
 	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
 	"github.com/openyurtio/openyurt/pkg/yurthub/metrics"
 
@@ -63,6 +64,13 @@ const (
 	ProxyReqCanCache
 	// ProxyListSelector represents label selector and filed selector string for list request
 	ProxyListSelector
+	YurtHubNamespace   = "kube-system"
+	CacheUserAgentsKey = "cache_agents"
+)
+
+var (
+	DefaultCacheAgents   = []string{"kubelet", "kube-proxy", "flanneld", "coredns", projectinfo.GetAgentName(), projectinfo.GetHubName()}
+	YurthubConfigMapName = fmt.Sprintf("%s-hub-cfg", strings.TrimRightFunc(projectinfo.GetProjectPrefix(), func(c rune) bool { return c == '-' }))
 )
 
 // WithValue returns a copy of parent in which the value associated with key is val.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind feature

#### What this PR does / why we need it:
    
- background:
    At present, only response for requests from fixed user agents(like kube-proxy, flanneld, coredns, kubelet, yurthub, yurt-tunnel-agent) can be cached in local disk by yurthub. if user's pod access kube-apiserver through yurthub, the response can not be cached on local disk for user agents can not be recognized.

- solution:
  1. It's not good idea to enable cache all response for requests through yurthub, because some clients only want to access kube-apiserver or some list requests may get large volume data and make pressure to local disk.
  2. So we add an configmap named yurt-hub-cfg with `cache_agents` field in kube-system namespace, user can add request user agent in this field.
  3. For example, `calico` components want to access kube-apiserver through yurthub and want to use yurthub cache ability, you can configure as following:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: yurt-hub-cfg
  namespace: kube-system
data:
  cache_agents: "calico"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
