### PR TITLE
split the yurthub certificate into server and client certificates

### DIFF
--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -138,7 +138,7 @@ func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.YurtHubProxySecurePort, "proxy-secure-port", o.YurtHubProxySecurePort, "the port on which to proxy HTTPS requests to kube-apiserver")
 	fs.StringVar(&o.ServerAddr, "server-addr", o.ServerAddr, "the address of Kubernetes kube-apiserver,the format is: \"server1,server2,...\"")
 	fs.StringVar(&o.CertMgrMode, "cert-mgr-mode", o.CertMgrMode, "the cert manager mode, hubself: auto generate client cert for hub agent.")
-	fs.StringVar(&o.YurtHubCertOrganizations, "hub-cert-organizations", o.YurtHubCertOrganizations, "Organizations that will be added into hub's certificate in hubself cert-mgr-mode, the format is: certOrg1,certOrg1,...")
+	fs.StringVar(&o.YurtHubCertOrganizations, "hub-cert-organizations", o.YurtHubCertOrganizations, "Organizations that will be added into hub's client certificate in hubself cert-mgr-mode, the format is: certOrg1,certOrg1,...")
 	fs.StringVar(&o.KubeletRootCAFilePath, "kubelet-ca-file", o.KubeletRootCAFilePath, "the ca file path used by kubelet.")
 	fs.StringVar(&o.KubeletPairFilePath, "kubelet-client-certificate", o.KubeletPairFilePath, "the path of kubelet client certificate file.")
 	fs.IntVar(&o.GCFrequency, "gc-frequency", o.GCFrequency, "the frequency to gc cache in storage(unit: minute).")

--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -124,7 +124,7 @@ func Run(cfg *config.YurtHubConfiguration, stopCh <-chan struct{}) error {
 	trace++
 
 	klog.Infof("%d. create tls config for secure servers ", trace)
-	cfg.TLSConfig, err = certificate.GenTLSConfigUseCertMgr(certManager, filepath.Join(cfg.RootDir, "pki"))
+	cfg.TLSConfig, err = server.GenUseCertMgrAndTLSConfig(restConfigMgr, certManager, filepath.Join(cfg.RootDir, "pki"), cfg.YurtHubProxyServerSecureDummyAddr, stopCh)
 	if err != nil {
 		return fmt.Errorf("could not create tls config, %v", err)
 	}

--- a/pkg/yurthub/certificate/pki.go
+++ b/pkg/yurthub/certificate/pki.go
@@ -23,92 +23,32 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"time"
 
 	"k8s.io/client-go/util/certificate"
-	"k8s.io/klog/v2"
-
-	"github.com/openyurtio/openyurt/pkg/projectinfo"
-	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/interfaces"
 )
 
