### PR TITLE
automatically clean dummy interface and iptables rule when yurthub is stopped by k8s

### DIFF
--- a/cmd/yurthub/yurthub.go
+++ b/cmd/yurthub/yurthub.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"github.com/openyurtio/openyurt/cmd/yurthub/app"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server"
 )
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
-	cmd := app.NewCmdStartYurtHub(wait.NeverStop)
+	cmd := app.NewCmdStartYurtHub(server.SetupSignalHandler())
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {
 		panic(err)

--- a/pkg/yurthub/network/iptables.go
+++ b/pkg/yurthub/network/iptables.go
@@ -84,3 +84,12 @@ func (im *IptablesManager) EnsureIptablesRules() error {
 	}
 	return nil
 }
+
+func (im *IptablesManager) CleanUpIptablesRules() {
+	for _, rule := range im.rules {
+		err := im.iptables.DeleteRule(rule.table, rule.chain, rule.args...)
+		if err != nil {
+			klog.Errorf("failed to delete iptables rule(%s -t %s %s %s), %v", rule.pos, rule.table, rule.chain, strings.Join(rule.args, " "), err)
+		}
+	}
+}

--- a/pkg/yurthub/network/network.go
+++ b/pkg/yurthub/network/network.go
@@ -76,6 +76,11 @@ func (m *NetworkManager) Run(stopCh <-chan struct{}) {
 			select {
 			case <-stopCh:
 				klog.Infof("exit network manager run goroutine normally")
+				m.iptablesManager.CleanUpIptablesRules()
+				err := m.ifController.DeleteDummyInterface(m.dummyIfName)
+				if err != nil {
+					klog.Errorf("failed to delete dummy interface %s, %v", m.dummyIfName, err)
+				}
 				return
 			case <-ticker.C:
 				if err := m.configureNetwork(); err != nil {


### PR DESCRIPTION
 

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind feature




#### What this PR does / why we need it:  
Automatically delete dummy interface and iptables rule set by yurthub, when the yurthub pod is stoped by k8s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #526

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
