### PR TITLE
feature: add lantency metrics for yurthub

### DIFF
--- a/pkg/yurthub/proxy/proxy.go
+++ b/pkg/yurthub/proxy/proxy.go
@@ -109,6 +109,7 @@ func (p *yurtReverseProxy) buildHandlerChain(handler http.Handler) http.Handler 
 	if p.cacheMgr != nil {
 		handler = util.WithListRequestSelector(handler)
 	}
+	handler = util.WithRequestTraceFull(handler)
 	handler = util.WithMaxInFlightLimit(handler, p.maxRequestsInFlight)
 	handler = util.WithRequestClientComponent(handler)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
The latency collector is used to collect yurthub request latency metrics, and the latency metrics can be  divided into two categories:
- **apiserver_latency**:  requests forward by proxy server -> api server ->  received by proxy server
- **full_latency**:  requests comming to proxy server -> processing by proxy server -> api server -> received by proxy server -> proxy server handling 


#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
The full latency start recording after [inflight requests limits has been applied](https://github.com/openyurtio/openyurt/blob/277c2ebe19763e89a637dabca49f6e482bef6cf2/pkg/yurthub/proxy/proxy.go#L112), because latency of blocked requests is of no use. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
