### PR TITLE
bugfix: exclude the effect of empty strings for agents

### DIFF
--- a/pkg/yurthub/cachemanager/cache_agent_test.go
+++ b/pkg/yurthub/cachemanager/cache_agent_test.go
@@ -50,6 +50,12 @@ func TestUpdateCacheAgents(t *testing.T) {
 			resultAgents:  sets.NewString(append([]string{"agent1", "agent2"}, util.DefaultCacheAgents...)...),
 			deletedAgents: sets.String{},
 		},
+		"empty agents added ": {
+			initAgents:    []string{},
+			cacheAgents:   "",
+			resultAgents:  sets.NewString(util.DefaultCacheAgents...),
+			deletedAgents: sets.String{},
+		},
 	}
 	for k, tt := range testcases {
 		t.Run(k, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
if user agent is an empty string, we need to filter it to avoid cache failure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
