### PR TITLE
bugfix: panic happened when x-tunnel-server-svc service type is lb

### DIFF
--- a/pkg/yurttunnel/server/serveraddr/addr.go
+++ b/pkg/yurttunnel/server/serveraddr/addr.go
@@ -351,8 +351,10 @@ func GetDefaultDomainsForSvc(ns, name string) []string {
 
 func NodeListToNodes(nodeLst *corev1.NodeList) []*corev1.Node {
 	nodes := make([]*corev1.Node, 0)
-	for _, node := range nodeLst.Items {
-		nodes = append(nodes, &node)
+	if nodeLst != nil {
+		for _, node := range nodeLst.Items {
+			nodes = append(nodes, &node)
+		}
 	}
 	return nodes
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
when type of service `x-tunnel-server-svc` is LoadBalancer, a panic will happen when yurt-tunnel-server component startups.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
