### PR TITLE
【ADD】update node servant revert step

### DIFF
--- a/pkg/node-servant/components/tunnel.go
+++ b/pkg/node-servant/components/tunnel.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	enutil "github.com/openyurtio/openyurt/pkg/yurtctl/util/edgenode"
+)
+
+func UnInstallYurtTunnelAgent() error {
+	yurttunnelAgentWorkdir := filepath.Join("/var/lib/", projectinfo.GetAgentName())
+
+	// remove yurttunnel-agent directory and certificates in it
+	if _, err := enutil.FileExists(yurttunnelAgentWorkdir); os.IsNotExist(err) {
+		klog.Infof("UnInstallYurtTunnelAgent: dir %s is not exists, skip delete", yurttunnelAgentWorkdir)
+		return nil
+	}
+	err := os.RemoveAll(yurttunnelAgentWorkdir)
+	if err != nil {
+		return err
+	}
+	klog.Infof("UnInstallYurtTunnelAgent: config dir %s  has been removed", yurttunnelAgentWorkdir)
+
+	return nil
+}
+
+func UnInstallYurtTunnelServer() error {
+	yurttunnelServerWorkdir := filepath.Join("/var/lib/", projectinfo.GetServerName())
+
+	// remove yurttunnel-server directory and certificates in it
+	if _, err := enutil.FileExists(yurttunnelServerWorkdir); os.IsNotExist(err) {
+		klog.Infof("UnInstallYurtTunnelServer: dir %s is not exists, skip delete", yurttunnelServerWorkdir)
+		return nil
+	}
+	err := os.RemoveAll(yurttunnelServerWorkdir)
+	if err != nil {
+		return err
+	}
+	klog.Infof("UnInstallYurtTunnelServer: config dir %s  has been removed", yurttunnelServerWorkdir)
+
+	return nil
+}

--- a/pkg/node-servant/revert/revert.go
+++ b/pkg/node-servant/revert/revert.go
@@ -45,6 +45,12 @@ func (n *nodeReverter) Do() error {
 	if err := n.unInstallYurtHub(); err != nil {
 		return err
 	}
+	if err := n.unInstallYurtTunnelAgent(); err != nil {
+		return err
+	}
+	if err := n.unInstallYurtTunnelServer(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -58,4 +64,12 @@ func (n *nodeReverter) unInstallYurtHub() error {
 	op := components.NewYurthubOperator("", "", "",
 		util.WorkingModeCloud, time.Duration(1)) // params is not important here
 	return op.UnInstall()
+}
+
+func (n *nodeReverter) unInstallYurtTunnelAgent() error {
+	return components.UnInstallYurtTunnelAgent()
+}
+
+func (n *nodeReverter) unInstallYurtTunnelServer() error {
+	return components.UnInstallYurtTunnelServer()
 }


### PR DESCRIPTION

#### What type of PR is this?
> /kind enhancement



#### What this PR does / why we need it:
Sometimes the node has residual certificate files related to tunnels, if we still use this nodes to join the cluster, the invalid certificate cannot create the grpc tunnel, it can make the error for connection closed.

If we don’t open the grpc process debug parameter, it’s hard to find it. So we need to clean the tunnel directory when node-servant do the revert option.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
