### PR TITLE
Refactor: separate the creation of informers from tunnel server component

### DIFF
--- a/cmd/yurt-tunnel-server/app/start.go
+++ b/cmd/yurt-tunnel-server/app/start.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/dns"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/handlerwrapper/initializer"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/handlerwrapper/wraphandler"
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/informers"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/iptables"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/pki"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/pki/certmanager"
@@ -75,6 +76,9 @@ func NewYurttunnelServerCommand(stopCh <-chan struct{}) *cobra.Command {
 // run starts the yurttunel-server
 func Run(cfg *config.CompletedConfig, stopCh <-chan struct{}) error {
 	var wg sync.WaitGroup
+	// register informers that tunnel server need
+	informers.RegisterInformersForTunnelServer(cfg.SharedInformerFactory)
+
 	// 0. start the DNS controller
 	if cfg.EnableDNSController {
 		dnsController, err := dns.NewCoreDNSRecordController(cfg.Client,

--- a/pkg/yurttunnel/informers/serverinformer.go
+++ b/pkg/yurttunnel/informers/serverinformer.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// RegisterInformersForTunnelServer registers shared informers that tunnel server use.
+func RegisterInformersForTunnelServer(informerFactory informers.SharedInformerFactory) {
+	// add node informers
+	informerFactory.Core().V1().Nodes()
+
+	// add service informers
+	informerFactory.InformerFor(&corev1.Service{}, newServiceInformer)
+
+	// add configMap informers
+	informerFactory.InformerFor(&corev1.ConfigMap{}, newConfigMapInformer)
+
+	// add endpoints informers
+	informerFactory.InformerFor(&corev1.Endpoints{}, newEndPointsInformer)
+}
+
+// newServiceInformer creates a shared index informers that returns services related to yurttunnel
+func newServiceInformer(cs clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	// this informers will be used by coreDNSRecordController and certificate manager,
+	// so it should return x-tunnel-server-svc and x-tunnel-server-internal-svc
+	selector := fmt.Sprintf("name=%v", projectinfo.YurtTunnelServerLabel())
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = selector
+	}
+	return coreinformers.NewFilteredServiceInformer(cs, constants.YurttunnelServerServiceNs, resyncPeriod, nil, tweakListOptions)
+}
+
+// newConfigMapInformer creates a shared index informers that returns only interested configmaps
+func newConfigMapInformer(cs clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	selector := fmt.Sprintf("metadata.name=%v", util.YurttunnelServerDnatConfigMapName)
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = selector
+	}
+	return coreinformers.NewFilteredConfigMapInformer(cs, util.YurttunnelServerDnatConfigMapNs, resyncPeriod, nil, tweakListOptions)
+}
+
+// newEndPointsInformer creates a shared index informers that returns only interested endpoints
+func newEndPointsInformer(cs clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	selector := fmt.Sprintf("metadata.name=%v", constants.YurttunnelEndpointsName)
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = selector
+	}
+	return coreinformers.NewFilteredEndpointsInformer(cs, constants.YurttunnelEndpointsNs, resyncPeriod, nil, tweakListOptions)
+}

--- a/pkg/yurttunnel/pki/certmanager/certmanager.go
+++ b/pkg/yurttunnel/pki/certmanager/certmanager.go
@@ -32,15 +32,12 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/server/serveraddr"
 
 	certificates "k8s.io/api/certificates/v1beta1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
-	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	clicert "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/certificate"
 	"k8s.io/klog/v2"
 )
@@ -58,9 +55,6 @@ func NewYurttunnelServerCertManager(
 		ips      = []net.IP{}
 		err      error
 	)
-
-	// add endPoints informer
-	factory.InformerFor(&v1.Endpoints{}, newEndPointsInformer)
 
 	// the ips and dnsNames should be acquired through api-server at the first time, because the informer factory has not started yet.
 	_ = wait.PollUntil(5*time.Second, func() (bool, error) {
@@ -193,13 +187,4 @@ func newCertManager(
 	}
 
 	return certManager, nil
-}
-
-// newEndPointsInformer creates a shared index informer that returns only interested endpoints
-func newEndPointsInformer(cs kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	selector := fmt.Sprintf("metadata.name=%v", constants.YurttunnelEndpointsName)
-	tweakListOptions := func(options *metav1.ListOptions) {
-		options.FieldSelector = selector
-	}
-	return coreinformers.NewFilteredEndpointsInformer(cs, constants.YurttunnelEndpointsNs, resyncPeriod, nil, tweakListOptions)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind enhancement
/kind design


#### What this PR does / why we need it:
The informers used by tunnel server is created by its component alone. This may cause the misuse of informers in the future. So i separate the creation of informers and tunnel server registers informers it need at the beginning of its start.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
no
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->