### PR TITLE
remove k8s.io/kubernetes dependency from e2e test

### DIFF
--- a/test/e2e/common/ns/ns.go
+++ b/test/e2e/common/ns/ns.go
@@ -24,7 +24,8 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/openyurtio/openyurt/test/e2e/util"
 )
 
 func DeleteNameSpace(c clientset.Interface, ns string) (err error) {
@@ -35,7 +36,7 @@ func DeleteNameSpace(c clientset.Interface, ns string) (err error) {
 	if !apierrs.IsNotFound(err) {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to delete created namespaces:"+ns)
 	}
-	err = framework.WaitForNamespacesDeleted(c, []string{ns}, framework.DefaultNamespaceDeletionTimeout)
+	err = util.WaitForNamespacesDeleted(c, []string{ns}, util.DefaultNamespaceDeletionTimeout)
 	return
 }
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -27,23 +27,24 @@ import (
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
+
+	"github.com/openyurtio/openyurt/test/e2e/util/ginkgowrapper"
+	"github.com/openyurtio/openyurt/test/e2e/yurtconfig"
 )
 
 func RunE2ETests(t *testing.T) {
 	klog.Infof("[edge] Start run e2e test")
 	gomega.RegisterFailHandler(ginkgowrapper.Fail)
 	var r []ginkgo.Reporter
-	if framework.TestContext.ReportDir != "" {
-
-		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
+	if yurtconfig.YurtE2eCfg.ReportDir != "" {
+		if err := os.MkdirAll(yurtconfig.YurtE2eCfg.ReportDir, 0755); err != nil {
 			klog.Errorf("Failed creating report directory: %v", err)
 		} else {
-			r = append(r, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir, fmt.Sprintf("yurt-e2e-test-report_%v%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode))))
+			r = append(r, reporters.NewJUnitReporter(path.Join(yurtconfig.YurtE2eCfg.ReportDir, fmt.Sprintf("yurt-e2e-test-report_%02d.xml", config.GinkgoConfig.ParallelNode))))
 		}
 	}
-	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunID, config.GinkgoConfig.ParallelNode)
-	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "openyurt  e2e suite", r)
+	klog.Infof("Starting e2e run %q on Ginkgo node %d", uuid.NewUUID(), config.GinkgoConfig.ParallelNode)
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "openyurt e2e suite", r)
 }

--- a/test/e2e/util/expect.go
+++ b/test/e2e/util/expect.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/onsi/gomega"
+)
+
+// ExpectEqual expects the specified two are the same, otherwise an exception raises
+func ExpectEqual(actual interface{}, extra interface{}, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).To(gomega.Equal(extra), explain...)
+}
+
+// ExpectNotEqual expects the specified two are not the same, otherwise an exception raises
+func ExpectNotEqual(actual interface{}, extra interface{}, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).NotTo(gomega.Equal(extra), explain...)
+}
+
+// ExpectError expects an error happens, otherwise an exception raises
+func ExpectError(err error, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, err).To(gomega.HaveOccurred(), explain...)
+}
+
+// ExpectNoError checks if "err" is set, and if so, fails assertion while logging the error.
+func ExpectNoError(err error, explain ...interface{}) {
+	ExpectNoErrorWithOffset(1, err, explain...)
+}
+
+// ExpectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> ExpectNoErrorWithOffset(1, ...) error would be logged for "f").
+func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
+	gomega.ExpectWithOffset(1+offset, err).NotTo(gomega.HaveOccurred(), explain...)
+}
+
+// ExpectConsistOf expects actual contains precisely the extra elements.  The ordering of the elements does not matter.
+func ExpectConsistOf(actual interface{}, extra interface{}, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).To(gomega.ConsistOf(extra), explain...)
+}
+
+// ExpectHaveKey expects the actual map has the key in the keyset
+func ExpectHaveKey(actual interface{}, key interface{}, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).To(gomega.HaveKey(key), explain...)
+}
+
+// ExpectEmpty expects actual is empty
+func ExpectEmpty(actual interface{}, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).To(gomega.BeEmpty(), explain...)
+}

