### PR TITLE
bugfix post header accept error

### DIFF
--- a/pkg/yurthub/proxy/util/util.go
+++ b/pkg/yurthub/proxy/util/util.go
@@ -61,14 +61,10 @@ func WithRequestContentType(handler http.Handler) http.Handler {
 					contentType = parts[0]
 				}
 
-				if len(contentType) == 0 {
-					klog.Errorf("no accept content type for request: %s", util.ReqString(req))
-					util.Err(errors.NewBadRequest("no accept content type is set."), w, req)
-					return
+				if len(contentType) != 0 {
+					ctx = util.WithReqContentType(ctx, contentType)
+					req = req.WithContext(ctx)
 				}
-
-				ctx = util.WithReqContentType(ctx, contentType)
-				req = req.WithContext(ctx)
 			}
 		}
 

--- a/pkg/yurthub/proxy/util/util_test.go
+++ b/pkg/yurthub/proxy/util/util_test.go
@@ -63,7 +63,7 @@ func TestWithRequestContentType(t *testing.T) {
 		"no accept type": {
 			Verb:        "POST",
 			Path:        "/api/v1/nodes/mynode",
-			Code:        http.StatusBadRequest,
+			Code:        http.StatusOK,
 			ContentType: "",
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> /kind bug

#### What this PR does / why we need it:
When using kubectl exec/attach command after access Yurthub, yurthub will return error: no accept content type for request: kubectl create pods: /api/v1/namespaces/xxxx/pods/xxxx/attach?container=xxxx&stderr=true&stdout=true
```
root@c-8cc95a:/# kubectl exec -it -n ingress-nginx       nginx-ingress-controller-p7m5t env
Error from server (BadRequest): no accept content type is set.
```
```
I1105 07:58:11.199787       1 util.go:232] start proxying: get /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz, in flight requests: 26
I1105 07:58:11.199904       1 loadbalancer.go:186] picked backend https://127.0.0.1:6443 by rr algorithm for request kubectl get pods: /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz
I1105 07:58:11.199923       1 remote.go:100] request: kubectl get pods: /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz with bearer token: xxx
I1105 07:58:11.204891       1 util.go:215] kubectl get pods: /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz with status code 200, spent 4.997435ms
I1105 07:58:11.204931       1 util.go:235] kubectl get pods: /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz request completed, left 25 requests in flight
I1105 07:58:11.252397       1 util.go:232] start proxying: post /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz/attach?container=nginx-ingress-controller&stderr=true&stdout=true, in flight requests: 26
E1105 07:58:11.252557       1 util.go:65] no accept content type for request: kubectl create pods: /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz/attach?container=nginx-ingress-controller&stderr=true&stdout=true
I1105 07:58:11.253406       1 util.go:235] kubectl create pods: /api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-mlrmz/attach?container=nginx-ingress-controller&stderr=true&stdout=true request completed, left 25 requests in flight
```

We can see that the kubectl command is not set accept in request header when using native kubernetes.

```
root@c-8cc95a:/# kubectl exec -it -n ingress-nginx       nginx-ingress-controller-p7m5t env -v8
I1105 08:29:58.181864     506 merged_client_builder.go:122] Using in-cluster configuration
I1105 08:29:58.182189     506 merged_client_builder.go:122] Using in-cluster configuration
I1105 08:29:58.183444     506 merged_client_builder.go:122] Using in-cluster configuration
I1105 08:29:58.191414     506 merged_client_builder.go:122] Using in-cluster configuration
I1105 08:29:58.191887     506 round_trippers.go:420] GET https://10.43.0.1:443/api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-p7m5t
I1105 08:29:58.191898     506 round_trippers.go:427] Request Headers:
I1105 08:29:58.191906     506 round_trippers.go:431]     Accept: application/json, */*
I1105 08:29:58.191912     506 round_trippers.go:431]     User-Agent: kubectl/v1.16.1 (linux/amd64) kubernetes/d647ddb
I1105 08:29:58.191920     506 round_trippers.go:431]     Authorization: Bearer <masked>
I1105 08:29:58.200544     506 round_trippers.go:446] Response Status: 200 OK in 8 milliseconds
I1105 08:29:58.200564     506 round_trippers.go:449] Response Headers:
I1105 08:29:58.200571     506 round_trippers.go:452]     Cache-Control: no-cache, private
I1105 08:29:58.200576     506 round_trippers.go:452]     Content-Type: application/json
I1105 08:29:58.200581     506 round_trippers.go:452]     Date: Fri, 05 Nov 2021 08:37:56 GMT
I1105 08:29:58.200730     506 request.go:968] Response Body: {"kind":"Pod","apiVersion":"v1","metadata":{"name":"nginx-ingress-controller-p7m5t","generateName":"nginx-ingress-controller-","namespace":"ingress-nginx","selfLink":"/api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-p7m5t","uid":"bb7f85f4-b056-45b5-8d19-c471993f5631","resourceVersion":"488139","creationTimestamp":"2021-11-03T08:07:54Z","labels":{"app":"ingress-nginx","controller-revision-hash":"7755fb95fb","pod-template-generation":"1"},"annotations":{"prometheus.io/port":"10254","prometheus.io/scrape":"true"},"ownerReferences":[{"apiVersion":"apps/v1","kind":"DaemonSet","name":"nginx-ingress-controller","uid":"fc30d3f7-66cc-4ade-ba28-fec49d920082","controller":true,"blockOwnerDeletion":true}]},"spec":{"volumes":[{"name":"nginx-ingress-serviceaccount-token-x8rhc","secret":{"secretName":"nginx-ingress-serviceaccount-token-x8rhc","defaultMode":420}}],"containers":[{"name":"nginx-ingress-controller","image":"10.113.80.97/multi-arch/library/sangforpaas/nginx-ingress-controller:nginx-0.25.1-sangfor1" [truncated 3928 chars]
I1105 08:29:58.206910     506 round_trippers.go:420] POST https://10.43.0.1:443/api/v1/namespaces/ingress-nginx/pods/nginx-ingress-controller-p7m5t/exec?command=env&container=nginx-ingress-controller&stdin=true&stdout=true&tty=true
I1105 08:29:58.206943     506 round_trippers.go:427] Request Headers:
I1105 08:29:58.206950     506 round_trippers.go:431]     X-Stream-Protocol-Version: v4.channel.k8s.io
I1105 08:29:58.206956     506 round_trippers.go:431]     X-Stream-Protocol-Version: v3.channel.k8s.io
I1105 08:29:58.206962     506 round_trippers.go:431]     X-Stream-Protocol-Version: v2.channel.k8s.io
I1105 08:29:58.206967     506 round_trippers.go:431]     X-Stream-Protocol-Version: channel.k8s.io
I1105 08:29:58.206973     506 round_trippers.go:431]     User-Agent: kubectl/v1.16.1 (linux/amd64) kubernetes/d647ddb
I1105 08:29:58.206980     506 round_trippers.go:431]     Authorization: Bearer <masked>
I1105 08:29:58.237224     506 round_trippers.go:446] Response Status: 101 Switching Protocols in 30 milliseconds
I1105 08:29:58.237248     506 round_trippers.go:449] Response Headers:
I1105 08:29:58.237255     506 round_trippers.go:452]     Connection: Upgrade
I1105 08:29:58.237260     506 round_trippers.go:452]     Upgrade: SPDY/3.1
I1105 08:29:58.237264     506 round_trippers.go:452]     X-Stream-Protocol-Version: v4.channel.k8s.io
I1105 08:29:58.237269     506 round_trippers.go:452]     Date: Fri, 05 Nov 2021 08:37:56 GMT
KUBERNETES_PORT=tcp://169.254.2.1:10268
KUBERNETES_PORT_10268_TCP=tcp://169.254.2.1:10268
KUBERNETES_PORT_10268_TCP_ADDR=169.254.2.1
KUBERNETES_PORT_10268_TCP_PORT=10268
KUBERNETES_PORT_10268_TCP_PROTO=tcp
KUBERNETES_SERVICE_HOST=169.254.2.1
KUBERNETES_SERVICE_PORT=10268
KUBERNETES_SERVICE_PORT_HTTPS=10268
```

So I don't think we need to do anything when the request header accept doesn't exist. Add only deal the context when accept not empty.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
