### PR TITLE
remove "k8s.io/kubernetes/pkg/controller/apis/config" dependency for yurt-controller-manager

### DIFF
--- a/cmd/yurt-controller-manager/app/options/generic.go
+++ b/cmd/yurt-controller-manager/app/options/generic.go
@@ -23,9 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	cliflag "k8s.io/component-base/cli/flag"
 	componentbaseconfig "k8s.io/component-base/config"
-	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 
 	"github.com/openyurtio/openyurt/pkg/controller/kubernetes/client/leaderelectionconfig"
+	kubectrlmgrconfig "github.com/openyurtio/openyurt/pkg/controller/kubernetes/controller/apis/config"
 )
 
 // GenericControllerManagerConfigurationOptions holds the options which are generic.

--- a/cmd/yurt-controller-manager/app/options/options.go
+++ b/cmd/yurt-controller-manager/app/options/options.go
@@ -37,10 +37,10 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog/v2"
 	nodelifecycleconfig "k8s.io/kube-controller-manager/config/v1alpha1"
-	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	utilpointer "k8s.io/utils/pointer"
 
 	yurtcontrollerconfig "github.com/openyurtio/openyurt/cmd/yurt-controller-manager/app/config"
+	kubectrlmgrconfig "github.com/openyurtio/openyurt/pkg/controller/kubernetes/controller/apis/config"
 )
 
 const (

--- a/pkg/controller/apis/config/types.go
+++ b/pkg/controller/apis/config/types.go
@@ -19,7 +19,8 @@ package config
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	nodelifecycleconfig "k8s.io/kube-controller-manager/config/v1alpha1"
-	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
+
+	kubectrlmgrconfig "github.com/openyurtio/openyurt/pkg/controller/kubernetes/controller/apis/config"
 )
 
 // YurtControllerManagerConfiguration contains elements describing yurt-controller manager.

--- a/pkg/controller/kubernetes/controller/apis/config/types.go
+++ b/pkg/controller/kubernetes/controller/apis/config/types.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfig "k8s.io/component-base/config"
+)
+
+// GenericControllerManagerConfiguration holds configuration for a generic controller-manager
+type GenericControllerManagerConfiguration struct {
+	// port is the port that the controller-manager's http service runs on.
+	Port int32
+	// address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
+	Address string
+	// minResyncPeriod is the resync period in reflectors; will be random between
+	// minResyncPeriod and 2*minResyncPeriod.
+	MinResyncPeriod metav1.Duration
+	// ClientConnection specifies the kubeconfig file and client connection
+	// settings for the proxy server to use when communicating with the apiserver.
+	ClientConnection componentbaseconfig.ClientConnectionConfiguration
+	// How long to wait between starting controller managers
+	ControllerStartInterval metav1.Duration
+	// leaderElection defines the configuration of leader election client.
+	LeaderElection componentbaseconfig.LeaderElectionConfiguration
+	// Controllers is the list of controllers to enable or disable
+	// '*' means "all enabled by default controllers"
+	// 'foo' means "enable 'foo'"
+	// '-foo' means "disable 'foo'"
+	// first item for a particular name wins
+	Controllers []string
+	// DebuggingConfiguration holds configuration for Debugging related features.
+	Debugging componentbaseconfig.DebuggingConfiguration
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage



#### What this PR does / why we need it:
- Remove "k8s.io/kubernetes/pkg/controller/apis/config" dependency for yurt-controller-manager. 
- The `k8s.io/controller-manager` only supports version 1.20.x or later. The current policy is to cache the used `k8s.io/kubernetes/pkg/controller/apis/config/types.go` file. After openYurt is upgraded to version 1.20.x, I will submit a PR to replace `k8s.io/kubernetes/pkg/controller` with `k8s.io/controller-manager`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
