### PR TITLE
output processing info to stdout at real time

### DIFF
--- a/pkg/yurtctl/cmd/cmd.go
+++ b/pkg/yurtctl/cmd/cmd.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -44,7 +45,7 @@ func NewYurtctlCommand() *cobra.Command {
 	cmds.PersistentFlags().String("kubeconfig", "", "The path to the kubeconfig file")
 	cmds.AddCommand(markautonomous.NewMarkAutonomousCmd())
 	cmds.AddCommand(clusterinfo.NewClusterInfoCmd())
-	cmds.AddCommand(yurttest.NewCmdTest())
+	cmds.AddCommand(yurttest.NewCmdTest(os.Stdout))
 
 	klog.InitFlags(nil)
 	// goflag.Parse()

--- a/pkg/yurtctl/cmd/yurttest/kindinit/init_test.go
+++ b/pkg/yurtctl/cmd/yurttest/kindinit/init_test.go
@@ -136,6 +136,7 @@ nodes:
 	}
 	for name, c := range cases {
 		initializer := newKindInitializer(
+			os.Stdout,
 			&initializerConfig{
 				ClusterName:    c.clusterName,
 				NodesNum:       c.nodesNum,

--- a/pkg/yurtctl/cmd/yurttest/kindinit/kindoperator_test.go
+++ b/pkg/yurtctl/cmd/yurttest/kindinit/kindoperator_test.go
@@ -163,7 +163,7 @@ func TestKindLoadDockerImage(t *testing.T) {
 			}, name, args...)
 		}
 		operator.SetExecCommand(fakeExecCommand)
-		if err := operator.KindLoadDockerImage(c.clusterName, c.image, c.nodeNames); err != nil {
+		if err := operator.KindLoadDockerImage(os.Stdout, c.clusterName, c.image, c.nodeNames); err != nil {
 			t.Errorf("unexpected cmd when loading docker images to kind at case %s, want: %s", caseName, c.want)
 		}
 	}

--- a/pkg/yurtctl/cmd/yurttest/yurttest.go
+++ b/pkg/yurtctl/cmd/yurttest/yurttest.go
@@ -18,13 +18,14 @@ package yurttest
 
 import (
 	"errors"
+	"io"
 
 	"github.com/spf13/cobra"
 
 	"github.com/openyurtio/openyurt/pkg/yurtctl/cmd/yurttest/kindinit"
 )
 
-func NewCmdTest() *cobra.Command {
+func NewCmdTest(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Tools for developers to test the OpenYurt Cluster",
@@ -37,8 +38,8 @@ func NewCmdTest() *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 	}
-
-	cmd.AddCommand(kindinit.NewKindInitCMD())
+	cmd.SetOut(out)
+	cmd.AddCommand(kindinit.NewKindInitCMD(out))
 
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Congrool <chpzhangyifei@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->
/kind enhancement




#### What this PR does / why we need it:
Currently, when using `yurtctl test init`, the output message will block at "Start to create cluster with kind" until kind has finished its work.
```
I0602 18:00:28.034602 1088603 init.go:277] Start to install kind
I0602 18:00:28.037127 1088603 init.go:282] Start to prepare kind node image
I0602 18:00:28.039353 1088603 init.go:287] Start to prepare config file for kind
I0602 18:00:28.039530 1088603 init.go:292] Start to create cluster with kind
```

And after kind finishing its work, all processing messages will be printed at stdout at once.
```
I0602 01:56:20.455733   23683 kindoperator.go:97] Creating cluster "openyurt-e2e-test" ...
 • Ensuring node image (kindest/node:v1.22.7) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.22.7) 🖼
 • Preparing nodes 📦 📦   ...
 ✓ Preparing nodes 📦 📦 
 • Writing configuration 📜  ...
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Installing CNI 🔌  ...
 ✓ Installing CNI 🔌
 • Installing StorageClass 💾  ...
 ✓ Installing StorageClass 💾
 • Joining worker nodes 🚜  ...
 ✓ Joining worker nodes 🚜
Set kubectl context to "kind-openyurt-e2e-test"
You can now use your cluster with:

kubectl cluster-info --context kind-openyurt-e2e-test --kubeconfig /home/runner/.kube/config

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
```

It has duplicated messages. And it's not user-friendly to make users wait for a long time without knowing what it is doing. With this pr, the processing messages of kind will be printed to the stdout at real time.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
