### PR TITLE
fix issue 957

### DIFF
--- a/pkg/yurthub/cachemanager/cache_manager_test.go
+++ b/pkg/yurthub/cachemanager/cache_manager_test.go
@@ -428,6 +428,37 @@ func TestCacheGetResponse(t *testing.T) {
 			resource:         "nodes",
 			cacheResponseErr: true,
 		},
+		"cache response for get namespace": {
+			group:   "",
+			version: "v1",
+			key:     "kubelet/namespaces/kube-system",
+			inputObj: runtime.Object(&v1.Namespace{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Namespace",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kube-system",
+					ResourceVersion: "1",
+				},
+			}),
+			userAgent: "kubelet",
+			accept:    "application/json",
+			verb:      "GET",
+			path:      "/api/v1/namespaces/kube-system",
+			resource:  "namespaces",
+			expectResult: struct {
+				err  error
+				rv   string
+				name string
+				ns   string
+				kind string
+			}{
+				rv:   "1",
+				name: "kube-system",
+				kind: "Namespace",
+			},
+		},
 	}
 
 	accessor := meta.NewAccessor()
@@ -1268,6 +1299,59 @@ func TestCacheListResponse(t *testing.T) {
 				data map[string]struct{}
 			}{
 				data: map[string]struct{}{},
+			},
+		},
+		"list namespaces": {
+			group:   "",
+			version: "v1",
+			key:     "kubelet/namespaces",
+			inputObj: runtime.Object(
+				&v1.NamespaceList{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "NamespaceList",
+					},
+					ListMeta: metav1.ListMeta{
+						ResourceVersion: "3",
+					},
+					Items: []v1.Namespace{
+						{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "v1",
+								Kind:       "Namespace",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:            "kube-system",
+								ResourceVersion: "4",
+							},
+						},
+						{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "v1",
+								Kind:       "Namespace",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:            "default",
+								ResourceVersion: "5",
+							},
+						},
+					},
+				},
+			),
+			userAgent:  "kubelet",
+			accept:     "application/json",
+			verb:       "GET",
+			path:       "/api/v1/namespaces",
+			resource:   "namespaces",
+			namespaced: false,
+			expectResult: struct {
+				err  bool
+				data map[string]struct{}
+			}{
+				data: map[string]struct{}{
+					"namespace-kube-system-4": {},
+					"namespace-default-5":     {},
+				},
 			},
 		},
 	}

--- a/pkg/yurthub/util/util.go
+++ b/pkg/yurthub/util/util.go
@@ -282,6 +282,10 @@ func KeyFunc(comp, resource, ns, name string) (string, error) {
 		return "", fmt.Errorf("createKey: comp, resource can not be empty")
 	}
 
+	if "namespaces" == resource {
+		return filepath.Join(comp, resource, name), nil
+	}
+
 	return filepath.Join(comp, resource, ns, name), nil
 }
 

--- a/pkg/yurthub/util/util_test.go
+++ b/pkg/yurthub/util/util_test.go
@@ -132,6 +132,22 @@ func TestKeyFunc(t *testing.T) {
 			name:     "mypod1",
 			result:   expectData{key: "kubelet/pods/default/mypod1"},
 		},
+		{
+			desc:     "get namespace",
+			comp:     "kubelet",
+			resource: "namespaces",
+			ns:       "kube-system",
+			name:     "kube-system",
+			result:   expectData{key: "kubelet/namespaces/kube-system"},
+		},
+		{
+			desc:     "list namespace",
+			comp:     "kubelet",
+			resource: "namespaces",
+			ns:       "",
+			name:     "kube-system",
+			result:   expectData{key: "kubelet/namespaces/kube-system"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?
> /kind bug

#### Which issue(s) this PR fixes:
Fixes #957

#### Special notes for your reviewer:
![image](https://user-images.githubusercontent.com/40267976/185527493-4949b34d-092d-4699-a9d3-6513e4f32b9e.png)

/root/go/pkg/mod/k8s.io/apiserver@v0.22.3/pkg/endpoints/request/requestinfo.go:180

This side causes the get and list namespace to return different namespace fields in requestInfo.
But there is a problem with the resources of namespace alone. So the specific resource namespace is circumvented in the code.