### PR TITLE
enhancement: revise key usage of yurthub server certificate

### DIFF
--- a/pkg/yurthub/certificate/server/certmanager.go
+++ b/pkg/yurthub/certificate/server/certmanager.go
@@ -92,7 +92,9 @@ func newCertManager(
 		SignerName:  certificates.LegacyUnknownSignerName,
 		GetTemplate: getTemplate,
 		Usages: []certificates.KeyUsage{
-			certificates.UsageAny,
+			certificates.UsageKeyEncipherment,
+			certificates.UsageDigitalSignature,
+			certificates.UsageServerAuth,
 		},
 		CertificateStore: certificateStore,
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
1. To reduce the key usage scope of yurthub https server certificate
2. `any` is not standard  key usage of certificate, you can reference link here: https://help.hcltechsw.com/domino/11.0.0/conf_keyusageextensionsandextendedkeyusage_r.html, tls handshake for any key usage maybe different in different languages, for example: golang and ruby. so we need to define the key usage explicitly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
