### PR TITLE
fix: not initialized `sets.String` cause panic

### DIFF
--- a/pkg/yurtctl/cmd/join/join.go
+++ b/pkg/yurtctl/cmd/join/join.go
@@ -205,7 +205,7 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		return nil, errors.Errorf("when --discovery-token-ca-cert-hash is not specified, --discovery-token-unsafe-skip-ca-verification should be true")
 	}
 
-	var ignoreErrors sets.String
+	ignoreErrors := sets.String{}
 	for i := range opt.ignorePreflightErrors {
 		ignoreErrors.Insert(opt.ignorePreflightErrors[i])
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug


#### What this PR does / why we need it:
The`ignoreErrors` (a map) param is not initialized before using so it will cause panic when use`yurtctl join` with the flag`--ignore-preflight-errors` set.

```
panic: assignment to entry in nil map

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/sets.String.Insert(0x0, 0xc00063fba0, 0x1, 0x1, 0xc0000a5440)
        /usr/local/gopath/pkg/mod/k8s.io/apimachinery@v0.20.12-rc.0/pkg/util/sets/string.go:51 +0x78
github.com/openyurtio/openyurt/pkg/yurtctl/cmd/join.newJoinData(0xc0002f4f00, 0xc000154580, 0x1, 0xb, 0xc000246000, 0x19be740, 0xc00000e018, 0x0, 0x0, 0x0)
        /usr/local/gopath/src/github.com/DrmagicE/openyurt-1/pkg/yurtctl/cmd/join/join.go:210 +0x13f
github.com/openyurtio/openyurt/pkg/yurtctl/cmd/join.NewCmdJoin.func2(0xc0002f4f00, 0xc000154580, 0x1, 0xb, 0x0, 0x0, 0x0, 0x0)
        /usr/local/gopath/src/github.com/DrmagicE/openyurt-1/pkg/yurtctl/cmd/join/join.go:110 +0x68
github.com/openyurtio/openyurt/pkg/yurtctl/kubernetes/kubeadm/app/cmd/phases/workflow.(*Runner).InitData(0xc0000c4000, 0xc000154580, 0x1, 0xb, 0xc00063fd10, 0x561d84, 0xc0002f1b80, 0xc0002dc0e0)
        /usr/local/gopath/src/github.com/DrmagicE/openyurt-1/pkg/yurtctl/kubernetes/kubeadm/app/cmd/phases/workflow/runner.go:183 +0x88
github.com/openyurtio/openyurt/pkg/yurtctl/kubernetes/kubeadm/app/cmd/phases/workflow.(*Runner).Run(0xc0000c4000, 0xc000154580, 0x1, 0xb, 0x4, 0x1795b28)
        /usr/local/gopath/src/github.com/DrmagicE/openyurt-1/pkg/yurtctl/kubernetes/kubeadm/app/cmd/phases/workflow/runner.go:203 +0xb0
github.com/openyurtio/openyurt/pkg/yurtctl/cmd/join.NewCmdJoin.func1(0xc0002f4f00, 0xc000154580, 0x1, 0xb, 0x0, 0x0)
        /usr/local/gopath/src/github.com/DrmagicE/openyurt-1/pkg/yurtctl/cmd/join/join.go:95 +0x64
github.com/spf13/cobra.(*Command).execute(0xc0002f4f00, 0xc000154160, 0xb, 0xb, 0xc0002f4f00, 0xc000154160)
        /usr/local/gopath/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x453
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002f4000, 0x0, 0x15366c0, 0xc000102058)
        /usr/local/gopath/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
        /usr/local/gopath/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
main.main()
        /usr/local/gopath/src/github.com/DrmagicE/openyurt-1/cmd/yurtctl/yurtctl.go:27 +0x27

```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
