### PR TITLE
add support for docker manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,11 @@ e2e:
 
 e2e-tests:
 	bash hack/run-e2e-tests.sh
+
+# create multi-arch manifest
+manifest:
+	bash hack/make-rules/release-manifest.sh
+
+# push generated manifest during 'make manifest'
+push_manifest:
+	bash hack/make-rules/push-manifest.sh

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -48,3 +48,19 @@ canonicalize_target() {
 host_platform() {
   echo "$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 }
+
+# Parameters
+# $1: binary_name
+get_component_name() {
+  local yurt_component_name
+  if [[ $1 =~ yurtctl ]]
+  then
+    yurt_component_name="yurtctl-servant"
+  elif [[ $1 =~ yurt-node-servant ]];
+  then
+    yurt_component_name="node-servant"
+  else
+    yurt_component_name=${binary_name}
+  fi
+  echo $yurt_component_name
+}

--- a/hack/lib/release-images.sh
+++ b/hack/lib/release-images.sh
@@ -49,7 +49,7 @@ readonly region=${REGION:-us}
 # $1: component name
 # $2: arch
 function get_image_name {
-    # If ${GIT_COMMIT} is not at a tag, add commit to the image tag. 
+    # If ${GIT_COMMIT} is not at a tag, add commit to the image tag.
     if [[ -z $(git tag --points-at ${GIT_COMMIT}) ]]; then
         yurt_component_image="${REPO}/$1:${TAG}-$2-$(echo ${GIT_COMMIT} | cut -c 1-7)"
     else
@@ -58,6 +58,7 @@ function get_image_name {
 
     echo ${yurt_component_image}
 }
+
 
 function build_multi_arch_binaries() {
     local docker_run_opts=(
@@ -108,12 +109,10 @@ function build_docker_image() {
                local docker_build_path=${DOCKER_BUILD_BASE_IDR}/${SUPPORTED_OS}/${arch}
                local docker_file_path=${docker_build_path}/Dockerfile.${binary_name}-${arch}
                mkdir -p ${docker_build_path}
-
-               local yurt_component_name
+               local yurt_component_name=$(get_component_name $binary_name)
                local base_image
                if [[ ${binary} =~ yurtctl ]]
                then
-                 yurt_component_name="yurtctl-servant"
                  case $arch in
                   amd64)
                       base_image="amd64/alpine:3.9"
@@ -134,7 +133,6 @@ ADD ${binary_name} /usr/local/bin/yurtctl
 EOF
                elif [[ ${binary} =~ yurt-node-servant ]];
                then
-                   yurt_component_name="node-servant"
                  case $arch in
                   amd64)
                       base_image="amd64/alpine:3.9"
@@ -157,7 +155,6 @@ RUN chmod +x /usr/local/bin/entry.sh
 ADD ${binary_name} /usr/local/bin/node-servant
 EOF
                else
-                 yurt_component_name=${binary_name}
                  base_image="k8s.gcr.io/debian-iptables-${arch}:v11.0.2"
                  cat <<EOF > "${docker_file_path}"
 FROM ${base_image}

--- a/hack/lib/release-manifest.sh
+++ b/hack/lib/release-manifest.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The OpenYurt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+
+
+# Parameters
+# $1: component name
+function get_manifest_name() {
+      # If ${GIT_COMMIT} is not at a tag, add commit to the image tag.
+      if [[ -z $(git tag --points-at ${GIT_COMMIT}) ]]; then
+          yurt_component_manifest="${REPO}/$1:${TAG}-$(echo ${GIT_COMMIT} | cut -c 1-7)"
+      else
+          yurt_component_manifest="${REPO}/$1:${TAG}"
+      fi
+      echo ${yurt_component_manifest}
+}
+
+function build_docker_manifest() {
+    # Always clean first
+    rm -Rf ${DOCKER_BUILD_BASE_IDR}
+    mkdir -p ${DOCKER_BUILD_BASE_IDR}
+
+    for binary in "${bin_targets_process_servant[@]}"; do
+      local binary_name=$(get_output_name $binary)
+      local yurt_component_name=$(get_component_name $binary_name)
+      local yurt_component_manifest=$(get_manifest_name $yurt_component_name)
+      echo ${yurt_component_manifest} >> ${DOCKER_BUILD_BASE_IDR}/manifest.list
+      # Remove existing manifest.
+      docker manifest rm ${yurt_component_manifest} || true
+      for arch in ${target_arch[@]}; do
+        case $arch in
+          amd64)
+              ;;
+          arm64)
+              ;;
+          arm)
+              ;;
+          *)
+              echo unknown arch $arch
+              exit 1
+         esac
+         yurt_component_image=$(get_image_name ${yurt_component_name} ${arch})
+         docker manifest create ${yurt_component_manifest} --amend  ${yurt_component_image}
+         docker manifest annotate ${yurt_component_manifest} ${yurt_component_image} --os ${SUPPORTED_OS} --arch ${arch}
+      done
+    done
+}
+
+push_manifest() {
+    cat ${DOCKER_BUILD_BASE_IDR}/manifest.list | xargs -I % sh -c 'echo pushing manifest %; docker manifest push --purge %; echo'
+}

