### PR TITLE
Notebug:change -e to -c

### DIFF
--- a/pkg/yurtctl/cmd/revert/cloudnode.go
+++ b/pkg/yurtctl/cmd/revert/cloudnode.go
@@ -52,7 +52,7 @@ func NewRevertCloudNodeCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("cloud-nodes", "c", "",
-		"The list of cloud nodes wanted to be revert.(e.g. -e cloudnode1,cloudnode2)")
+		"The list of cloud nodes wanted to be revert.(e.g. -c cloudnode1,cloudnode2)")
 	commonFlags(cmd)
 	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage



#### What this PR does / why we need it:
When we use ` _output/bin/yurtctl revert cloudnode -h `,there is a bug in the information:
![image](https://user-images.githubusercontent.com/85030237/144992210-73f3029f-816a-4ee4-968d-ba8135789211.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
