### PR TITLE
[bugfix] detect unannotated tags when initilizing GIT_VERSION

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -26,7 +26,7 @@ YURT_LOCAL_BIN_DIR=${YURT_OUTPUT_DIR}/local/bin
 
 PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
 LABEL_PREFIX=${LABEL_PREFIX:-openyurt.io}
-GIT_VERSION=${GIT_VERSION:-$(git describe --abbrev=0)}
+GIT_VERSION=${GIT_VERSION:-$(git describe --abbrev=0 --tags)}
 GIT_COMMIT=$(git rev-parse HEAD)
 BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 REPO=${REPO:-openyurt}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In current master branch of openyurt, the command `git describe --abbrev=0` will initilize `GIT_VERSION` as `v0.5.0`, because it is the latest annotated tag and `v0.6.0` is not an annotated tag. Using the option of `--tags` will make `git describe` get the latest tag even it is unannotated.

The description of `--tags` option in the `git describe -h`: 
```
--tags                use any tag, even unannotated
```

We can check if a tag is an annotated tag through command `git for-each-ref refs/tags`. An unannotated tag will be marked as `commit`.
```
$ git for-each-ref refs/tags
2abb8ad93848adb2a11244373c01bd79d713eb38 commit refs/tags/v0.1.0-beta.1
9d0ae1b2aff825ff5efcde728e143e431cce8246 tag    refs/tags/v0.2.0
1ece6ab01a006b3fd6b6cd0e48dd6f33f95e4ed1 tag    refs/tags/v0.3.0
050a2d77d7b87c67bf5b2c3509505ec4a5008bca tag    refs/tags/v0.4.0
f19e66343e354dbf829ab0a277207a59ba31b902 commit refs/tags/v0.4.1
1a4933e345da9c5ed696e420698aac44c2fc343c tag    refs/tags/v0.5.0
7df5fd6a019e28ee4147a4b271f7ada91e6372a9 commit refs/tags/v0.6.0
d6f7f4866221e6df098996d0916a09022039042d commit refs/tags/v0.6.1
```

Why isn't it `v0.6.1` ?
I read some documention of git, and found that the command `git describe --abbrev=0 --tags` will only describe the lastest tag in the current branch. In other words, it will find the latest tag before the commit pointed by `HEAD`. `v0.6.1` is at a detachd `HEAD`, thus it will not be found by using `git describe` at the master branch.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
