### PR TITLE
keep the images of the latest version of each openyurt component consistent

### DIFF
--- a/config/setup/yurt-controller-manager.yaml
+++ b/config/setup/yurt-controller-manager.yaml
@@ -130,7 +130,7 @@ spec:
       - operator: "Exists"
       affinity:
         nodeAffinity:
-          # we prefer allocating ecm on cloud node
+          # we prefer allocating ycm on cloud node
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             preference:

--- a/config/setup/yurt-tunnel-agent.yaml
+++ b/config/setup/yurt-tunnel-agent.yaml
@@ -25,7 +25,6 @@ spec:
         - --node-ip=$(POD_IP)
         - --v=2
         image: openyurt/yurt-tunnel-agent:latest
-        imagePullPolicy: IfNotPresent
         name: yurt-tunnel-agent
         volumeMounts:
         - name: k8s-dir

--- a/config/setup/yurt-tunnel-dns.yaml
+++ b/config/setup/yurt-tunnel-dns.yaml
@@ -127,7 +127,6 @@ spec:
       containers:
         - name: yurt-tunnel-dns
           image: coredns/coredns:1.9.3
-          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 170Mi

--- a/config/setup/yurt-tunnel-server.yaml
+++ b/config/setup/yurt-tunnel-server.yaml
@@ -196,7 +196,6 @@ spec:
       containers:
       - name: yurt-tunnel-server
         image: openyurt/yurt-tunnel-server:latest
-        imagePullPolicy: IfNotPresent
         command:
         - yurt-tunnel-server
         args:

--- a/config/setup/yurthub.yaml
+++ b/config/setup/yurthub.yaml
@@ -22,7 +22,6 @@ spec:
   containers:
   - name: yurt-hub
     image: openyurt/yurthub:latest
-    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: hub-dir
       mountPath: /var/lib/yurthub

--- a/config/yaml-template/yurt-controller-manager.yaml
+++ b/config/yaml-template/yurt-controller-manager.yaml
@@ -130,7 +130,7 @@ spec:
       - operator: "Exists"
       affinity:
         nodeAffinity:
-          # we prefer allocating ecm on cloud node
+          # we prefer allocating ycm on cloud node
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             preference:

--- a/config/yaml-template/yurt-tunnel-agent.yaml
+++ b/config/yaml-template/yurt-tunnel-agent.yaml
@@ -25,7 +25,6 @@ spec:
         - --node-ip=$(POD_IP)
         - --v=2
         image: __repo__/__project_prefix__-tunnel-agent:__tag__
-        imagePullPolicy: IfNotPresent
         name: __project_prefix__-tunnel-agent
         volumeMounts:
         - name: k8s-dir

--- a/config/yaml-template/yurt-tunnel-server.yaml
+++ b/config/yaml-template/yurt-tunnel-server.yaml
@@ -196,7 +196,6 @@ spec:
       containers:
       - name: __project_prefix__-tunnel-server
         image: __repo__/__project_prefix__-tunnel-server:__tag__
-        imagePullPolicy: IfNotPresent
         command:
         - __project_prefix__-tunnel-server
         args:

--- a/config/yaml-template/yurthub.yaml
+++ b/config/yaml-template/yurthub.yaml
@@ -22,7 +22,6 @@ spec:
   containers:
   - name: __project_prefix__-hub
     image: __repo__/__project_prefix__hub:__tag__
-    imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: hub-dir
       mountPath: /var/lib/yurthub


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug
#### What this PR does / why we need it:

Ensure that the images of the latest version of each openyurt component pulled are always consistent.

Since we post images to dockerhub every day, in the process of deploying openyurt, we often encounter the problem that the 
 latest versions of these openyurt components are inconsistent, such as issue #940. The main reason may be that the imagePullPolicy of some components is `Always`, where others are `IfNotPresent`.
