### PR TITLE
Separate YurtHubHost  & YurtHubProxyHost

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/openyurtio/openyurt/cmd/yurthub/app/options"
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	ipUtils "github.com/openyurtio/openyurt/pkg/util/ip"
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/discardcloudservice"
@@ -118,8 +119,8 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 	restMapperManager := meta.NewRESTMapperManager(storageManager)
 
 	hubServerAddr := net.JoinHostPort(options.YurtHubHost, options.YurtHubPort)
-	proxyServerAddr := net.JoinHostPort(options.YurtHubHost, options.YurtHubProxyPort)
-	proxySecureServerAddr := net.JoinHostPort(options.YurtHubHost, options.YurtHubProxySecurePort)
+	proxyServerAddr := net.JoinHostPort(options.YurtHubProxyHost, options.YurtHubProxyPort)
+	proxySecureServerAddr := net.JoinHostPort(options.YurtHubProxyHost, options.YurtHubProxySecurePort)
 	proxyServerDummyAddr := net.JoinHostPort(options.HubAgentDummyIfIP, options.YurtHubProxyPort)
 	proxySecureServerDummyAddr := net.JoinHostPort(options.HubAgentDummyIfIP, options.YurtHubProxySecurePort)
 	workingMode := util.WorkingMode(options.WorkingMode)
@@ -137,10 +138,11 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 	}
 
 	// use dummy ip and bind ip as cert IP SANs
-	certIPs := []net.IP{
+	certIPs := ipUtils.RemoveDupIPs([]net.IP{
 		net.ParseIP(options.HubAgentDummyIfIP),
 		net.ParseIP(options.YurtHubHost),
-	}
+		net.ParseIP(options.YurtHubProxyHost),
+	})
 
 	cfg := &YurtHubConfiguration{
 		LBMode:                            options.LBMode,

--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -41,7 +41,8 @@ const (
 // YurtHubOptions is the main settings for the yurthub
 type YurtHubOptions struct {
 	ServerAddr                string
-	YurtHubHost               string
+	YurtHubHost               string // YurtHub server host (e.g.: expose metrics API)
+	YurtHubProxyHost          string // YurtHub proxy server host
 	YurtHubPort               string
 	YurtHubProxyPort          string
 	YurtHubProxySecurePort    string
@@ -77,6 +78,7 @@ type YurtHubOptions struct {
 func NewYurtHubOptions() *YurtHubOptions {
 	o := &YurtHubOptions{
 		YurtHubHost:               "127.0.0.1",
+		YurtHubProxyHost:          "127.0.0.1",
 		YurtHubProxyPort:          util.YurtHubProxyPort,
 		YurtHubPort:               util.YurtHubPort,
 		YurtHubProxySecurePort:    util.YurtHubProxySecurePort,
@@ -131,8 +133,9 @@ func (options *YurtHubOptions) Validate() error {
 
 // AddFlags returns flags for a specific yurthub by section name
 func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.YurtHubHost, "bind-address", o.YurtHubHost, "the IP address on which to listen for the --serve-port port.")
+	fs.StringVar(&o.YurtHubHost, "bind-address", o.YurtHubHost, "the IP address of YurtHub Server")
 	fs.StringVar(&o.YurtHubPort, "serve-port", o.YurtHubPort, "the port on which to serve HTTP requests(like profiling, metrics) for hub agent.")
+	fs.StringVar(&o.YurtHubProxyHost, "bind-proxy-address", o.YurtHubProxyHost, "the IP address of YurtHub Proxy Server")
 	fs.StringVar(&o.YurtHubProxyPort, "proxy-port", o.YurtHubProxyPort, "the port on which to proxy HTTP requests to kube-apiserver")
 	fs.StringVar(&o.YurtHubProxySecurePort, "proxy-secure-port", o.YurtHubProxySecurePort, "the port on which to proxy HTTPS requests to kube-apiserver")
 	fs.StringVar(&o.ServerAddr, "server-addr", o.ServerAddr, "the address of Kubernetes kube-apiserver,the format is: \"server1,server2,...\"")

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -66,3 +66,16 @@ func JoinIPStrings(ips []net.IP) string {
 	}
 	return strings.Join(strs, ",")
 }
+
+// RemoveDupIPs removes duplicate ips from the ip list and returns a new created list
+func RemoveDupIPs(ips []net.IP) []net.IP {
+	results := make([]net.IP, 0, len(ips))
+	temp := map[string]bool{}
+	for _, ip := range ips {
+		if _, ok := temp[string(ip)]; !ok {
+			temp[string(ip)] = true
+			results = append(results, ip)
+		}
+	}
+	return results
+}

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package ip
 
 import (
+	"net"
+	"reflect"
 	"testing"
 )
 
@@ -40,5 +42,48 @@ func TestGetLoopbackIP(t *testing.T) {
 		if lo6 != "::1" {
 			t.Errorf("got ipv6 loopback addr: '%s', expect: '::1'", lo6)
 		}
+	}
+}
+
+func TestRemoveDupIPs(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalIps []net.IP
+		expectedIps []net.IP
+	}{
+		{
+			"no duplication",
+			[]net.IP{[]byte("1.1.1.1")},
+			[]net.IP{[]byte("1.1.1.1")},
+		},
+		{
+			"empty list",
+			[]net.IP{},
+			[]net.IP{},
+		},
+		{
+			"dup list",
+			[]net.IP{[]byte("1.1.1.1"), []byte("1.1.1.1")},
+			[]net.IP{[]byte("1.1.1.1")},
+		},
+		{
+			"nil list",
+			nil,
+			[]net.IP{},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			t.Logf("\tTestCase: %s", test.name)
+			{
+				get := RemoveDupIPs(test.originalIps)
+				if !reflect.DeepEqual(get, test.expectedIps) {
+					t.Errorf("\texpect %v, but get %v", test.expectedIps, get)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind enhancement


#### What this PR does / why we need it:
Currently, yurthub only have one configurable host `YurtHubHost`  for both yurthub server (metrics related API) & yurthub proxy server. The two servers served for different purposed  have  to share one host which is not resonable.

This PR separate these two, and make them both configurable by adding a new flag `bind-proxy-address` to `yurthub` cmd

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

--> 
This PR add a new cmd flag `bind-proxy-address` for `yurthub`.


```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
