### PR TITLE
Docs: replace guide link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To experience the power of OpenYurt, please try the detailed [tutorials](https:/
 ### Contributing
 
 If you are willing to be a contributor for the OpenYurt project, please refer to our [CONTRIBUTING](CONTRIBUTING.md) document for details.
-We have also prepared a developer [guide](./docs/developer-guide.md) to help the code contributors.
+We have also prepared a developer [guide](https://openyurt.io/docs/developer-manuals/how-to-contribute) to help the code contributors.
 
 ### Meeting
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -76,7 +76,7 @@ OpenYurt官网提供详细的[教程](https://openyurt.io/docs/next/)来演示�
 
 ## 社区
 ### 贡献
-如果您愿意为 OpenYurt 项目做贡献，请参阅我们的 [CONTRIBUTING](CONTRIBUTING.md) 文档以获取详细信息。我们还准备了开发人员指南来帮助代码贡献者。
+如果您愿意为 OpenYurt 项目做贡献，请参阅我们的 [CONTRIBUTING](CONTRIBUTING.md) 文档以获取详细信息。我们还准备了[开发人员指南](https://openyurt.io/docs/developer-manuals/how-to-contribute)来帮助代码贡献者。
 
 ### 周会
 


### PR DESCRIPTION
Signed-off-by: Lancelot <1984737645@qq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> /kind documentation

/kind documentation
#### What this PR does / why we need it:
In the README.md, developer guide link can not be accessed.And current master branch does not have developer-guide.md.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1041 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