-// hubServerCertMgr is the certificate manager for server usage, which will cache the old hub-server-certificate,
-type hubServerCertMgr struct {
-	// the path of old hub server certificate
-	oldCertFile string
-	// the cached old hub server certificate
-	oldCert *tls.Certificate
-	// the actual hub certMgr
-	hubCertMgr certificate.Manager
-}
-
-// newHubServerCertMgr creates a certificate manager for the yurthub-server
-func newHubServerCertMgr(certDir string, hubCertMgr certificate.Manager) hubServerCertMgr {
-	var oldCertFile string
-	var oldCert *tls.Certificate
-
-	store, err := certificate.NewFileStore(fmt.Sprintf("%s-server", projectinfo.GetHubName()), certDir, certDir, "", "")
-	if err != nil {
-		oldCertFile = ""
-		oldCert = nil
-	} else {
-		oldCertFile = store.CurrentPath()
-		oldCert, err = store.Current()
-		if err != nil {
-			oldCert = nil
-		}
-	}
-
-	return hubServerCertMgr{
-		oldCertFile: oldCertFile,
-		oldCert:     oldCert,
-		hubCertMgr:  hubCertMgr,
-	}
-}
-
-// Current is used to obtain the certificate for hub server usage.
-// If the current certificate of hub certMgr is invalid (if the key usages of certificate doesn't contain the UsageServerAuth),
-// the old certificate in the yurthub-server-current.pem will be used.
-func (scm *hubServerCertMgr) Current() *tls.Certificate {
-	cert := scm.hubCertMgr.Current()
-	if cert == nil {
-		return &tls.Certificate{Certificate: nil}
-	}
-
-	if hasServerAuthUsage(cert) {
-		return cert
-	}
-
-	klog.V(3).Infof("the %s certificate is not valid for server, try to use the old server certificate in %s",
-		projectinfo.GetHubName(), scm.oldCertFile)
-	if scm.oldCert != nil && time.Now().Before(scm.oldCert.Leaf.NotAfter) {
-		return scm.oldCert
-	} else {
-		klog.V(3).Infof("failed to get the old %s server certificate, wait for the new hub certificate", projectinfo.GetHubName())
-	}
-	return &tls.Certificate{Certificate: nil}
-}
-
-// GenTLSConfigUseCertMgr generates a TLS configuration by using the given certificate manager
-func GenTLSConfigUseCertMgr(m interfaces.YurtCertificateManager, certDir string) (*tls.Config, error) {
-	// generate the TLS configuration based on the latest certificate
-	rootCert, err := GenCertPoolUseCA(m.GetCaFile())
-	if err != nil {
-		klog.Errorf("could not generate a x509 CertPool based on the given CA file, %v", err)
-		return nil, err
-	}
-
+// GenTGenTLSConfigUseCertMgrAndCertPool generates a TLS configuration
+// using the given certificate manager and x509 CertPool
+func GenTLSConfigUseCertMgrAndCertPool(
+	m certificate.Manager,
+	root *x509.CertPool) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		// Can't use SSLv3 because of POODLE and BEAST
 		// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
 		// Can't use TLSv1.1 because of RC4 cipher usage
 		MinVersion: tls.VersionTLS12,
-		ClientCAs:  rootCert,
+		ClientCAs:  root,
 		ClientAuth: tls.VerifyClientCertIfGiven,
 	}
 
-	scm := newHubServerCertMgr(certDir, m)
-	tlsConfig.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) { return scm.Current(), nil }
+	tlsConfig.GetCertificate =
+		func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert := m.Current()
+			if cert == nil {
+				return &tls.Certificate{Certificate: nil}, nil
+			}
+			return cert, nil
+		}
 
 	return tlsConfig, nil
 }
