### PR TITLE
Refactor: tunnel-agent can connect new address of tunnel server

### DIFF
--- a/cmd/yurt-tunnel-agent/app/config/config.go
+++ b/cmd/yurt-tunnel-agent/app/config/config.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package config
 
-import "k8s.io/client-go/kubernetes"
+import (
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+)
 
 // Config is the main context object for yurttunel-agent
 type Config struct {
@@ -26,6 +30,7 @@ type Config struct {
 	Client           kubernetes.Interface
 	AgentIdentifiers string
 	AgentMetaAddr    string
+	ProbInterval     time.Duration
 }
 
 type completedConfig struct {

--- a/cmd/yurt-tunnel-agent/app/options/options.go
+++ b/cmd/yurt-tunnel-agent/app/options/options.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/openyurtio/openyurt/cmd/yurt-tunnel-agent/app/config"
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
@@ -46,6 +47,7 @@ type AgentOptions struct {
 	AgentIdentifiers string
 	MetaHost         string
 	MetaPort         string
+	ProbInterval     int
 }
 
 // NewAgentOptions creates a new AgentOptions with a default config.
@@ -92,6 +94,7 @@ func (o *AgentOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.AgentIdentifiers, "agent-identifiers", o.AgentIdentifiers, "The identifiers of the agent, which will be used by the server when choosing agent.")
 	fs.StringVar(&o.MetaHost, "meta-host", o.MetaHost, "The ip address on which listen for --meta-port port.")
 	fs.StringVar(&o.MetaPort, "meta-port", o.MetaPort, "The port on which to serve HTTP requests like profling, metrics")
+	fs.IntVar(&o.ProbInterval, "probe-interval", o.ProbInterval, "The interval of probing the connection to tunnel server.")
 }
 
 // agentIdentifiersIsValid verify agent identifiers are valid or not.
@@ -128,6 +131,12 @@ func (o *AgentOptions) Config() (*config.Config, error) {
 		TunnelServerAddr: o.TunnelServerAddr,
 		AgentIdentifiers: o.AgentIdentifiers,
 		AgentMetaAddr:    net.JoinHostPort(o.MetaHost, o.MetaPort),
+	}
+
+	if o.ProbInterval == 0 {
+		c.ProbInterval = 5 * time.Second
+	} else {
+		c.ProbInterval = time.Duration(o.ProbInterval * 1e+9)
 	}
 
 	if len(c.AgentIdentifiers) == 0 {

--- a/cmd/yurt-tunnel-agent/app/start.go
+++ b/cmd/yurt-tunnel-agent/app/start.go
@@ -29,7 +29,6 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/pki/certmanager"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/server/serveraddr"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/util"
-
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -113,7 +112,7 @@ func Run(cfg *config.CompletedConfig, stopCh <-chan struct{}) error {
 	}
 
 	// 4. start the yurttunnel-agent
-	ta := agent.NewTunnelAgent(tlsCfg, tunnelServerAddr, cfg.NodeName, cfg.AgentIdentifiers)
+	ta := agent.NewTunnelAgent(tlsCfg, tunnelServerAddr, cfg.NodeName, cfg.AgentIdentifiers, cfg.Client, cfg.ProbInterval)
 	ta.Run(stopCh)
 
 	// 5. start meta server

--- a/pkg/yurttunnel/agent/agent.go
+++ b/pkg/yurttunnel/agent/agent.go
@@ -18,6 +18,9 @@ package agent
 
 import (
 	"crypto/tls"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
 )
 
 // TunnelAgent sets up tunnel to TunnelServer, receive requests
@@ -28,12 +31,14 @@ type TunnelAgent interface {
 
 // NewTunnelAgent generates a new TunnelAgent
 func NewTunnelAgent(tlsCfg *tls.Config,
-	tunnelServerAddr, nodeName, agentIdentifiers string) TunnelAgent {
+	tunnelServerAddr, nodeName, agentIdentifiers string, client kubernetes.Interface, probInterval time.Duration) TunnelAgent {
 	ata := anpTunnelAgent{
 		tlsCfg:           tlsCfg,
 		tunnelServerAddr: tunnelServerAddr,
 		nodeName:         nodeName,
 		agentIdentifiers: agentIdentifiers,
+		client:           client,
+		probInterval:     probInterval,
 	}
 
 	return &ata

--- a/test/integration/yurttunnel_test.go
+++ b/test/integration/yurttunnel_test.go
@@ -190,6 +190,8 @@ func startTunnelAgent(t *testing.T) {
 		fmt.Sprintf(":%d", ServerAgentPort), /* tunnelServerAddr */
 		"dummy-agent",                       /* nodeName */
 		"ipv4=127.0.0.1&host=localhost",     /* agentIdentifiers */
+		nil,
+		5*time.Second,
 	)
 	tunnelAgent.Run(wait.NeverStop)
 	klog.Info("[TEST] Yurttunnel Agent is running")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind enhancement
/kind good-first-issue
/kind feature




#### What this PR does / why we need it:
when the service address of yurt-tunnel-server changed, connection between yurt-tunnel-agent and yurt-tunnel-server will be broken.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #412 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
NONE
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
