### PR TITLE
user can specifies the certificate directory

### DIFF
--- a/cmd/yurt-tunnel-agent/app/config/config.go
+++ b/cmd/yurt-tunnel-agent/app/config/config.go
@@ -16,7 +16,14 @@ limitations under the License.
 
 package config
 
-import "k8s.io/client-go/kubernetes"
+import (
+	"fmt"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
+
+	"k8s.io/client-go/kubernetes"
+)
 
 // Config is the main context object for yurttunel-agent
 type Config struct {
@@ -26,6 +33,7 @@ type Config struct {
 	Client           kubernetes.Interface
 	AgentIdentifiers string
 	AgentMetaAddr    string
+	CertDir          string
 }
 
 type completedConfig struct {
@@ -42,5 +50,8 @@ type CompletedConfig struct {
 func (c *Config) Complete() *CompletedConfig {
 	cc := completedConfig{c}
 
+	if cc.CertDir == "" {
+		cc.CertDir = fmt.Sprintf(constants.YurttunnelAgentCertDir, projectinfo.GetAgentName())
+	}
 	return &CompletedConfig{&cc}
 }

--- a/cmd/yurt-tunnel-agent/app/options/options.go
+++ b/cmd/yurt-tunnel-agent/app/options/options.go
@@ -46,6 +46,7 @@ type AgentOptions struct {
 	AgentIdentifiers string
 	MetaHost         string
 	MetaPort         string
+	CertDir          string
 }
 
 // NewAgentOptions creates a new AgentOptions with a default config.
@@ -92,6 +93,7 @@ func (o *AgentOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.AgentIdentifiers, "agent-identifiers", o.AgentIdentifiers, "The identifiers of the agent, which will be used by the server when choosing agent.")
 	fs.StringVar(&o.MetaHost, "meta-host", o.MetaHost, "The ip address on which listen for --meta-port port.")
 	fs.StringVar(&o.MetaPort, "meta-port", o.MetaPort, "The port on which to serve HTTP requests like profling, metrics")
+	fs.StringVar(&o.CertDir, "cert-dir", o.CertDir, "The directory of certificate stored at.")
 }
 
 // agentIdentifiersIsValid verify agent identifiers are valid or not.
@@ -128,6 +130,7 @@ func (o *AgentOptions) Config() (*config.Config, error) {
 		TunnelServerAddr: o.TunnelServerAddr,
 		AgentIdentifiers: o.AgentIdentifiers,
 		AgentMetaAddr:    net.JoinHostPort(o.MetaHost, o.MetaPort),
+		CertDir:          o.CertDir,
 	}
 
 	if len(c.AgentIdentifiers) == 0 {

--- a/cmd/yurt-tunnel-agent/app/start.go
+++ b/cmd/yurt-tunnel-agent/app/start.go
@@ -87,7 +87,7 @@ func Run(cfg *config.CompletedConfig, stopCh <-chan struct{}) error {
 
 	// 2. create a certificate manager
 	agentCertMgr, err =
-		certmanager.NewYurttunnelAgentCertManager(cfg.Client)
+		certmanager.NewYurttunnelAgentCertManager(cfg.Client, cfg.CertDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/yurt-tunnel-server/app/config/config.go
+++ b/cmd/yurt-tunnel-server/app/config/config.go
@@ -18,7 +18,11 @@ package config
 
 import (
 	"crypto/x509"
+	"fmt"
 	"net"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
 
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -33,6 +37,7 @@ type Config struct {
 	DNSSyncPeriod               int
 	CertDNSNames                []string
 	CertIPs                     []net.IP
+	CertDir                     string
 	ListenAddrForAgent          string
 	ListenAddrForMaster         string
 	ListenInsecureAddrForMaster string
@@ -61,6 +66,9 @@ func (c *Config) Complete() *CompletedConfig {
 
 	if cc.InterceptorServerUDSFile == "" {
 		cc.InterceptorServerUDSFile = "/tmp/interceptor-proxier.sock"
+	}
+	if cc.CertDir == "" {
+		cc.CertDir = fmt.Sprintf(constants.YurttunnelServerCertDir, projectinfo.GetServerName())
 	}
 	return &CompletedConfig{&cc}
 }

--- a/cmd/yurt-tunnel-server/app/options/options.go
+++ b/cmd/yurt-tunnel-server/app/options/options.go
@@ -41,6 +41,7 @@ type ServerOptions struct {
 	InsecureBindAddr       string
 	CertDNSNames           string
 	CertIPs                string
+	CertDir                string
 	Version                bool
 	EnableIptables         bool
 	EnableDNSController    bool
@@ -91,6 +92,7 @@ func (o *ServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.InsecureBindAddr, "insecure-bind-address", o.InsecureBindAddr, fmt.Sprintf("the ip address on which the %s will listen for --insecure-port port.", projectinfo.GetServerName()))
 	fs.StringVar(&o.CertDNSNames, "cert-dns-names", o.CertDNSNames, "DNS names that will be added into server's certificate. (e.g., dns1,dns2)")
 	fs.StringVar(&o.CertIPs, "cert-ips", o.CertIPs, "IPs that will be added into server's certificate. (e.g., ip1,ip2)")
+	fs.StringVar(&o.CertDir, "cert-dir", o.CertDir, "The directory of certificate stored at.")
 	fs.BoolVar(&o.EnableIptables, "enable-iptables", o.EnableIptables, "If allow iptable manager to set the dnat rule.")
 	fs.BoolVar(&o.EnableDNSController, "enable-dns-controller", o.EnableDNSController, "If allow DNS controller to set the dns rules.")
 	fs.BoolVar(&o.EgressSelectorEnabled, "egress-selector-enable", o.EgressSelectorEnabled, "If the apiserver egress selector has been enabled.")
@@ -114,6 +116,7 @@ func (o *ServerOptions) Config() (*config.Config, error) {
 		DNSSyncPeriod:         o.DNSSyncPeriod,
 		CertDNSNames:          make([]string, 0),
 		CertIPs:               make([]net.IP, 0),
+		CertDir:               o.CertDir,
 		ServerCount:           o.ServerCount,
 		ProxyStrategy:         o.ProxyStrategy,
 	}

--- a/cmd/yurt-tunnel-server/app/start.go
+++ b/cmd/yurt-tunnel-server/app/start.go
@@ -107,7 +107,7 @@ func Run(cfg *config.CompletedConfig, stopCh <-chan struct{}) error {
 
 	// 2. create a certificate manager for the tunnel server and run the
 	// csr approver for both yurttunnel-server and yurttunnel-agent
-	serverCertMgr, err := certmanager.NewYurttunnelServerCertManager(cfg.Client, cfg.SharedInformerFactory, cfg.CertDNSNames, cfg.CertIPs, stopCh)
+	serverCertMgr, err := certmanager.NewYurttunnelServerCertManager(cfg.Client, cfg.SharedInformerFactory, cfg.CertDir, cfg.CertDNSNames, cfg.CertIPs, stopCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/yurttunnel/pki/certmanager/certmanager.go
+++ b/pkg/yurttunnel/pki/certmanager/certmanager.go
@@ -47,6 +47,7 @@ import (
 func NewYurttunnelServerCertManager(
 	clientset kubernetes.Interface,
 	factory informers.SharedInformerFactory,
+	certDir string,
 	clCertNames []string,
 	clIPs []net.IP,
 	stopCh <-chan struct{}) (certificate.Manager, error) {
@@ -94,7 +95,7 @@ func NewYurttunnelServerCertManager(
 	return newCertManager(
 		clientset,
 		projectinfo.GetServerName(),
-		fmt.Sprintf(constants.YurttunnelServerCertDir, projectinfo.GetServerName()),
+		certDir,
 		constants.YurttunneServerCSRCN,
 		[]string{constants.YurttunneServerCSROrg, constants.YurttunnelCSROrg},
 		dnsNames,
@@ -111,7 +112,8 @@ func NewYurttunnelServerCertManager(
 // NewYurttunnelAgentCertManager creates a certificate manager for
 // the yurttunel-agent
 func NewYurttunnelAgentCertManager(
-	clientset kubernetes.Interface) (certificate.Manager, error) {
+	clientset kubernetes.Interface,
+	certDir string) (certificate.Manager, error) {
 	// As yurttunnel-agent will run on the edge node with Host network mode,
 	// we can use the status.podIP as the node IP
 	nodeIP := os.Getenv(constants.YurttunnelAgentPodIPEnv)
@@ -123,7 +125,7 @@ func NewYurttunnelAgentCertManager(
 	return newCertManager(
 		clientset,
 		projectinfo.GetAgentName(),
-		fmt.Sprintf(constants.YurttunnelAgentCertDir, projectinfo.GetAgentName()),
+		certDir,
 		constants.YurttunnelAgentCSRCN,
 		[]string{constants.YurttunnelCSROrg},
 		[]string{os.Getenv("NODE_NAME")},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
 /kind enhancement
 /kind good-first-issue
 /kind feature


#### What this PR does / why we need it:
In order to make the certificates of yurt-tunnel components can be saved in any directory that user wants to save.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #409 



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
user can use `--cert-dir` parameter to specify the directory of certificate about both yurt tunnel server and agent.