@@ -134,18 +74,4 @@ func GenCertPoolUseCA(caFile string) (*x509.CertPool, error) {
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(caData)
 	return certPool, nil
-}
-
-// hasServerAuthUsage checks whether the certificate is valid or not
-func hasServerAuthUsage(cert *tls.Certificate) bool {
-	if cert == nil {
-		return false
-	}
-	// if the key usages of certificate doesn't contain the UsageServerAuth, it means the cert is invalid
-	for _, v := range cert.Leaf.ExtKeyUsage {
-		if v == x509.ExtKeyUsageServerAuth {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/yurthub/certificate/server/certmanager.go
+++ b/pkg/yurthub/certificate/server/certmanager.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"net"
+
+	certificates "k8s.io/api/certificates/v1beta1"
+	"k8s.io/client-go/kubernetes"
+	clicert "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"k8s.io/client-go/util/certificate"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+)
+
+const (
+	YurtHubServerCSROrg = "system:masters"
+	YurtHubCSROrg       = "openyurt:yurthub"
+	YurtHubServerCSRCN  = "kube-apiserver-kubelet-client"
+)
+
+// NewYurtHubServerCertManager creates a certificate manager for
+// the yurthub-server
+func NewYurtHubServerCertManager(
+	clientset kubernetes.Interface,
+	certDir,
+	proxyServerSecureDummyAddr string) (certificate.Manager, error) {
+
+	klog.Infof("subject of yurthub server certificate")
+	host, _, err := net.SplitHostPort(proxyServerSecureDummyAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return newCertManager(
+		clientset,
+		fmt.Sprintf("%s-server", projectinfo.GetHubName()),
+		certDir,
+		YurtHubServerCSRCN,
+		[]string{YurtHubServerCSROrg, YurtHubCSROrg},
+		[]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP(host)})
+}
+
+// NewCertManager creates a certificate manager that will generates a
+// certificate by sending a csr to the apiserver
+func newCertManager(
+	clientset kubernetes.Interface,
+	componentName,
+	certDir,
+	commonName string,
+	organizations []string,
+	ipAddrs []net.IP) (certificate.Manager, error) {
+	certificateStore, err :=
+		certificate.NewFileStore(componentName, certDir, certDir, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize the server certificate store: %v", err)
+	}
+
+	getTemplate := func() *x509.CertificateRequest {
+		return &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   commonName,
+				Organization: organizations,
+			},
+			IPAddresses: ipAddrs,
+		}
+	}
+
+	certManager, err := certificate.NewManager(&certificate.Config{
+		ClientFn: func(current *tls.Certificate) (clicert.CertificateSigningRequestInterface, error) {
+			return clientset.CertificatesV1beta1().CertificateSigningRequests(), nil
+		},
+		SignerName:  certificates.LegacyUnknownSignerName,
+		GetTemplate: getTemplate,
+		Usages: []certificates.KeyUsage{
+			certificates.UsageKeyEncipherment,
+			certificates.UsageDigitalSignature,
+			certificates.UsageServerAuth,
+		},
+		CertificateStore: certificateStore,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize server certificate manager: %v", err)
+	}
+
+	return certManager, nil
+}

--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -21,13 +21,21 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 
 	"github.com/openyurtio/openyurt/cmd/yurthub/app/config"
 	"github.com/openyurtio/openyurt/pkg/profile"
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/yurthub/certificate"
 	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/interfaces"
+	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/server"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/rest"
 )
 
 // Server is an interface for providing http service for yurthub
@@ -159,4 +167,47 @@ func registerHandlers(c *mux.Router, cfg *config.YurtHubConfiguration, certifica
 func healthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, "OK")
+}
+
+// create a certificate manager for the yurthub server and run the csr approver for both yurthub
+// and generate a TLS configuration
+func GenUseCertMgrAndTLSConfig(restConfigMgr *rest.RestConfigManager, certificateMgr interfaces.YurtCertificateManager, certDir, proxyServerSecureDummyAddr string, stopCh <-chan struct{}) (*tls.Config, error) {
+	cfg := restConfigMgr.GetRestConfig(false)
+	if cfg == nil {
+		return nil, fmt.Errorf("failed to prepare rest config based ong hub agent client certificate")
+	}
+
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// create a certificate manager for the yurthub server and run the csr approver for both yurthub
+	serverCertMgr, err := server.NewYurtHubServerCertManager(clientSet, certDir, proxyServerSecureDummyAddr)
+	if err != nil {
+		return nil, err
+	}
+	serverCertMgr.Start()
+
+	// generate the TLS configuration based on the latest certificate
+	rootCert, err := certificate.GenCertPoolUseCA(certificateMgr.GetCaFile())
+	if err != nil {
+		klog.Errorf("could not generate a x509 CertPool based on the given CA file, %v", err)
+		return nil, err
+	}
+	tlsCfg, err := certificate.GenTLSConfigUseCertMgrAndCertPool(serverCertMgr, rootCert)
+	if err != nil {
+		return nil, err
+	}
+
+	// waiting for the certificate is generated
+	_ = wait.PollUntil(5*time.Second, func() (bool, error) {
+		// keep polling until the certificate is signed
+		if serverCertMgr.Current() != nil {
+			return true, nil
+		}
+		klog.Infof("waiting for the master to sign the %s certificate", projectinfo.GetHubName())
+		return false, nil
+	}, stopCh)
+
+	return tlsCfg, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug


#### What this PR does / why we need it:
Restore the original certificate mode of yurthub, which is, server and client certificates are managed separately. Avoid certificate verification errors when some components that have strict requirements on the use of certificates connect to yurthub. (for example, fluend)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch please take review

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
