### PR TITLE
delete yurtctl-lock and yurt-tunnel-nodes when revert the whole cluster

### DIFF
--- a/pkg/yurttunnel/constants/constants.go
+++ b/pkg/yurttunnel/constants/constants.go
@@ -29,6 +29,9 @@ const (
 	YurttunnelServerExternalAddrKey     = "x-tunnel-server-external-addr"
 	YurttunnelEndpointsNs               = "kube-system"
 	YurttunnelEndpointsName             = "x-tunnel-server-svc"
+	YurttunnelDNSRecordConfigMapNs      = "kube-system"
+	YurttunnelDNSRecordConfigMapName    = "%s-tunnel-nodes"
+	YurttunnelDNSRecordNodeDataKey      = "tunnel-nodes"
 
 	// yurttunnel PKI related constants
 	YurttunnelCSROrg                 = "openyurt:yurttunnel"

--- a/pkg/yurttunnel/dns/handler.go
+++ b/pkg/yurttunnel/dns/handler.go
@@ -224,10 +224,10 @@ func (dnsctl *coreDNSRecordController) getCurrentDNSRecords() ([]string, error) 
 		return nil, err
 	}
 
-	data, ok := cm.Data[yurttunnelDNSRecordNodeDataKey]
+	data, ok := cm.Data[constants.YurttunnelDNSRecordNodeDataKey]
 	if !ok {
 		return nil, fmt.Errorf("key %q not found in %s/%s ConfigMap, %v",
-			yurttunnelDNSRecordNodeDataKey, constants.YurttunnelServerServiceNs, yurttunnelDNSRecordConfigMapName, err)
+			constants.YurttunnelDNSRecordNodeDataKey, constants.YurttunnelServerServiceNs, yurttunnelDNSRecordConfigMapName, err)
 	}
 
 	return strings.Split(data, "\n"), nil

--- a/pkg/yurttunnel/dns/util.go
+++ b/pkg/yurttunnel/dns/util.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
 )
@@ -40,11 +39,11 @@ func formatDNSRecord(ip, host string) string {
 }
 
 // getNodeHostIP returns the provided node's "primary" IP
-func getNodeHostIP(node *v1.Node) (string, error) {
+func getNodeHostIP(node *corev1.Node) (string, error) {
 	// re-sort the addresses with InternalIPs first and then ExternalIPs
 	allIPs := make([]net.IP, 0, len(node.Status.Addresses))
 	for _, addr := range node.Status.Addresses {
-		if addr.Type == v1.NodeInternalIP {
+		if addr.Type == corev1.NodeInternalIP {
 			ip := net.ParseIP(addr.Address)
 			if ip != nil {
 				allIPs = append(allIPs, ip)
@@ -53,7 +52,7 @@ func getNodeHostIP(node *v1.Node) (string, error) {
 		}
 	}
 	for _, addr := range node.Status.Addresses {
-		if addr.Type == v1.NodeExternalIP {
+		if addr.Type == corev1.NodeExternalIP {
 			ip := net.ParseIP(addr.Address)
 			if ip != nil {
 				allIPs = append(allIPs, ip)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Delete the yurt-tunnel-nodes configmap and yurtctl-lock when revert the whole openyurt cluster back to k8s cluster.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #531 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

I'll add the test log in the following comment.

