### PR TITLE
Use stable os/arch label when setup

### DIFF
--- a/config/setup/yurt-tunnel-agent.yaml
+++ b/config/setup/yurt-tunnel-agent.yaml
@@ -15,7 +15,7 @@ spec:
         k8s-app: yurt-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         openyurt.io/is-edge-worker: "true"
       containers:
       - command:

--- a/config/setup/yurt-tunnel-server.yaml
+++ b/config/setup/yurt-tunnel-server.yaml
@@ -190,8 +190,8 @@ spec:
       tolerations:
       - operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
         openyurt.io/is-edge-worker: "false"
       containers:
       - name: yurt-tunnel-server

--- a/config/yaml-template/yurt-tunnel-agent.yaml
+++ b/config/yaml-template/yurt-tunnel-agent.yaml
@@ -15,7 +15,7 @@ spec:
         k8s-app: __project_prefix__-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         __label_prefix__/is-edge-worker: "true"
       containers:
       - command:

--- a/config/yaml-template/yurt-tunnel-server.yaml
+++ b/config/yaml-template/yurt-tunnel-server.yaml
@@ -190,8 +190,8 @@ spec:
       tolerations:
       - operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
         __label_prefix__/is-edge-worker: "false"
       containers:
       - name: __project_prefix__-tunnel-server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:
beta.kubernetes.io/arch and beta.kubernetes.io/os labels deprecated since v1.14
use stable labels to stop show warning

#### Does this PR introduce a user-facing change?
NONE

