### PR TITLE
bugfix: use buffered channel for signal notifications

### DIFF
--- a/cmd/yurt-tunnel-server/server.go
+++ b/cmd/yurt-tunnel-server/server.go
@@ -32,7 +32,10 @@ func main() {
 	klog.InitFlags(nil)
 	defer klog.Flush()
 
-	s := make(chan os.Signal)
+	// Set up channel on which to send signal notifications.
+	// We must use a buffered channel or risk missing the signal
+	// if we're not ready to receive when the signal is sent.
+	s := make(chan os.Signal, 1)
 	signal.Notify(s, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM,
 		syscall.SIGQUIT, syscall.SIGILL, syscall.SIGTRAP, syscall.SIGABRT)
 	stop := make(chan struct{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
bugfix: use buffered channel for signal notifications

When I upgrade to go 1.17, executing `make` will cause an error:
```sh
# go version
go version go1.17.1 darwin/amd64
# make
go fmt ./pkg/... ./cmd/...
pkg/yurthub/network/dummyif_test.go
pkg/yurthub/network/dummyif_unsupported.go
go vet ./pkg/... ./cmd/...
# github.com/openyurtio/openyurt/cmd/yurt-tunnel-server
cmd/yurt-tunnel-server/server.go:39:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
make: *** [vet] Error 2
```

FYI: https://github.com/golang/go/blob/ee91bb83198f61aa8f26c3100ca7558d302c0a98/src/os/signal/example_test.go#L14-L17

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
