### PR TITLE
allow codecov to tolerate coverage rate jitter

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind enhancement


#### What this PR does / why we need it:

As we can see in #922 , there're some unforseen mistakes in our unit tests, which may result in coverage rate jitter and cause unexpected and unrelative codecov failure when submiting prs. Thus, we'd better tolerate small coverage rate drop to make contribution process more friendly.

Currently, we set the threshold as 2%. And when coverage rate drop exceeds 2%, this pr will received a failure notification from codecov.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
