### PR TITLE
[bug] add NoArgs check for cmds

### DIFF
--- a/cmd/yurt-node-servant/convert/convert.go
+++ b/cmd/yurt-node-servant/convert/convert.go
@@ -47,6 +47,7 @@ func NewConvertCmd() *cobra.Command {
 			}
 			klog.Info("convert success")
 		},
+		Args: cobra.NoArgs,
 	}
 	setFlags(cmd)
 

--- a/cmd/yurt-node-servant/preflight-convert/preflight.go
+++ b/cmd/yurt-node-servant/preflight-convert/preflight.go
@@ -48,6 +48,7 @@ func NewxPreflightConvertCmd() *cobra.Command {
 			}
 			klog.Info("convert pre-flight checks success")
 		},
+		Args: cobra.NoArgs,
 	}
 	setFlags(cmd)
 

--- a/cmd/yurt-node-servant/revert/revert.go
+++ b/cmd/yurt-node-servant/revert/revert.go
@@ -40,6 +40,7 @@ func NewRevertCmd() *cobra.Command {
 			}
 			klog.Info("revert success")
 		},
+		Args: cobra.NoArgs,
 	}
 	setFlags(cmd)
 

--- a/cmd/yurt-tunnel-agent/app/start.go
+++ b/cmd/yurt-tunnel-agent/app/start.go
@@ -61,6 +61,7 @@ func NewYurttunnelAgentCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 			return nil
 		},
+		Args: cobra.NoArgs,
 	}
 
 	agentOptions.AddFlags(cmd.Flags())

--- a/cmd/yurt-tunnel-server/app/start.go
+++ b/cmd/yurt-tunnel-server/app/start.go
@@ -65,6 +65,7 @@ func NewYurttunnelServerCommand(stopCh <-chan struct{}) *cobra.Command {
 			}
 			return nil
 		},
+		Args: cobra.NoArgs,
 	}
 
 	serverOptions.AddFlags(cmd.Flags())

--- a/pkg/node-servant/constant.go
+++ b/pkg/node-servant/constant.go
@@ -139,7 +139,7 @@ spec:
         - /bin/sh
         - -c
         args:
-        - "/usr/local/bin/entry.sh preflight-convert if {{.ignore_preflight_errors}} {{if .ignore_preflight_errors}}--ignore-preflight-errors {{.ignore_preflight_errors}} {{end}}"
+        - "/usr/local/bin/entry.sh preflight-convert {{if .ignore_preflight_errors}}--ignore-preflight-errors {{.ignore_preflight_errors}} {{end}}"
         securityContext:
           privileged: true
         volumeMounts:

--- a/pkg/yurtctl/cmd/clusterinfo/clusterinfo.go
+++ b/pkg/yurtctl/cmd/clusterinfo/clusterinfo.go
@@ -66,6 +66,7 @@ func NewClusterInfoCmd() *cobra.Command {
 				klog.Fatalf("fail to run cluster-info cmd: %s", err)
 			}
 		},
+		Args: cobra.NoArgs,
 	}
 
 	return cmd

--- a/pkg/yurtctl/cmd/convert/convert.go
+++ b/pkg/yurtctl/cmd/convert/convert.go
@@ -87,6 +87,7 @@ func NewConvertCmd() *cobra.Command {
 				os.Exit(1)
 			}
 		},
+		Args: cobra.NoArgs,
 	}
 
 	setFlags(cmd)

--- a/pkg/yurtctl/cmd/markautonomous/markautonomous.go
+++ b/pkg/yurtctl/cmd/markautonomous/markautonomous.go
@@ -60,6 +60,7 @@ func NewMarkAutonomousCmd() *cobra.Command {
 				klog.Fatalf("fail to make nodes autonomous: %s", err)
 			}
 		},
+		Args: cobra.NoArgs,
 	}
 
 	cmd.Flags().StringP("autonomous-nodes", "a", "",

--- a/pkg/yurtctl/cmd/revert/revert.go
+++ b/pkg/yurtctl/cmd/revert/revert.go
@@ -73,6 +73,7 @@ func NewRevertCmd() *cobra.Command {
 				os.Exit(1)
 			}
 		},
+		Args: cobra.NoArgs,
 	}
 
 	cmd.Flags().String("node-servant-image",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind bug



#### What this PR does / why we need it:

Some commands don't need args. However, currently there's no check when users pass useless args. As an example:

```bash
yurtctl convert edgenode worker-node -c master-node
```

The command above will work without any error report, though we've removed the `edgenode` subcommand at #617.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
