### PR TITLE
support ipv6 network

### DIFF
--- a/cmd/yurt-tunnel-server/app/config/config.go
+++ b/cmd/yurt-tunnel-server/app/config/config.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/util/iptables"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
 )
 
@@ -34,6 +35,7 @@ type Config struct {
 	EnableIptables              bool
 	EnableDNSController         bool
 	IptablesSyncPeriod          int
+	IPFamily                    iptables.Protocol
 	DNSSyncPeriod               int
 	CertDNSNames                []string
 	CertIPs                     []net.IP
@@ -71,4 +73,8 @@ func (c *Config) Complete() *CompletedConfig {
 		cc.CertDir = fmt.Sprintf(constants.YurttunnelServerCertDir, projectinfo.GetServerName())
 	}
 	return &CompletedConfig{&cc}
+}
+
+func (c *Config) IsIPv6() bool {
+	return c.IPFamily == iptables.ProtocolIpv6
 }

--- a/cmd/yurt-tunnel-server/app/start.go
+++ b/cmd/yurt-tunnel-server/app/start.go
@@ -93,11 +93,12 @@ func Run(cfg *config.CompletedConfig, stopCh <-chan struct{}) error {
 	}
 	// 1. start the IP table manager
 	if cfg.EnableIptables {
-		iptablesMgr := iptables.NewIptablesManager(cfg.Client,
+		iptablesMgr := iptables.NewIptablesManagerWithIPFamily(cfg.Client,
 			cfg.SharedInformerFactory.Core().V1().Nodes(),
 			cfg.ListenAddrForMaster,
 			cfg.ListenInsecureAddrForMaster,
-			cfg.IptablesSyncPeriod)
+			cfg.IptablesSyncPeriod,
+			cfg.IPFamily)
 		if iptablesMgr == nil {
 			return fmt.Errorf("fail to create a new IptableManager")
 		}
@@ -121,7 +122,7 @@ func Run(cfg *config.CompletedConfig, stopCh <-chan struct{}) error {
 
 	// 4. create handler wrappers
 	mInitializer := initializer.NewMiddlewareInitializer(cfg.SharedInformerFactory)
-	wrappers, err := wraphandler.InitHandlerWrappers(mInitializer)
+	wrappers, err := wraphandler.InitHandlerWrappers(mInitializer, cfg.IsIPv6())
 	if err != nil {
 		klog.Errorf("failed to init handler wrappers, %v", err)
 		return err

--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -91,6 +91,7 @@ type YurtHubConfiguration struct {
 	WorkingMode                       util.WorkingMode
 	KubeletHealthGracePeriod          time.Duration
 	FilterManager                     *filter.Manager
+	CertIPs                           []net.IP
 }
 
 // Complete converts *options.YurtHubOptions to *YurtHubConfiguration
@@ -135,6 +136,12 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		return nil, err
 	}
 
+	// use dummy ip and bind ip as cert IP SANs
+	certIPs := []net.IP{
+		net.ParseIP(options.HubAgentDummyIfIP),
+		net.ParseIP(options.YurtHubHost),
+	}
+
 	cfg := &YurtHubConfiguration{
 		LBMode:                            options.LBMode,
 		RemoteServers:                     us,
@@ -167,6 +174,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		YurtSharedFactory:                 yurtSharedFactory,
 		KubeletHealthGracePeriod:          options.KubeletHealthGracePeriod,
 		FilterManager:                     filterManager,
+		CertIPs:                           certIPs,
 	}
 
 	return cfg, nil

--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -59,7 +59,7 @@ func NewCmdStartYurtHub(stopCh <-chan struct{}) *cobra.Command {
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				klog.V(1).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 			})
-			if err := options.ValidateOptions(yurtHubOptions); err != nil {
+			if err := yurtHubOptions.Validate(); err != nil {
 				klog.Fatalf("validate options: %v", err)
 			}
 
@@ -125,7 +125,8 @@ func Run(cfg *config.YurtHubConfiguration, stopCh <-chan struct{}) error {
 	trace++
 
 	klog.Infof("%d. create tls config for secure servers ", trace)
-	cfg.TLSConfig, err = server.GenUseCertMgrAndTLSConfig(restConfigMgr, certManager, filepath.Join(cfg.RootDir, "pki"), cfg.NodeName, cfg.YurtHubProxyServerSecureDummyAddr, stopCh)
+	cfg.TLSConfig, err = server.GenUseCertMgrAndTLSConfig(
+		restConfigMgr, certManager, filepath.Join(cfg.RootDir, "pki"), cfg.NodeName, cfg.CertIPs, stopCh)
 	if err != nil {
 		return fmt.Errorf("could not create tls config, %w", err)
 	}

--- a/pkg/util/certmanager/certmanager.go
+++ b/pkg/util/certmanager/certmanager.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
 	"github.com/openyurtio/openyurt/pkg/util/certmanager/store"
+	utilip "github.com/openyurtio/openyurt/pkg/util/ip"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/constants"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/server/serveraddr"
 )
@@ -69,7 +70,7 @@ func NewYurttunnelServerCertManager(
 	)
 
 	// the ips and dnsNames should be acquired through api-server at the first time, because the informer factory has not started yet.
-	_ = wait.PollUntil(5*time.Second, func() (bool, error) {
+	werr := wait.PollUntil(5*time.Second, func() (bool, error) {
 		dnsNames, ips, err = serveraddr.GetYurttunelServerDNSandIP(clientset)
 		if err != nil {
 			klog.Errorf("failed to get yurt tunnel server dns and ip, %v", err)
@@ -94,10 +95,14 @@ func NewYurttunnelServerCertManager(
 
 		return true, nil
 	}, stopCh)
-	// add user specified DNS names and IP addresses
+	if werr != nil {
+		return nil, werr
+	}
+
+	// add user specified DNS anems and IP addresses
 	dnsNames = append(dnsNames, clCertNames...)
 	ips = append(ips, clIPs...)
-	klog.Infof("subject of tunnel server certificate, ips=%#+v, dnsNames=%#+v", ips, dnsNames)
+	klog.Infof("subject of tunnel server certificate, ips=%s, dnsNames=%#+v", utilip.JoinIPStrings(ips), dnsNames)
 
 	// the dynamic ip acquire func
 	getIPs := func() ([]net.IP, error) {
@@ -180,13 +185,8 @@ func NewYurttunnelAgentCertManager(
 func NewYurtHubServerCertManager(
 	clientset kubernetes.Interface,
 	certDir,
-	nodeName,
-	proxyServerSecureDummyAddr string) (certificate.Manager, error) {
-
-	host, _, err := net.SplitHostPort(proxyServerSecureDummyAddr)
-	if err != nil {
-		return nil, err
-	}
+	nodeName string,
+	certIPs []net.IP) (certificate.Manager, error) {
 
 	return newCertManager(
 		clientset,
@@ -201,7 +201,7 @@ func NewYurtHubServerCertManager(
 			certificatesv1.UsageDigitalSignature,
 			certificatesv1.UsageServerAuth,
 		},
-		[]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP(host)},
+		certIPs,
 		nil)
 }
 

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ip
+
+import (
+	"net"
+	"strings"
+
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+)
+
+const (
+	DefaultLoopbackIP4 = "127.0.0.1"
+	DefaultLoopbackIP6 = "::1"
+)
+
+// MustGetLoopbackIP is a wrapper for GetLoopbackIP. If any error occurs or loopback interface is not found,
+// will fall back to 127.0.0.1 for ipv4 or ::1 for ipv6.
+func MustGetLoopbackIP(wantIPv6 bool) string {
+	ip, err := GetLoopbackIP(wantIPv6)
+	if err != nil {
+		klog.Errorf("failed to get loopback addr: %v", err)
+	}
+	if ip != "" {
+		return ip
+	}
+	if wantIPv6 {
+		return DefaultLoopbackIP6
+	}
+	return DefaultLoopbackIP4
+}
+
+// GetLoopbackIP returns the ip address of local loopback interface.
+func GetLoopbackIP(wantIPv6 bool) (string, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", err
+	}
+	for _, address := range addrs {
+		if ipnet, ok := address.(*net.IPNet); ok && ipnet.IP.IsLoopback() && wantIPv6 == utilnet.IsIPv6(ipnet.IP) {
+			return ipnet.IP.String(), nil
+		}
+	}
+	return "", nil
+}
+
+func JoinIPStrings(ips []net.IP) string {
+	var strs []string
+	for _, ip := range ips {
+		strs = append(strs, ip.String())
+	}
+	return strings.Join(strs, ",")
+}

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ip
+
+import (
+	"testing"
+)
+
+func TestGetLoopbackIP(t *testing.T) {
+	lo4, err := GetLoopbackIP(false)
+	if err != nil {
+		t.Errorf("failed to get ipv4 loopback address: %v", err)
+	}
+	t.Logf("got ipv4 loopback address: %s", lo4)
+	if lo4 != "127.0.0.1" {
+		t.Errorf("got ipv4 loopback addr: '%s', expect: '127.0.0.1'", lo4)
+	}
+
+	lo6, err := GetLoopbackIP(true)
+	if err != nil {
+		t.Errorf("failed to get ipv6 loopback address: %v", err)
+	}
+	if lo6 != "" {
+		// dual stack env
+		t.Logf("got ipv6 loopback address: %s", lo6)
+		if lo6 != "::1" {
+			t.Errorf("got ipv6 loopback addr: '%s', expect: '::1'", lo6)
+		}
+	}
+}

--- a/pkg/yurthub/network/iptables.go
+++ b/pkg/yurthub/network/iptables.go
@@ -22,6 +22,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/openyurtio/openyurt/pkg/util/iptables"
 )
@@ -40,6 +41,9 @@ type IptablesManager struct {
 
 func NewIptablesManager(dummyIfIP, dummyIfPort string) *IptablesManager {
 	protocol := iptables.ProtocolIpv4
+	if utilnet.IsIPv6String(dummyIfIP) {
+		protocol = iptables.ProtocolIpv6
+	}
 	execer := exec.New()
 	iptInterface := iptables.New(execer, protocol)
 
@@ -63,16 +67,16 @@ func makeupIptablesRules(ifIP, ifPort string) []iptablesRule {
 		{iptables.Prepend, iptables.Table("raw"), iptables.ChainOutput, []string{"-p", "tcp", "--sport", ifPort, "-s", ifIP, "-j", "NOTRACK"}},
 		// accept traffic from 169.254.2.1:10261
 		{iptables.Prepend, iptables.TableFilter, iptables.ChainOutput, []string{"-p", "tcp", "--sport", ifPort, "-s", ifIP, "-j", "ACCEPT"}},
-		// skip connection track for traffic from container to 127.0.0.1:10261
-		{iptables.Prepend, iptables.Table("raw"), iptables.ChainPrerouting, []string{"-p", "tcp", "--dport", ifPort, "--destination", "127.0.0.1", "-j", "NOTRACK"}},
-		// skip connection track for traffic from host network to 127.0.0.1:10261
-		{iptables.Prepend, iptables.Table("raw"), iptables.ChainOutput, []string{"-p", "tcp", "--dport", ifPort, "--destination", "127.0.0.1", "-j", "NOTRACK"}},
-		// accept traffic to 127.0.0.1:10261
-		{iptables.Prepend, iptables.TableFilter, iptables.ChainInput, []string{"-p", "tcp", "--dport", ifPort, "--destination", "127.0.0.1", "-j", "ACCEPT"}},
-		// skip connection track for traffic from 127.0.0.1:10261
-		{iptables.Prepend, iptables.Table("raw"), iptables.ChainOutput, []string{"-p", "tcp", "--sport", ifPort, "-s", "127.0.0.1", "-j", "NOTRACK"}},
-		// accept traffic from 127.0.0.1:10261
-		{iptables.Prepend, iptables.TableFilter, iptables.ChainOutput, []string{"-p", "tcp", "--sport", ifPort, "-s", "127.0.0.1", "-j", "ACCEPT"}},
+		// skip connection track for traffic from container to localhost:10261
+		{iptables.Prepend, iptables.Table("raw"), iptables.ChainPrerouting, []string{"-p", "tcp", "--dport", ifPort, "--destination", "localhost", "-j", "NOTRACK"}},
+		// skip connection track for traffic from host network to localhost:10261
+		{iptables.Prepend, iptables.Table("raw"), iptables.ChainOutput, []string{"-p", "tcp", "--dport", ifPort, "--destination", "localhost", "-j", "NOTRACK"}},
+		// accept traffic to localhost:10261
+		{iptables.Prepend, iptables.TableFilter, iptables.ChainInput, []string{"-p", "tcp", "--dport", ifPort, "--destination", "localhost", "-j", "ACCEPT"}},
+		// skip connection track for traffic from localhost:10261
+		{iptables.Prepend, iptables.Table("raw"), iptables.ChainOutput, []string{"-p", "tcp", "--sport", ifPort, "-s", "localhost", "-j", "NOTRACK"}},
+		// accept traffic from localhost:10261
+		{iptables.Prepend, iptables.TableFilter, iptables.ChainOutput, []string{"-p", "tcp", "--sport", ifPort, "-s", "localhost", "-j", "ACCEPT"}},
 	}
 }
 

--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -169,7 +169,12 @@ func healthz(w http.ResponseWriter, _ *http.Request) {
 }
 
 // GenUseCertMgrAndTLSConfig create a certificate manager for the yurthub server and generate a TLS configuration
-func GenUseCertMgrAndTLSConfig(restConfigMgr *rest.RestConfigManager, certificateMgr interfaces.YurtCertificateManager, certDir, nodeName, proxyServerSecureDummyAddr string, stopCh <-chan struct{}) (*tls.Config, error) {
+func GenUseCertMgrAndTLSConfig(
+	restConfigMgr *rest.RestConfigManager,
+	certificateMgr interfaces.YurtCertificateManager,
+	certDir, nodeName string,
+	certIPs []net.IP,
+	stopCh <-chan struct{}) (*tls.Config, error) {
 	cfg := restConfigMgr.GetRestConfig(false)
 	if cfg == nil {
 		return nil, fmt.Errorf("failed to prepare rest config based ong hub agent client certificate")
@@ -180,7 +185,7 @@ func GenUseCertMgrAndTLSConfig(restConfigMgr *rest.RestConfigManager, certificat
 		return nil, err
 	}
 	// create a certificate manager for the yurthub server and run the csr approver for both yurthub
-	serverCertMgr, err := certmanager.NewYurtHubServerCertManager(clientSet, certDir, nodeName, proxyServerSecureDummyAddr)
+	serverCertMgr, err := certmanager.NewYurtHubServerCertManager(clientSet, certDir, nodeName, certIPs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
+++ b/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/handlerwrapper/tracerequest"
 )
 
-func InitHandlerWrappers(mi initializer.MiddlewareInitializer) (hw.HandlerWrappers, error) {
+func InitHandlerWrappers(mi initializer.MiddlewareInitializer, isIPv6 bool) (hw.HandlerWrappers, error) {
 	wrappers := make(hw.HandlerWrappers, 0)
 	// register all of middleware here
 	//
@@ -42,7 +42,7 @@ func InitHandlerWrappers(mi initializer.MiddlewareInitializer) (hw.HandlerWrappe
 	//
 	// then the middleware m2 will be called before the mw1
 	wrappers = append(wrappers, tracerequest.NewTraceReqMiddleware())
-	wrappers = append(wrappers, localhostproxy.NewLocalHostProxyMiddleware())
+	wrappers = append(wrappers, localhostproxy.NewLocalHostProxyMiddleware(isIPv6))
 
 	// init all of wrappers
 	for i := range wrappers {

--- a/pkg/yurttunnel/server/interceptor.go
+++ b/pkg/yurttunnel/server/interceptor.go
@@ -88,7 +88,7 @@ func NewRequestInterceptor(udsSockFile string, cfg *tls.Config) *RequestIntercep
 			}
 		}
 
-		fmt.Fprintf(proxyConn, "CONNECT %s HTTP/1.1\r\nHost: %s%s\r\n\r\n", addr, "127.0.0.1", connectHeaders)
+		fmt.Fprintf(proxyConn, "CONNECT %s HTTP/1.1\r\nHost: localhost%s\r\n\r\n", addr, connectHeaders)
 		br := newBufioReader(proxyConn)
 		defer putBufioReader(br)
 		res, err := http.ReadResponse(br, nil)

--- a/pkg/yurttunnel/server/serveraddr/addr_test.go
+++ b/pkg/yurttunnel/server/serveraddr/addr_test.go
@@ -447,6 +447,7 @@ func TestExtractTunnelServerDNSandIPs(t *testing.T) {
 					net.ParseIP("192.168.1.1"),
 					net.ParseIP("10.10.102.1"),
 					net.ParseIP("127.0.0.1"),
+					net.ParseIP("::1"),
 					net.ParseIP("192.168.1.2"),
 					net.ParseIP("192.168.1.3"),
 				},
@@ -520,6 +521,7 @@ func TestExtractTunnelServerDNSandIPs(t *testing.T) {
 				ips: []net.IP{
 					net.ParseIP("10.10.102.1"),
 					net.ParseIP("127.0.0.1"),
+					net.ParseIP("::1"),
 					net.ParseIP("192.168.1.2"),
 					net.ParseIP("192.168.1.3"),
 				},
@@ -612,6 +614,7 @@ func TestExtractTunnelServerDNSandIPs(t *testing.T) {
 					net.ParseIP("192.168.1.5"),
 					net.ParseIP("10.10.102.1"),
 					net.ParseIP("127.0.0.1"),
+					net.ParseIP("::1"),
 					net.ParseIP("192.168.1.2"),
 					net.ParseIP("192.168.1.3"),
 				},

--- a/pkg/yurttunnel/trafficforward/iptables/iptables.go
+++ b/pkg/yurttunnel/trafficforward/iptables/iptables.go
@@ -34,13 +34,13 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/util/ip"
 	"github.com/openyurtio/openyurt/pkg/util/iptables"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/server/metrics"
 	"github.com/openyurtio/openyurt/pkg/yurttunnel/util"
 )
 
 const (
-	loopbackAddr              = "127.0.0.1"
 	reqReturnComment          = "return request to access node directly"
 	dnatToTunnelComment       = "dnat to tunnel for access node"
 	yurttunnelServerPortChain = "TUNNEL-PORT"
@@ -84,6 +84,7 @@ type iptablesManager struct {
 	nodeInformer     coreinformer.NodeInformer
 	iptables         iptables.Interface
 	execer           exec.Interface
+	loopbackAddr     string
 	conntrackPath    string
 	secureDnatDest   string
 	insecureDnatDest string
@@ -92,18 +93,18 @@ type iptablesManager struct {
 	syncPeriod       int
 }
 
-// NewIptablesManager creates an IptablesManager; deletes old chains, if any;
+// NewIptablesManagerWithIPFamily creates an IptablesManager; deletes old chains, if any;
 // generates new dnat rules based on IPs of current active nodes; and
 // appends the rules to the iptable.
-func NewIptablesManager(client clientset.Interface,
+func NewIptablesManagerWithIPFamily(client clientset.Interface,
 	nodeInformer coreinformer.NodeInformer,
 	listenAddr string,
 	listenInsecureAddr string,
-	syncPeriod int) IptablesManager {
+	syncPeriod int,
+	ipFamily iptables.Protocol) IptablesManager {
 
-	protocol := iptables.ProtocolIpv4
 	execer := exec.New()
-	iptInterface := iptables.New(execer, protocol)
+	iptInterface := iptables.New(execer, ipFamily)
 
 	if syncPeriod < defaultSyncPeriod {
 		syncPeriod = defaultSyncPeriod
@@ -121,6 +122,8 @@ func NewIptablesManager(client clientset.Interface,
 		syncPeriod:       syncPeriod,
 	}
 
+	im.loopbackAddr = ip.MustGetLoopbackIP(ipFamily == iptables.ProtocolIpv6)
+
 	// conntrack setting
 	conntrackPath, err := im.execer.LookPath("conntrack")
 	if err != nil {
@@ -133,6 +136,15 @@ func NewIptablesManager(client clientset.Interface,
 	_ = im.deleteJumpChains(iptablesJumpChains)
 
 	return im
+}
+
+// NewIptablesManager creates an IptablesManager with ipv4 protocol
+func NewIptablesManager(client clientset.Interface,
+	nodeInformer coreinformer.NodeInformer,
+	listenAddr string,
+	listenInsecureAddr string,
+	syncPeriod int) IptablesManager {
+	return NewIptablesManagerWithIPFamily(client, nodeInformer, listenAddr, listenInsecureAddr, syncPeriod, iptables.ProtocolIpv4)
 }
 
 // Run starts the iptablesManager that will updates dnat rules periodically
@@ -361,7 +373,7 @@ func (im *iptablesManager) ensurePortIptables(port string, currentIPs, deletedIP
 			iptables.Prepend,
 			iptables.TableNAT, portChain, reqReturnPortIptablesArgs...)
 		if err != nil {
-			klog.Errorf("could not ensure -j RETURN iptables rule for %s:%s: %v", ip, port, err)
+			klog.Errorf("could not ensure -j RETURN iptables rule for %s: %v", net.JoinHostPort(ip, port), err)
 			return err
 		}
 	}
@@ -382,7 +394,7 @@ func (im *iptablesManager) ensurePortIptables(port string, currentIPs, deletedIP
 		err = im.iptables.DeleteRule(iptables.TableNAT,
 			portChain, deletedIPIptablesArgs...)
 		if err != nil {
-			klog.Errorf("could not delete old iptables rules for %s:%s: %v", ip, port, err)
+			klog.Errorf("could not delete old iptables rules for %s: %v", net.JoinHostPort(ip, port), err)
 			return err
 		}
 	}
@@ -509,7 +521,7 @@ func (im *iptablesManager) syncIptableSetting() {
 	// check if there are new nodes
 	nodesIP := im.getIPOfNodesWithoutAgent()
 	nodesChanged, addedNodesIP, deletedNodesIP := im.getAddedAndDeletedNodes(nodesIP)
-	currentNodesIP := append(nodesIP, loopbackAddr)
+	currentNodesIP := append(nodesIP, im.loopbackAddr)
 
 	// update the iptables setting if necessary
 	err = im.ensurePortsIptables(currentDnatPorts, deletedDnatPorts, currentNodesIP, deletedNodesIP, portMappings)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind enhancement



#### What this PR does / why we need it:

We need to run openyurt on ipv6 network.

Current works makes yurt-tunnel and yurthub work well on ipv6 network. 

- yurt-tunnel-server

  - determine protocol stack according to bind ip format
  - set default insecure bind address to ::1 when ipv6
  - use ip6tables instead of iptables when ipv6

- yurt-tunnel-agent

  - determine protocol stack according to node ip format
  - set default meta host to ::1 when ipv6
 
- yurthub

  - use `fd00::2:1` as the default dummy if ip when binding an ipv6 address(yurthub still use 127.0.0.1 as default, set --bind-address to ::1 in ipv6 )
  - use ip6tables instead iptables when dummy ip is an ipv6 address
 
  use fd00::2:1 in ipv6, as the counterpart of 169.254.2.1 in ipv4, referring to [node local dns cache ipv6 configuration](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/#configuration). 

- other changes:

  - use `net.JoinHostPort` instead of `fmt.Sprintf("%s:%d", host, port)`
  - use ::1 as loopback address when ipv6
  - add ::1 to cert SANs