--- a/test/e2e/util/ginkgowrapper/wrapper.go
+++ b/test/e2e/util/ginkgowrapper/wrapper.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ginkgowrapper wraps Ginkgo Fail and Skip functions to panic
+// with structured data instead of a constant string.
+package ginkgowrapper
+
+import (
+	"bufio"
+	"bytes"
+	"regexp"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+)
+
+// FailurePanic is the value that will be panicked from Fail.
+type FailurePanic struct {
+	Message        string // The failure message passed to Fail
+	Filename       string // The filename that is the source of the failure
+	Line           int    // The line number of the filename that is the source of the failure
+	FullStackTrace string // A full stack trace starting at the source of the failure
+}
+
+// String makes FailurePanic look like the old Ginkgo panic when printed.
+func (FailurePanic) String() string { return ginkgo.GINKGO_PANIC }
+
+// Fail wraps ginkgo.Fail so that it panics with more useful
+// information about the failure. This function will panic with a
+// FailurePanic.
+func Fail(message string, callerSkip ...int) {
+	skip := 1
+	if len(callerSkip) > 0 {
+		skip += callerSkip[0]
+	}
+
+	_, file, line, _ := runtime.Caller(skip)
+	fp := FailurePanic{
+		Message:        message,
+		Filename:       file,
+		Line:           line,
+		FullStackTrace: pruneStack(skip),
+	}
+
+	defer func() {
+		e := recover()
+		if e != nil {
+			panic(fp)
+		}
+	}()
+
+	ginkgo.Fail(message, skip)
+}
+
+// ginkgo adds a lot of test running infrastructure to the stack, so
+// we filter those out
+var stackSkipPattern = regexp.MustCompile(`onsi/ginkgo`)
+
+func pruneStack(skip int) string {
+	skip += 2 // one for pruneStack and one for debug.Stack
+	stack := debug.Stack()
+	scanner := bufio.NewScanner(bytes.NewBuffer(stack))
+	var prunedStack []string
+
+	// skip the top of the stack
+	for i := 0; i < 2*skip+1; i++ {
+		scanner.Scan()
+	}
+
+	for scanner.Scan() {
+		if stackSkipPattern.Match(scanner.Bytes()) {
+			scanner.Scan() // these come in pairs
+		} else {
+			prunedStack = append(prunedStack, scanner.Text())
+			scanner.Scan() // these come in pairs
+			prunedStack = append(prunedStack, scanner.Text())
+		}
+	}
+
+	return strings.Join(prunedStack, "\n")
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/util"
+)
+
+const (
+	// DefaultNamespaceDeletionTimeout is timeout duration for waiting for a namespace deletion.
+	DefaultNamespaceDeletionTimeout = 5 * time.Minute
+
+	// PodStartTimeout is how long to wait for the pod to be started.
+	PodStartTimeout = 5 * time.Minute
+)
+
+// LoadRestConfigAndClientset returns rest config and  clientset for connecting to kubernetes clusters.
+func LoadRestConfigAndClientset(kubeconfig string) (*restclient.Config, *clientset.Clientset, error) {
+	config, err := util.LoadRESTClientConfig(kubeconfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error load rest client config: %v", err)
+	}
+
+	client, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error new clientset: %v", err)
+	}
+
+	return config, client, nil
+}
+
+func YurtDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[openyurt.io] "+text, body)
+}
+
+// WaitForNamespacesDeleted waits for the namespaces to be deleted.
+func WaitForNamespacesDeleted(c clientset.Interface, namespaces []string, timeout time.Duration) error {
+	ginkgo.By("Waiting for namespaces to vanish")
+	nsMap := map[string]bool{}
+	for _, ns := range namespaces {
+		nsMap[ns] = true
+	}
+	//Now POLL until all namespaces have been eradicated.
+	return wait.Poll(2*time.Second, timeout,
+		func() (bool, error) {
+			nsList, err := c.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				return false, err
+			}
+			for _, item := range nsList.Items {
+				if _, ok := nsMap[item.Name]; ok {
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+}

--- a/test/e2e/yurt/yurt.go
+++ b/test/e2e/yurt/yurt.go
@@ -21,14 +21,16 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"github.com/openyurtio/openyurt/test/e2e/common/ns"
-	p "github.com/openyurtio/openyurt/test/e2e/common/pod"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
+
+	"github.com/openyurtio/openyurt/test/e2e/common/ns"
+	p "github.com/openyurtio/openyurt/test/e2e/common/pod"
+	"github.com/openyurtio/openyurt/test/e2e/util"
+	"github.com/openyurtio/openyurt/test/e2e/util/ginkgowrapper"
+	"github.com/openyurtio/openyurt/test/e2e/yurtconfig"
 )
 
 const (
@@ -40,24 +42,24 @@ const (
 )
 
 func Register() {
-	var _ = framework.KubeDescribe(YurtE2ENamespaceName, func() {
+	var _ = util.YurtDescribe(YurtE2ENamespaceName, func() {
 		gomega.RegisterFailHandler(ginkgowrapper.Fail)
 		defer ginkgo.GinkgoRecover()
 		var (
 			c   clientset.Interface
 			err error
 		)
-		c, err = framework.LoadClientset()
+		c = yurtconfig.YurtE2eCfg.KubeClient
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail get client set")
 
 		err = ns.DeleteNameSpace(c, YurtE2ENamespaceName)
-		framework.ExpectNoError(err)
+		util.ExpectNoError(err)
 
 		ginkgo.By(YurtE2ETestDesc + "yurt_test_create namespace")
 		_, err = ns.CreateNameSpace(c, YurtE2ENamespaceName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to create namespace")
 
-		framework.KubeDescribe(YurtE2ETestDesc+": cluster_info", func() {
+		util.YurtDescribe(YurtE2ETestDesc+": cluster_info", func() {
 			ginkgo.It(YurtE2ETestDesc+": should get cluster pod num", func() {
 				cs := c
 				ginkgo.By("get current pod num")
@@ -83,7 +85,7 @@ func Register() {
 
 		})
 
-		framework.KubeDescribe(YurtE2ETestDesc+": pod_operate_test", func() {
+		util.YurtDescribe(YurtE2ETestDesc+": pod_operate_test", func() {
 			ginkgo.It("pod_operate", func() {
 				cs := c
 				podName := "yurt-test-busybox"
@@ -122,7 +124,7 @@ func Register() {
 				ginkgo.By("delete namespace: " + YurtE2ENamespaceName)
 				err = ns.DeleteNameSpace(cs, YurtE2ENamespaceName)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail delete created namespaces:"+YurtE2ENamespaceName)
-				framework.ExpectNoError(err)
+				util.ExpectNoError(err)
 			})
 
 		})

--- a/test/e2e/yurtconfig/yurtconfig.go
+++ b/test/e2e/yurtconfig/yurtconfig.go
@@ -16,12 +16,20 @@ limitations under the License.
 
 package yurtconfig
 
+import (
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+)
+
 type YurtE2eConfig struct {
 	NodeType           string
 	RegionID           string
 	AccessKeyID        string
 	AccessKeySecret    string
 	EnableYurtAutonomy bool
+	KubeClient         *clientset.Clientset
+	RestConfig         *restclient.Config
+	ReportDir          string
 }
 
 var YurtE2eCfg YurtE2eConfig

--- a/test/e2e/yurthub/yurthub.go
+++ b/test/e2e/yurthub/yurthub.go
@@ -24,18 +24,19 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"github.com/openyurtio/openyurt/pkg/projectinfo"
-	"github.com/openyurtio/openyurt/pkg/yurtctl/constants"
-	nd "github.com/openyurtio/openyurt/test/e2e/common/node"
-	"github.com/openyurtio/openyurt/test/e2e/common/ns"
-	p "github.com/openyurtio/openyurt/test/e2e/common/pod"
-	ycfg "github.com/openyurtio/openyurt/test/e2e/yurtconfig"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/yurtctl/constants"
+	nd "github.com/openyurtio/openyurt/test/e2e/common/node"
+	"github.com/openyurtio/openyurt/test/e2e/common/ns"
+	p "github.com/openyurtio/openyurt/test/e2e/common/pod"
+	"github.com/openyurtio/openyurt/test/e2e/util"
+	ycfg "github.com/openyurtio/openyurt/test/e2e/yurtconfig"
 )
 
 const (
@@ -49,17 +50,17 @@ func Register() {
 		klog.Infof("not enable yurt node autonomy test, so yurt-node-autonomy will not run, and will return.")
 		return
 	}
-	var _ = framework.KubeDescribe(YurtHubNamespaceName, func() {
+	var _ = util.YurtDescribe(YurtHubNamespaceName, func() {
 		var (
 			c   clientset.Interface
 			err error
 		)
 		defer ginkgo.GinkgoRecover()
-		c, err = framework.LoadClientset()
+		c = ycfg.YurtE2eCfg.KubeClient
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to get client set")
 
 		err = ns.DeleteNameSpace(c, YurtHubNamespaceName)
-		framework.ExpectNoError(err)
+		util.ExpectNoError(err)
 
 		ginkgo.By("yurthub create namespace")
 		_, err = ns.CreateNameSpace(c, YurtHubNamespaceName)
@@ -71,10 +72,10 @@ func Register() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to delete created namespaces")
 		})
 
-		framework.KubeDescribe("node autonomy", func() {
+		util.YurtDescribe("node autonomy", func() {
 			ginkgo.It("yurt node autonomy", func() {
 				NodeManager, err := nd.NewNodeController(ycfg.YurtE2eCfg.NodeType, ycfg.YurtE2eCfg.RegionID, ycfg.YurtE2eCfg.AccessKeyID, ycfg.YurtE2eCfg.AccessKeySecret)
-				framework.ExpectNoError(err)
+				util.ExpectNoError(err)
 
 				podName := "test-yurthub-busybox"
 				objectMeta := metav1.ObjectMeta{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
remove k8s.io/kubernetes dependency from e2e test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #551 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
