### PR TITLE
When yurtctl revert executes yurtappmanager to delete automatically, no crd resource error is reported.

### DIFF
--- a/pkg/yurtctl/cmd/revert/revert.go
+++ b/pkg/yurtctl/cmd/revert/revert.go
@@ -436,7 +436,7 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the UnitedDeploymentCRD/%s: %s",
 			"UnitedDeployment", err)
 	}
-	klog.Info("removeYurtAppManager方法 for yurt app manager is finished")
+	klog.Info("removeYurtAppManager for yurt app manager is finished")
 	klog.V(4).Infof("UnitedDeploymentCRD/%s is deleted", "UnitedDeployment")
 	return nil
 }

--- a/pkg/yurtctl/cmd/revert/revert.go
+++ b/pkg/yurtctl/cmd/revert/revert.go
@@ -350,7 +350,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the deployment/%s: %s",
 			constants.YurtAppManager, err)
 	}
-	klog.Info("deployment for yurt app manager is removed")
 	klog.V(4).Infof("deployment/%s is deleted", constants.YurtAppManager)
 
 	// 2. remove the Role
@@ -360,7 +359,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the role/%s: %s",
 			"yurt-app-leader-election-role", err)
 	}
-	klog.Info("Role for yurt app manager is removed")
 
 	// 3. remove the ClusterRole
 	if err := client.RbacV1().ClusterRoles().
@@ -369,7 +367,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the clusterrole/%s: %s",
 			"yurt-app-manager-role", err)
 	}
-	klog.Info("ClusterRole for yurt app manager is removed")
 
 	// 4. remove the ClusterRoleBinding
 	if err := client.RbacV1().ClusterRoleBindings().
@@ -378,7 +375,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the clusterrolebinding/%s: %s",
 			"yurt-app-manager-rolebinding", err)
 	}
-	klog.Info("ClusterRoleBinding for yurt app manager is removed")
 	klog.V(4).Infof("clusterrolebinding/%s is deleted", "yurt-app-manager-rolebinding")
 
 	// 5. remove the RoleBinding
@@ -388,7 +384,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the rolebinding/%s: %s",
 			"yurt-app-leader-election-rolebinding", err)
 	}
-	klog.Info("RoleBinding for yurt app manager is removed")
 	klog.V(4).Infof("clusterrolebinding/%s is deleted", "yurt-app-leader-election-rolebinding")
 
 	// 6 remove the Secret
@@ -398,7 +393,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the secret/%s: %s",
 			"yurt-app-webhook-certs", err)
 	}
-	klog.Info("secret for yurt app manager is removed")
 	klog.V(4).Infof("secret/%s is deleted", "yurt-app-webhook-certs")
 
 	// 7 remove Service
@@ -408,7 +402,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the service/%s: %s",
 			"yurt-app-webhook-service", err)
 	}
-	klog.Info("Service for yurt app manager is removed")
 	klog.V(4).Infof("service/%s is deleted", "yurt-app-webhook-service")
 
 	// 8. remove the MutatingWebhookConfiguration
@@ -418,7 +411,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the MutatingWebhookConfiguration/%s: %s",
 			"yurt-app-mutating-webhook-configuration", err)
 	}
-	klog.Info("MutatingWebhookConfiguration for yurt app manager is removed")
 	klog.V(4).Infof("MutatingWebhookConfiguration/%s is deleted", "yurt-app-mutating-webhook-configuration")
 
 	// 9. remove the ValidatingWebhookConfiguration
@@ -428,7 +420,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the ValidatingWebhookConfiguration/%s: %s",
 			"yurt-app-validating-webhook-configuration", err)
 	}
-	klog.Info("ValidatingWebhookConfiguration for yurt app manager is removed")
 	klog.V(4).Infof("ValidatingWebhookConfiguration/%s is deleted", "yurt-app-validating-webhook-configuration")
 
 	// 10. remove nodepoolcrd
@@ -437,7 +428,6 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the NodePoolCRD/%s: %s",
 			"nodepoolcrd", err)
 	}
-	klog.Info("crd for yurt app manager is removed")
 	klog.V(4).Infof("NodePoolCRD/%s is deleted", "NodePool")
 
 	// 11. remove UnitedDeploymentcrd
@@ -446,7 +436,7 @@ func removeYurtAppManager(client *kubernetes.Clientset, yurtAppManagerClientSet 
 		return fmt.Errorf("fail to delete the UnitedDeploymentCRD/%s: %s",
 			"UnitedDeployment", err)
 	}
-	klog.Info("UnitedDeploymentcrd for yurt app manager is removed")
+	klog.Info("removeYurtAppManager方法 for yurt app manager is finished")
 	klog.V(4).Infof("UnitedDeploymentCRD/%s is deleted", "UnitedDeployment")
 	return nil
 }

--- a/pkg/yurtctl/util/kubernetes/util.go
+++ b/pkg/yurtctl/util/kubernetes/util.go
@@ -422,7 +422,7 @@ func DeleteCRDResource(clientset *kubernetes.Clientset, yurtAppManagerClientSet 
 		return err
 	}
 	if uns == nil {
-		klog.Info("不存在 " + name + " 这种crd资源，不需要删除")
+		klog.Info("There is no CRD resource like " + name + " and it does not need to be deleted")
 		return nil
 	}
 

--- a/pkg/yurtctl/util/kubernetes/util.go
+++ b/pkg/yurtctl/util/kubernetes/util.go
@@ -415,6 +415,17 @@ func DeleteCRDResource(clientset *kubernetes.Clientset, yurtAppManagerClientSet 
 	} else {
 		dri = yurtAppManagerClientSet.Resource(mapping.Resource)
 	}
+
+	var uns *unstructured.Unstructured
+	uns, err = dri.Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if uns == nil {
+		klog.Info("不存在 " + name + " 这种crd资源，不需要删除")
+		return nil
+	}
+
 	err = dri.Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage


/kind bug
#### What this PR does / why we need it:
Yurtappmanager does not use the method of deleting crd resources when crd is not deployed.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #557 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
