### PR TITLE
docs: add RBAC instruction for patched flannel

### DIFF
--- a/docs/tutorial/edge-pod-network.md
+++ b/docs/tutorial/edge-pod-network.md
@@ -78,3 +78,39 @@ git reset --hard 9ebe139e77e82afb122e335328007bca86905ae4;
 wget https://raw.githubusercontent.com/openyurtio/openyurt/master/docs/tutorial/0002-ipam-keep-pod-ip.patch;
 git am 0002-ipam-keep-pod-ip.patch;
 ```
+# Add additional RBAC role for flannel
+After patch, flannel now needs to get node resource. The original RBAC granted to flannel does not permit for "get
+node" operation. So, we need to grant flannel permission to get nodes. Take the official installation as an example:
+```bash
+$ kubectl get clusterrole flannel
+NAME      CREATED AT
+flannel   2021-11-16T07:05:00Z
+```
+We need to edit the flannel `clusterrole`, add "get" into the related verbs list:
+```diff
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
++     - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind documentation


#### What this PR does / why we need it:
The RBAC requirement for patched flannel is missing, which produce "Failed to get node" error. 
```
I1214 03:35:54.782398       1 main.go:402] Found network config - Backend type: vxlan
W1214 03:35:54.782470       1 client_config.go:608] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
E1214 03:35:54.799285       1 main.go:673] Failed to get node for backend data: nodes "zj-cache1.js" is forbidden: User "system:serviceaccount:kube-system:flannel" cannot get resource "nodes" in API group "" at the cluster scope
I1214 03:35:54.799382       1 vxlan.go:124] VXLAN config: VNI=1 Port=0 GBP=false Learning=false DirectRouting=false
I1214 03:35:54.924836       1 main.go:317] Setting up masking rules
I1214 03:35:55.178859       1 main.go:325] Changing default FORWARD chain policy to ACCEPT
I1214 03:35:55.179024       1 main.go:333] Wrote subnet file to /run/flannel/subnet.env
I1214 03:35:55.179034       1 main.go:337] Running backend.
I1214 03:35:55.179044       1 main.go:355] Waiting for all goroutines to exit
I1214 03:35:55.179083       1 vxlan_network.go:59] watching for new subnet leases
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
