### PR TITLE
Add orgs to yurthub server crt

### DIFF
--- a/pkg/util/certmanager/factory/factory_test.go
+++ b/pkg/util/certmanager/factory/factory_test.go
@@ -76,6 +76,7 @@ func TestNew(t *testing.T) {
 				CommonName:     fmt.Sprintf("system:node:%s", constants.YurtTunnelServerNodeName),
 				Organizations:  []string{user.NodesGroup},
 				ForServerUsage: true,
+				Extension:      []string{"openyurt:tenant:myspace"},
 			},
 			nil,
 		},
@@ -87,13 +88,14 @@ func TestNew(t *testing.T) {
 			t.Logf("\tTestCase: %s", tt.name)
 			{
 				fc := NewCertManagerFactory(&fake.Clientset{})
-				_, get := fc.New(tt.cfg)
+				mg, get := fc.New(tt.cfg)
 
 				if !reflect.DeepEqual(get, tt.expect) {
 					t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
 				}
 				t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
 
+				mg.Start()
 			}
 		})
 	}

--- a/pkg/yurthub/certificate/token/token.go
+++ b/pkg/yurthub/certificate/token/token.go
@@ -127,7 +127,7 @@ func NewYurtHubCertManager(cfg *CertificateManagerConfiguration) (hubCert.YurtCe
 		return ycm, errors.Wrap(err, "couldn't new hub server cert store")
 	}
 
-	ycm.hubServerCertManager, err = ycm.newHubServerCertificateManager(ycm.hubServerCertStore, cfg.NodeName, cfg.CertIPs)
+	ycm.hubServerCertManager, err = ycm.newHubServerCertificateManager(ycm.hubServerCertStore, cfg.NodeName, cfg.CertIPs, cfg.YurtHubCertOrganizations)
 	if err != nil {
 		return ycm, errors.Wrap(err, "couldn't new hub server certificate manager")
 	}
@@ -357,7 +357,7 @@ func (ycm *yurtHubCertManager) generateCertClientFn(current *tls.Certificate) (c
 
 // newHubServerCertificateManager create a certificate manager for yurthub component to prepare server certificate
 // that used to handle requests from clients on edge nodes.
-func (ycm *yurtHubCertManager) newHubServerCertificateManager(fileStore certificate.FileStore, nodeName string, certIPs []net.IP) (certificate.Manager, error) {
+func (ycm *yurtHubCertManager) newHubServerCertificateManager(fileStore certificate.FileStore, nodeName string, certIPs []net.IP, customedOrgs []string) (certificate.Manager, error) {
 	kubeClientFn := func(current *tls.Certificate) (clientset.Interface, error) {
 		// waiting for the certificate is generated
 		_ = wait.PollInfinite(5*time.Second, func() (bool, error) {
@@ -384,6 +384,7 @@ func (ycm *yurtHubCertManager) newHubServerCertificateManager(fileStore certific
 		CommonName:     fmt.Sprintf("system:node:%s", nodeName),
 		Organizations:  []string{user.NodesGroup},
 		IPs:            certIPs,
+		Extension:      customedOrgs,
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind enhancement
> /sig iot


#### What this PR does / why we need it:
we use tenant ns as org  when we do client csr, but when we do server csr, the org is not used. And the csr will be rejected by beehive 'cause beehive think the server's csr tenant ns is not equal to it should be.


This pr use command parameter "YurtHubCertOrganizations" as org to ask for its server crt.

As k8s 1.22 does not allow custom orgs except "system:nodes", the orgs will be added into ExtraExtension 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
@rambohe-ch 

#### Does this PR introduce a user-facing change?
NONE
```release-note

```