--- a/hack/make-rules/push-manifest.sh
+++ b/hack/make-rules/push-manifest.sh
@@ -14,25 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
-set -o pipefail
+set -x
 
 YURT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
-YURT_MOD="$(head -1 $YURT_ROOT/go.mod | awk '{print $2}')"
-YURT_OUTPUT_DIR=${YURT_ROOT}/_output
-YURT_BIN_DIR=${YURT_OUTPUT_DIR}/bin
-YURT_LOCAL_BIN_DIR=${YURT_OUTPUT_DIR}/local/bin
+source "${YURT_ROOT}/hack/lib/init.sh"
+export DOCKER_CLI_EXPERIMENTAL=enabled
 
-PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
-LABEL_PREFIX=${LABEL_PREFIX:-openyurt.io}
-GIT_VERSION=${GIT_VERSION:-v0.5.0}
-GIT_COMMIT=$(git rev-parse HEAD)
-BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-REPO=${REPO:-openyurt}
-TAG=$GIT_VERSION
-
-source "${YURT_ROOT}/hack/lib/common.sh"
-source "${YURT_ROOT}/hack/lib/build.sh"
-source "${YURT_ROOT}/hack/lib/release-images.sh"
-source "${YURT_ROOT}/hack/lib/release-manifest.sh"
+push_manifest

--- a/hack/make-rules/release-manifest.sh
+++ b/hack/make-rules/release-manifest.sh
@@ -14,25 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
-set -o pipefail
+set -x
 
 YURT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
-YURT_MOD="$(head -1 $YURT_ROOT/go.mod | awk '{print $2}')"
-YURT_OUTPUT_DIR=${YURT_ROOT}/_output
-YURT_BIN_DIR=${YURT_OUTPUT_DIR}/bin
-YURT_LOCAL_BIN_DIR=${YURT_OUTPUT_DIR}/local/bin
+source "${YURT_ROOT}/hack/lib/init.sh"
+export DOCKER_CLI_EXPERIMENTAL=enabled
 
-PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
-LABEL_PREFIX=${LABEL_PREFIX:-openyurt.io}
-GIT_VERSION=${GIT_VERSION:-v0.5.0}
-GIT_COMMIT=$(git rev-parse HEAD)
-BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-REPO=${REPO:-openyurt}
-TAG=$GIT_VERSION
-
-source "${YURT_ROOT}/hack/lib/common.sh"
-source "${YURT_ROOT}/hack/lib/build.sh"
-source "${YURT_ROOT}/hack/lib/release-images.sh"
-source "${YURT_ROOT}/hack/lib/release-manifest.sh"
+build_docker_manifest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

 /kind enhancement


#### What this PR does / why we need it:
Add `make manifest` and `make push_manifest` in Makefile to support multi-arch docker manifest creation.

After the corresponding multi-arch images have been pushed to the registry, users can use `make manifest && make push_manifest` to create and push the manifest.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
