### PR TITLE
bugfix: add client auth key usage to yurt-tunnel-server certmanager

### DIFF
--- a/pkg/yurttunnel/pki/certmanager/certmanager.go
+++ b/pkg/yurttunnel/pki/certmanager/certmanager.go
@@ -92,6 +92,7 @@ func NewYurttunnelServerCertManager(
 			certificates.UsageKeyEncipherment,
 			certificates.UsageDigitalSignature,
 			certificates.UsageServerAuth,
+			certificates.UsageClientAuth,
 		},
 		ips)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->
/kind bug

#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage



#### What this PR does / why we need it:
The key usage `certificates.UsageClientAuth` is missing from `yurt-tunnel-server` certmanager.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #508

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @SataQiu @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
