### PR TITLE
clean redundant lint in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifneq (${https_proxy},)
 DOCKER_BUILD_ARGS += --build-arg https_proxy='${https_proxy}'
 endif
 
-.PHONY: clean all build
+.PHONY: clean all build test
 
 all: test build
 
@@ -55,17 +55,9 @@ gen-yaml:
 	hack/make-rules/genyaml.sh $(WHAT)
 
 # Run test
-test: fmt vet
+test:
 	go test -v -short ./pkg/... ./cmd/... -coverprofile cover.out
 	go test -v  -coverpkg=./pkg/yurttunnel/...  -coverprofile=yurttunnel-cover.out ./test/integration/yurttunnel_test.go
-
-# Run go fmt against code
-fmt:
-	go fmt ./pkg/... ./cmd/...
-
-# Run go vet against code
-vet:
-	go vet ./pkg/... ./cmd/...
 
 clean:
 	-rm -Rf _output


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->


#### What type of PR is this?
/kind clean



#### What this PR does / why we need it:
We have already had `vet` and `fmt` in [golangci-lint](https://github.com/openyurtio/openyurt/blob/master/.golangci.yaml#L42-L48). So we don't need to run them before running unit tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

