### PR TITLE
[enhancement] enable `yurtctl test init` to install cluster without default kindnet

### DIFF
--- a/hack/make-rules/local-up-openyurt.sh
+++ b/hack/make-rules/local-up-openyurt.sh
@@ -31,7 +31,9 @@
 # KUBERNETESVERSION
 # KUBERNETESVERSION declares the kubernetes version the cluster will use. The format is "v1.XX". 
 # Now only v1.17, v1.18, v1.19, v1.20 v1.21 v1.22 and v1.23 are supported. The default value is v1.22.
-
+#
+# DISABLE_DEFAULT_CNI
+# If set to be true, the default cni, kindnet, will not be installed in the cluster.
 
 set -x
 set -e
@@ -64,6 +66,7 @@ readonly CLUSTER_NAME="openyurt-e2e-test"
 readonly KUBERNETESVERSION=${KUBERNETESVERSION:-"v1.22"}
 readonly NODES_NUM=${NODES_NUM:-2}
 readonly KIND_KUBECONFIG=${KIND_KUBECONFIG:-${HOME}/.kube/config}
+readonly DISABLE_DEFAULT_CNI=${DISABLE_DEFAULT_CNI:-"false"}
 ENABLE_DUMMY_IF=true
 if [[ "${LOCAL_OS}" == darwin ]]; then
   ENABLE_DUMMY_IF=false
@@ -113,7 +116,7 @@ function local_up_openyurt {
     ${YURT_LOCAL_BIN_DIR}/${LOCAL_OS}/${LOCAL_ARCH}/yurtctl test init \
       --kubernetes-version=${KUBERNETESVERSION} --kube-config=${KIND_KUBECONFIG} \
       --cluster-name=${CLUSTER_NAME} --openyurt-version=${YURT_VERSION} --use-local-images --ignore-error \
-      --node-num=${NODES_NUM} --enable-dummy-if=${ENABLE_DUMMY_IF}
+      --node-num=${NODES_NUM} --enable-dummy-if=${ENABLE_DUMMY_IF} --disable-default-cni=${DISABLE_DEFAULT_CNI}
 }
 
 function cleanup {

--- a/pkg/yurtctl/cmd/yurttest/kindinit/init_test.go
+++ b/pkg/yurtctl/cmd/yurttest/kindinit/init_test.go
@@ -111,10 +111,11 @@ func TestValidateOpenYurtVersion(t *testing.T) {
 func TestPrepareConfigFile(t *testing.T) {
 	var nodeImage = "kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
 	cases := map[string]struct {
-		clusterName    string
-		nodesNum       int
-		kindConfigPath string
-		want           string
+		clusterName       string
+		nodesNum          int
+		kindConfigPath    string
+		disableDefaultCNI bool
+		want              string
 	}{
 		"one node": {
 			clusterName:    "case1",
@@ -123,6 +124,8 @@ func TestPrepareConfigFile(t *testing.T) {
 			want: `apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 name: case1
+networking:
+  disableDefaultCNI: false
 nodes:
   - role: control-plane
     image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9`,
@@ -134,6 +137,24 @@ nodes:
 			want: `apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 name: case2
+networking:
+  disableDefaultCNI: false
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+  - role: worker
+    image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9`,
+		},
+		"disable default cni": {
+			clusterName:       "case3",
+			nodesNum:          2,
+			kindConfigPath:    "/tmp/prepareConfigFile.case3",
+			disableDefaultCNI: true,
+			want: `apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+name: case3
+networking:
+  disableDefaultCNI: true
 nodes:
   - role: control-plane
     image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
@@ -145,10 +166,11 @@ nodes:
 		initializer := newKindInitializer(
 			os.Stdout,
 			&initializerConfig{
-				ClusterName:    c.clusterName,
-				NodesNum:       c.nodesNum,
-				KindConfigPath: c.kindConfigPath,
-				NodeImage:      nodeImage,
+				ClusterName:       c.clusterName,
+				NodesNum:          c.nodesNum,
+				KindConfigPath:    c.kindConfigPath,
+				DisableDefaultCNI: c.disableDefaultCNI,
+				NodeImage:         nodeImage,
 			},
 		)
 		defer os.Remove(c.kindConfigPath)

--- a/pkg/yurtctl/constants/openyurt-kindconfig-tmpl.go
+++ b/pkg/yurtctl/constants/openyurt-kindconfig-tmpl.go
@@ -20,6 +20,8 @@ const (
 	OpenYurtKindConfig = `apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 name: {{.cluster_name}}
+networking:
+  disableDefaultCNI: {{.disable_default_cni}}
 nodes:
   - role: control-plane
     image: {{.kind_node_image}}`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

/kind enhancement


#### What this PR does / why we need it:

Sometimes, we does not want the default cni kindnet to be installed in the cluster. For example, if we want to test other cni like flannel or calico to check if them can be compatible with openyurt, we need to uninstall the kindnet first and then install the cni we want. It's not such a easy job. This pr provides a way for users to install kind cluster without any pre-installed CNI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
