### PR TITLE
bugfix: only set signer name when not nil in order to prevent panic.

### DIFF
--- a/pkg/controller/certificates/csrapprover.go
+++ b/pkg/controller/certificates/csrapprover.go
@@ -359,16 +359,22 @@ func v1Csr2v1beta1Csr(csr *certificatesv1.CertificateSigningRequest) *certificat
 }
 
 func v1beta1Csr2v1Csr(csr *certificatesv1beta1.CertificateSigningRequest) *certificatesv1.CertificateSigningRequest {
+	if csr == nil {
+		return nil
+	}
 	v1Csr := &certificatesv1.CertificateSigningRequest{
 		ObjectMeta: csr.ObjectMeta,
 		Spec: certificatesv1.CertificateSigningRequestSpec{
-			Request:    csr.Spec.Request,
-			SignerName: *csr.Spec.SignerName,
-			Usages:     make([]certificatesv1.KeyUsage, 0),
+			Request: csr.Spec.Request,
+			Usages:  make([]certificatesv1.KeyUsage, 0),
 		},
 		Status: certificatesv1.CertificateSigningRequestStatus{
 			Conditions: make([]certificatesv1.CertificateSigningRequestCondition, 0),
 		},
+	}
+
+	if csr.Spec.SignerName != nil {
+		v1Csr.Spec.SignerName = *csr.Spec.SignerName
 	}
 
 	for _, usage := range csr.Spec.Usages {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
> /sig storage

/kind bug

#### What this PR does / why we need it:
 only set signer name when not nil in order to prevent panic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
