### PR TITLE
bugfix: service topology filter can not work when hub agent work on cloud mode

### DIFF
--- a/pkg/yurthub/cachemanager/cache_agent_test.go
+++ b/pkg/yurthub/cachemanager/cache_agent_test.go
@@ -64,7 +64,7 @@ func TestUpdateCacheAgents(t *testing.T) {
 			}
 
 			// add agents
-			deletedAgents := m.UpdateCacheAgents(tt.cacheAgents, "")
+			deletedAgents := m.updateCacheAgents(tt.cacheAgents, "")
 
 			if !deletedAgents.Equal(tt.deletedAgents) {
 				t.Errorf("Got deleted agents: %v, expect agents: %v", deletedAgents, tt.deletedAgents)

--- a/pkg/yurthub/cachemanager/cache_manager.go
+++ b/pkg/yurthub/cachemanager/cache_manager.go
@@ -52,8 +52,6 @@ import (
 type CacheManager interface {
 	CacheResponse(req *http.Request, prc io.ReadCloser, stopCh <-chan struct{}) error
 	QueryCache(req *http.Request) (runtime.Object, error)
-	UpdateCacheAgents(agents, action string) sets.String
-	ListCacheAgents() []string
 	CanCacheFor(req *http.Request) bool
 	DeleteKindFor(gvr schema.GroupVersionResource) error
 }

--- a/pkg/yurthub/filter/interfaces.go
+++ b/pkg/yurthub/filter/interfaces.go
@@ -38,4 +38,4 @@ type Handler interface {
 	ObjectResponseFilter(b []byte) ([]byte, error)
 }
 
-type NodeGetter func() (*v1.Node, error)
+type NodeGetter func(name string) (*v1.Node, error)

--- a/pkg/yurthub/filter/masterservice/filter.go
+++ b/pkg/yurthub/filter/masterservice/filter.go
@@ -70,14 +70,6 @@ func (msf *masterServiceFilter) SetMasterServiceAddr(addr string) error {
 	return nil
 }
 
-func (msf *masterServiceFilter) Approve(comp, resource, verb string) bool {
-	if !msf.Approver.Approve(comp, resource, verb) {
-		return false
-	}
-
-	return true
-}
-
 func (msf *masterServiceFilter) Filter(req *http.Request, rc io.ReadCloser, stopCh <-chan struct{}) (int, io.ReadCloser, error) {
 	s := filterutil.CreateSerializer(req, msf.serializerManager)
 	if s == nil {

--- a/pkg/yurthub/filter/servicetopology/handler.go
+++ b/pkg/yurthub/filter/servicetopology/handler.go
@@ -153,7 +153,7 @@ func (fh *serviceTopologyFilterHandler) reassembleEndpointSlice(endpointSlice *d
 	} else if serviceTopologyType == AnnotationServiceTopologyValueNodePool || serviceTopologyType == AnnotationServiceTopologyValueZone {
 		// if type of service Topology is openyurt.io/nodepool
 		// filter the endpoint just on the node which is in the same nodepool with current node
-		currentNode, err := fh.nodeGetter()
+		currentNode, err := fh.nodeGetter(fh.nodeName)
 		if err != nil {
 			klog.Infof("skip reassemble endpointSlice, failed to get current node %s, err: %v", fh.nodeName, err)
 			return endpointSlice

--- a/pkg/yurthub/proxy/proxy.go
+++ b/pkg/yurthub/proxy/proxy.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurthub/app/config"
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/interfaces"
-	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
 	"github.com/openyurtio/openyurt/pkg/yurthub/healthchecker"
 	"github.com/openyurtio/openyurt/pkg/yurthub/proxy/local"
 	"github.com/openyurtio/openyurt/pkg/yurthub/proxy/remote"
@@ -55,7 +54,6 @@ func NewYurtReverseProxyHandler(
 	transportMgr transport.Interface,
 	healthChecker healthchecker.HealthChecker,
 	certManager interfaces.YurtCertificateManager,
-	filterChain filter.Interface,
 	stopCh <-chan struct{}) (http.Handler, error) {
 	cfg := &server.Config{
 		LegacyAPIGroupPrefixes: sets.NewString(server.DefaultLegacyAPIPrefix),
@@ -69,7 +67,7 @@ func NewYurtReverseProxyHandler(
 		transportMgr,
 		healthChecker,
 		certManager,
-		filterChain,
+		yurtHubCfg.FilterChain,
 		stopCh)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
1. service topology filter can not work when hub agent work on cloud mode
--> solution: service topology filter will list/watch node from kube-apsierver if working mode is cloud

2. optimize shared informers register. extract all of informers register and
make a common function named registerInformers

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #600 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @DrmagicE 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
