### PR TITLE
[Fix] trim suffix new line when getting gopath

### DIFF
--- a/pkg/yurtctl/cmd/yurttest/kindinit/kindoperator.go
+++ b/pkg/yurtctl/cmd/yurttest/kindinit/kindoperator.go
@@ -164,11 +164,12 @@ func (k *KindOperator) goMinorVersion() (int, error) {
 }
 
 func getGoBinPath() (string, error) {
-	gopath, err := exec.Command("bash", "-c", "go env GOPATH").CombinedOutput()
+	buf, err := exec.Command("bash", "-c", "go env GOPATH").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to get GOPATH, %w", err)
 	}
-	return filepath.Join(string(gopath), "bin"), nil
+	gopath := strings.TrimSuffix(string(buf), "\n")
+	return filepath.Join(gopath, "bin"), nil
 }
 
 func checkIfKindAt(path string) (bool, string) {

--- a/pkg/yurtctl/cmd/yurttest/kindinit/kindoperator_test.go
+++ b/pkg/yurtctl/cmd/yurttest/kindinit/kindoperator_test.go
@@ -197,10 +197,7 @@ func fakeExeCommand(string, ...string) *exec.Cmd {
 
 func TestGetGoBinPath(t *testing.T) {
 	gopath, err := getGoBinPath()
-	if err != nil {
-		t.Errorf("failed to get GOPATH")
-	}
-	if find := strings.Contains(gopath, "/go") && strings.Contains(gopath, "/bin"); !find {
+	if gopath == "" || err != nil {
 		t.Errorf("failed to get GOPATH")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

When `exec.Command("base", "-c", "go env GOPATH")`, the path it returns looks like `"/home/ys3/.gvm/pkgsets/system/global\n"`, while the suffix `\n` we do not need.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
