### PR TITLE
beta.kubernetes.io is deprecated, use kubernetes.io instead

### DIFF
--- a/charts/openyurt/templates/yurt-tunnel-agent.yaml
+++ b/charts/openyurt/templates/yurt-tunnel-agent.yaml
@@ -14,7 +14,7 @@ spec:
         k8s-app: yurt-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         openyurt.io/is-edge-worker: "true"
       containers:
       - command:

--- a/charts/openyurt/templates/yurt-tunnel-server.yaml
+++ b/charts/openyurt/templates/yurt-tunnel-server.yaml
@@ -189,8 +189,8 @@ spec:
       tolerations:
         - operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
         openyurt.io/is-edge-worker: "false"
       containers:
         - name: yurt-tunnel-server

--- a/config/setup/yurt-tunnel-agent.yaml
+++ b/config/setup/yurt-tunnel-agent.yaml
@@ -15,7 +15,7 @@ spec:
         k8s-app: yurt-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         openyurt.io/is-edge-worker: "true"
       containers:
       - command:

--- a/config/setup/yurt-tunnel-server.yaml
+++ b/config/setup/yurt-tunnel-server.yaml
@@ -190,8 +190,8 @@ spec:
       tolerations:
       - operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
         openyurt.io/is-edge-worker: "false"
       containers:
       - name: yurt-tunnel-server

--- a/config/yaml-template/yurt-tunnel-agent.yaml
+++ b/config/yaml-template/yurt-tunnel-agent.yaml
@@ -15,7 +15,7 @@ spec:
         k8s-app: __project_prefix__-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         __label_prefix__/is-edge-worker: "true"
       containers:
       - command:

--- a/config/yaml-template/yurt-tunnel-server.yaml
+++ b/config/yaml-template/yurt-tunnel-server.yaml
@@ -190,8 +190,8 @@ spec:
       tolerations:
       - operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
-        beta.kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
         __label_prefix__/is-edge-worker: "false"
       containers:
       - name: __project_prefix__-tunnel-server

--- a/pkg/yurtctl/constants/yurt-app-manager-tmpl.go
+++ b/pkg/yurtctl/constants/yurt-app-manager-tmpl.go
@@ -680,7 +680,7 @@ spec:
           readOnly: true
       nodeSelector:
         openyurt.io/is-edge-worker: "false"
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-node-critical
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/pkg/yurtctl/constants/yurt-tunnel-agent-tmpl.go
+++ b/pkg/yurtctl/constants/yurt-tunnel-agent-tmpl.go
@@ -35,7 +35,7 @@ spec:
         k8s-app: yurt-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         {{.edgeWorkerLabel}}: "true"
       containers:
       - command:

--- a/pkg/yurtctl/constants/yurt-tunnel-server-tmpl.go
+++ b/pkg/yurtctl/constants/yurt-tunnel-server-tmpl.go
@@ -221,7 +221,7 @@ spec:
       tolerations:
       - operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         {{.edgeWorkerLabel}}: "false"
       containers:
       - name: yurt-tunnel-server


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

deprecated resource should not be used to avoid warning.

#### Which issue(s) this PR fixes:

avoid the following deprecation warning.

```bash
root@tomoyafujita:~/openyurt# kubectl apply -f config/setup/yurt-tunnel-server.yaml
clusterrole.rbac.authorization.k8s.io/tunnel-proxy-client created
clusterrolebinding.rbac.authorization.k8s.io/tunnel-proxy-client created
clusterrole.rbac.authorization.k8s.io/yurt-tunnel-server created
clusterrolebinding.rbac.authorization.k8s.io/yurt-tunnel-server created
serviceaccount/yurt-tunnel-server created
service/x-tunnel-server-svc created
service/x-tunnel-server-internal-svc created
configmap/yurt-tunnel-server-cfg created
Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/arch]: deprecated since v1.14; use "kubernetes.io/arch" instead
Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
deployment.apps/yurt-tunnel-server created
```

#### Special notes for your reviewer:

N.A

#### Does this PR introduce a user-facing change?

None
