### PR TITLE
fix: get proper nodename from hostname in yurtadm

### DIFF
--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -20,7 +20,6 @@ package join
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/lithammer/dedent"
@@ -40,6 +39,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
 	yurtphase "github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/phases"
 	yurtconstants "github.com/openyurtio/openyurt/pkg/yurtadm/constants"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/util/edgenode"
 	yurtadmutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/kubernetes"
 )
 
@@ -217,16 +217,11 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		ignoreErrors.Insert(opt.ignorePreflightErrors[i])
 	}
 
-	// Either use the config file if specified, or convert public kubeadm API to the internal JoinConfiguration
-	// and validates JoinConfiguration
-	name := opt.nodeName
-	if name == "" {
-		klog.V(1).Infoln("[preflight] found NodeName empty; using OS hostname as NodeName")
-		hostname, err := os.Hostname()
-		if err != nil {
-			return nil, err
-		}
-		name = hostname
+	// Either use specified nodename or get hostname from OS envs
+	name, err := edgenode.GetHostname(opt.nodeName)
+	if err != nil {
+		klog.Errorf("failed to get node name, %v", err)
+		return nil, err
 	}
 
 	data := &joinData{

--- a/pkg/yurtadm/util/edgenode/util_test.go
+++ b/pkg/yurtadm/util/edgenode/util_test.go
@@ -27,3 +27,71 @@ func Test_GetPodManifestPath(t *testing.T) {
 		t.Fatal("get path err: " + path)
 	}
 }
+
+func Test_GetHostName(t *testing.T) {
+	oldOSHost := osHostName
+	defer func() {
+		osHostName = oldOSHost
+	}()
+
+	osHostName = func() (string, error) {
+		return "test_host", nil
+	}
+
+	tests := []struct {
+		name             string
+		hostNameOverride string
+		expectedHostName string
+		expectError      bool
+	}{
+		{
+			"host name with upper case character",
+			"TEST_HOST",
+			"test_host",
+			false,
+		},
+		{
+			"host name with leading space ",
+			"    test_host",
+			"test_host",
+			false,
+		},
+		{
+			"valid host name",
+			"test_host",
+			"test_host",
+			false,
+		},
+		{
+			"invalid host name",
+			"    ",
+			"",
+			true,
+		},
+		{
+			"get from os envs",
+			"",
+			"test_host",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", test.name)
+			{
+				hostName, err := GetHostname(test.hostNameOverride)
+				if err != nil && !test.expectError {
+					t.Errorf("unexpected error: %s", err)
+				}
+				if err == nil && test.expectError {
+					t.Errorf("expected error, got none")
+				}
+				if test.expectedHostName != hostName {
+					t.Errorf("expected output %q, got %q", test.expectedHostName, hostName)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:
Currently when joining node with `yurtadm join`, it will get the nodename from `os.hostname()` directly which is problematic when hostname doesn't comply to the k8s object name specification. And this pr make this compatible with k8s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
