### PR TITLE
[bugfix] fix mistaken selflink in yurthub

### DIFF
--- a/pkg/yurthub/cachemanager/cache_manager.go
+++ b/pkg/yurthub/cachemanager/cache_manager.go
@@ -237,7 +237,7 @@ func setListObjSelfLink(listObj runtime.Object, req *http.Request) error {
 		clusterScoped = false
 	}
 
-	prefix := "/" + path.Join(info.APIGroup, info.APIGroup)
+	prefix := "/" + path.Join(info.APIGroup, info.APIVersion)
 	namer := handlers.ContextBasedNaming{
 		SelfLinker:         runtime.SelfLinker(meta.NewAccessor()),
 		SelfLinkPathPrefix: path.Join(prefix, info.Resource) + "/",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind bug


SelfLink should have the format `/<apigroup>/<apiversion>/<resource>`.

By the way, selflink will be removed soon at [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1164-remove-selflink), and we may have to take it into consideration. The timeline is:
```
2019-07-23: KEP merged.
2019-07-24: KEP move to implementable.
v1.16: Released in Alpha
v1.20: Released in Beta, enabled by default
2022-01-10: KEP updated to target GA in v1.24
```