### PR TITLE
[bug] fix some bugs when local up openyurt

### DIFF
--- a/hack/lib/release-images.sh
+++ b/hack/lib/release-images.sh
@@ -50,7 +50,7 @@ readonly region=${REGION:-us}
 function get_image_name {
     # If ${GIT_COMMIT} is not at a tag, add commit to the image tag. 
     if [[ -z $(git tag --points-at ${GIT_COMMIT}) ]]; then
-        yurt_component_image="${REPO}/$1:${TAG}-$2-$(expr substr ${GIT_COMMIT} 1 7)"
+        yurt_component_image="${REPO}/$1:${TAG}-$2-$(echo ${GIT_COMMIT} | cut -c 1-7)"
     else
         yurt_component_image="${REPO}/$1:${TAG}-$2"
     fi    

--- a/hack/local_up_openyurt.sh
+++ b/hack/local_up_openyurt.sh
@@ -182,7 +182,7 @@ function kind_load_images {
         fi
         
         echo "loading image ${imagename} to nodes"
-        local nodesarg=$(echo "${master} ${edgenodes[@]}" | sed "s/ /,/g")
+        local nodesarg=$(echo ${master} ${edgenodes[@]} | sed "s/ /,/g")
         kind load image-archive ${IMAGES_DIR}/${imagename} \
             --name ${CLUSTER_NAME} --nodes ${nodesarg}
     done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug



#### What this PR does / why we need it:
When we set `NODE_NUM` greater than 2, there's a bug which prevents us from converting worker nodes into openyurt nodes.
The reason of the problem is that the following command will end in format error when we use it to load images into kind nodes.
```bash
 local nodesarg=$(echo "${master} ${edgenodes[@]}" | sed "s/ /,/g")
```
Assuming that we have two edge nodes called `openyurt-e2e-test-worker` and `openyurt-e2e-test-worker2` respectively. The master node is called as `openyurt-e2e-test-control-plane`. The result of the command is
```bash
loading image yurthub-linux-amd64.tar to nodes
++ echo 'openyurt-e2e-test-control-plane openyurt-e2e-test-worker
openyurt-e2e-test-worker2'
++ sed 's/ /,/g'
+ local 'nodesarg=openyurt-e2e-test-control-plane,openyurt-e2e-test-worker
openyurt-e2e-test-worker2'
``` 
Then when we use `nodesarg` to load images into kind nodes, the result is something like this:
```bash
+ kind load image-archive /root/openyurt/openyurt/_output/images/yurthub-linux-amd64.tar --name openyurt-e2e-test --nodes openyurt-e2e-test-control-plane,openyurt-e2e-test-worker openyurt-e2e-test-worker2
```
We can find that there's no comma between `openyurt-e2e-test-worker` and `openyurt-e2e-test-worker2` which `kind` requires. As a result, the image is only loaded into `openyurt-e2e-test-control-plane` and `openyurt-e2e-test-worker`. Thus, the conversion of openyurt-e2e-test-worker2 will fail for the lack of images.
 ```bash
[root@node1 openyurt]# kubectl get pod -A
NAMESPACE            NAME                                                      READY   STATUS             RESTARTS   AGE
kube-system          coredns-66bff467f8-6zrgr                                  1/1     Running            0          11m
kube-system          coredns-66bff467f8-blcd4                                  1/1     Running            0          11m
kube-system          etcd-openyurt-e2e-test-control-plane                      1/1     Running            0          11m
kube-system          kindnet-csdvg                                             1/1     Running            0          11m
kube-system          kindnet-kvj55                                             1/1     Running            0          11m
kube-system          kindnet-r5vnm                                             1/1     Running            0          11m
kube-system          kube-apiserver-openyurt-e2e-test-control-plane            1/1     Running            0          11m
kube-system          kube-controller-manager-openyurt-e2e-test-control-plane   1/1     Running            0          10m
kube-system          kube-proxy-dg7mc                                          1/1     Running            0          11m
kube-system          kube-proxy-k6cnw                                          1/1     Running            0          11m
kube-system          kube-proxy-rc855                                          1/1     Running            0          11m
kube-system          kube-scheduler-openyurt-e2e-test-control-plane            1/1     Running            0          11m
kube-system          yurt-controller-manager-64869c8847-tb8rp                  1/1     Running            0          10m
kube-system          yurt-hub-openyurt-e2e-test-control-plane                  1/1     Running            0          7m58s
kube-system          yurt-hub-openyurt-e2e-test-worker                         1/1     Running            0          9m58s
kube-system          yurtctl-servant-convert-openyurt-e2e-test-worker2-dxw89   0/1     ImagePullBackOff   0          9m59s
local-path-storage   local-path-provisioner-59c6df4d-x8l29                     1/1     Running            0          11m
```

 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
