### PR TITLE
feature: yurtadm join add yurthubserveraddr para

### DIFF
--- a/pkg/node-servant/components/yurthub.go
+++ b/pkg/node-servant/components/yurthub.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openyurtio/openyurt/pkg/util/templates"
+	constants "github.com/openyurtio/openyurt/pkg/yurtadm/constants"
 	enutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/edgenode"
 	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/hubself"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
@@ -74,6 +75,7 @@ func (op *yurtHubOperator) Install() error {
 	// 1-1. replace variables in yaml file
 	klog.Infof("setting up yurthub apiServer addr")
 	yurthubTemplate, err := templates.SubsituteTemplate(enutil.YurthubTemplate, map[string]string{
+		"yurthubServerAddr":    constants.DefaultYurtHubServerAddr,
 		"kubernetesServerAddr": op.apiServerAddr,
 		"image":                op.yurthubImage,
 		"joinToken":            op.joinToken,

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -72,7 +72,7 @@ func RemoveDupIPs(ips []net.IP) []net.IP {
 	results := make([]net.IP, 0, len(ips))
 	temp := map[string]bool{}
 	for _, ip := range ips {
-		if _, ok := temp[string(ip)]; !ok {
+		if _, ok := temp[string(ip)]; ip != nil && !ok {
 			temp[string(ip)] = true
 			results = append(results, ip)
 		}

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -71,6 +71,11 @@ func TestRemoveDupIPs(t *testing.T) {
 			nil,
 			[]net.IP{},
 		},
+		{
+			"nil ip",
+			[]net.IP{[]byte("1.1.1.1"), nil},
+			[]net.IP{[]byte("1.1.1.1")},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -67,6 +67,7 @@ type joinOptions struct {
 	ignorePreflightErrors    []string
 	nodeLabels               string
 	kubernetesResourceServer string
+	yurthubServer            string
 }
 
 // newJoinOptions returns a struct ready for being used for creating cmd join flags.
@@ -80,6 +81,7 @@ func newJoinOptions() *joinOptions {
 		unsafeSkipCAVerification: false,
 		ignorePreflightErrors:    make([]string, 0),
 		kubernetesResourceServer: yurtconstants.DefaultKubernetesResourceServer,
+		yurthubServer:            yurtconstants.DefaultYurtHubServerAddr,
 	}
 }
 
@@ -165,6 +167,10 @@ func addJoinConfigFlags(flagSet *flag.FlagSet, joinOptions *joinOptions) {
 		&joinOptions.kubernetesResourceServer, yurtconstants.KubernetesResourceServer, joinOptions.kubernetesResourceServer,
 		"Sets the address for downloading k8s node resources",
 	)
+	flagSet.StringVar(
+		&joinOptions.yurthubServer, yurtconstants.YurtHubServerAddr, joinOptions.yurthubServer,
+		"Sets the address for yurthub server addr",
+	)
 }
 
 type joinData struct {
@@ -181,6 +187,7 @@ type joinData struct {
 	caCertHashes             sets.String
 	nodeLabels               map[string]string
 	kubernetesResourceServer string
+	yurthubServer            string
 }
 
 // newJoinData returns a new joinData struct to be used for the execution of the kubeadm join workflow.
@@ -233,6 +240,7 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		ignorePreflightErrors: ignoreErrors,
 		pauseImage:            opt.pauseImage,
 		yurthubImage:          opt.yurthubImage,
+		yurthubServer:         opt.yurthubServer,
 		caCertHashes:          sets.NewString(opt.caCertHashes...),
 		organizations:         opt.organizations,
 		nodeLabels:            make(map[string]string),
@@ -303,6 +311,11 @@ func (j *joinData) PauseImage() string {
 // YurtHubImage returns the YurtHub image.
 func (j *joinData) YurtHubImage() string {
 	return j.yurthubImage
+}
+
+// YurtHubServer returns the YurtHub server addr.
+func (j *joinData) YurtHubServer() string {
+	return j.yurthubServer
 }
 
 // KubernetesVersion returns the kubernetes version.

--- a/pkg/yurtadm/cmd/join/joindata/data.go
+++ b/pkg/yurtadm/cmd/join/joindata/data.go
@@ -34,6 +34,7 @@ type YurtJoinData interface {
 	JoinToken() string
 	PauseImage() string
 	YurtHubImage() string
+	YurtHubServer() string
 	KubernetesVersion() string
 	TLSBootstrapCfg() *clientcmdapi.Config
 	BootstrapClient() *clientset.Clientset

--- a/pkg/yurtadm/cmd/join/phases/joinnode.go
+++ b/pkg/yurtadm/cmd/join/phases/joinnode.go
@@ -183,6 +183,7 @@ func addYurthubStaticYaml(data joindata.YurtJoinData, podManifestPath string) er
 		"joinToken":            data.JoinToken(),
 		"workingMode":          data.NodeRegistration().WorkingMode,
 		"organizations":        data.NodeRegistration().Organizations,
+		"yurthubServerAddr":    data.YurtHubServer(),
 	}
 
 	yurthubTemplate, err := templates.SubsituteTemplate(edgenode.YurthubTemplate, ctx)

--- a/pkg/yurtadm/cmd/join/phases/postcheck.go
+++ b/pkg/yurtadm/cmd/join/phases/postcheck.go
@@ -63,7 +63,7 @@ func runPostCheck(c workflow.RunData) error {
 	klog.V(1).Infof("kubelet service is active")
 
 	klog.V(1).Infof("waiting hub agent ready.")
-	if err := checkYurthubHealthz(); err != nil {
+	if err := checkYurthubHealthz(j); err != nil {
 		return err
 	}
 	klog.V(1).Infof("hub agent is ready")
@@ -85,8 +85,8 @@ func checkKubeletStatus() error {
 }
 
 //checkYurthubHealthz check if YurtHub is healthy.
-func checkYurthubHealthz() error {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", edgenode.ServerHealthzServer, edgenode.ServerHealthzURLPath), nil)
+func checkYurthubHealthz(joinData joindata.YurtJoinData) error {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", joinData.YurtHubServer()), edgenode.ServerHealthzURLPath), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -52,6 +52,7 @@ const (
 	YurtTunnelServer             = "yurt-tunnel-server"
 	YurtTunnelAgent              = "yurt-tunnel-agent"
 	Yurthub                      = "yurthub"
+	DefaultYurtHubServerAddr     = "127.0.0.1"
 	YurtAppManager               = "yurt-app-manager"
 	YurtAppManagerNamespace      = "kube-system"
 	DirMode                      = 0755

--- a/pkg/yurtadm/constants/join_options.go
+++ b/pkg/yurtadm/constants/join_options.go
@@ -35,4 +35,7 @@ const (
 
 	// KubernetesResourceServer flag sets the address for download k8s node resources.
 	KubernetesResourceServer = "kubernetes-resource-server"
+
+	// YurtHubServerAddr flag set the address of yurthub server (not proxy server!)
+	YurtHubServerAddr = "yurthub-server-addr"
 )

--- a/pkg/yurtadm/util/edgenode/common.go
+++ b/pkg/yurtadm/util/edgenode/common.go
@@ -87,6 +87,7 @@ spec:
     command:
     - yurthub
     - --v=2
+    - --bind-address={{.yurthubServerAddr}}
     - --server-addr={{.kubernetesServerAddr}}
     - --node-name=$(NODE_NAME)
     - --join-token={{.joinToken}}
@@ -102,7 +103,7 @@ spec:
       {{end}}
     livenessProbe:
       httpGet:
-        host: 127.0.0.1
+        host: {{.yurthubServerAddr}}
         path: /v1/healthz
         port: 10267
       initialDelaySeconds: 300


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:
When using `yurtadm join`, currently it's set as `127.0.0.1` as default. This PR adds an extra parameter `yurthubServerAddr` to make this configurable. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Add an extra parameter `yurthubServerAddr` for `yurtadm join` command
```