### PR TITLE
bugfix: non resource handle miss for coredns

### DIFF
--- a/pkg/yurthub/certificate/hubself/fake_cert_mgr.go
+++ b/pkg/yurthub/certificate/hubself/fake_cert_mgr.go
@@ -58,7 +58,7 @@ e35EltCRCjoejRHTuN9TC0uCoVipAiAXaJIx/Q47vGwiw6Y8KXsNU6y54gTbOSxX
 -----END RSA PRIVATE KEY-----`
 )
 
-type fakeYurtHubCertManager struct {
+type FakeYurtHubCertManager struct {
 	certificatePEM   string
 	keyPEM           string
 	rootDir          string
@@ -84,7 +84,7 @@ func NewFakeYurtHubCertManager(rootDir, yurthubConfigFile, certificatePEM, keyPE
 		rd = filepath.Join(HubRootDir, hn)
 	}
 
-	fyc := &fakeYurtHubCertManager{
+	fyc := &FakeYurtHubCertManager{
 		certificatePEM:   certificatePEM,
 		keyPEM:           keyPEM,
 		rootDir:          rd,
@@ -96,7 +96,7 @@ func NewFakeYurtHubCertManager(rootDir, yurthubConfigFile, certificatePEM, keyPE
 }
 
 // Start create the yurthub.conf file
-func (fyc *fakeYurtHubCertManager) Start() {
+func (fyc *FakeYurtHubCertManager) Start() {
 	dStorage, err := disk.NewDiskStorage(fyc.rootDir)
 	if err != nil {
 		klog.Errorf("failed to create storage, %v", err)
@@ -110,10 +110,10 @@ func (fyc *fakeYurtHubCertManager) Start() {
 }
 
 // Stop do nothing
-func (fyc *fakeYurtHubCertManager) Stop() {}
+func (fyc *FakeYurtHubCertManager) Stop() {}
 
 // Current returns the certificate created by the entered fyc.certificatePEM and fyc.keyPEM
-func (fyc *fakeYurtHubCertManager) Current() *tls.Certificate {
+func (fyc *FakeYurtHubCertManager) Current() *tls.Certificate {
 	certificate, err := tls.X509KeyPair([]byte(fyc.certificatePEM), []byte(fyc.keyPEM))
 	if err != nil {
 		panic(fmt.Sprintf("Unable to initialize certificate: %v", err))
@@ -128,31 +128,31 @@ func (fyc *fakeYurtHubCertManager) Current() *tls.Certificate {
 }
 
 // ServerHealthy returns true
-func (fyc *fakeYurtHubCertManager) ServerHealthy() bool {
+func (fyc *FakeYurtHubCertManager) ServerHealthy() bool {
 	return true
 }
 
 // Update do nothing
-func (fyc *fakeYurtHubCertManager) Update(_ *config.YurtHubConfiguration) error {
+func (fyc *FakeYurtHubCertManager) Update(_ *config.YurtHubConfiguration) error {
 	return nil
 }
 
 // GetCaFile returns the empty path
-func (fyc *fakeYurtHubCertManager) GetCaFile() string {
+func (fyc *FakeYurtHubCertManager) GetCaFile() string {
 	return ""
 }
 
 // GetConfFilePath returns the path of yurtHub config file path
-func (fyc *fakeYurtHubCertManager) GetConfFilePath() string {
+func (fyc *FakeYurtHubCertManager) GetConfFilePath() string {
 	return fyc.getHubConfFile()
 }
 
 // NotExpired returns true
-func (fyc *fakeYurtHubCertManager) NotExpired() bool {
+func (fyc *FakeYurtHubCertManager) NotExpired() bool {
 	return fyc.Current() != nil
 }
 
 // getHubConfFile returns the path of hub agent conf file.
-func (fyc *fakeYurtHubCertManager) getHubConfFile() string {
+func (fyc *FakeYurtHubCertManager) getHubConfFile() string {
 	return filepath.Join(fyc.rootDir, fmt.Sprintf(hubConfigFileName, fyc.hubName))
 }

--- a/pkg/yurthub/server/certificate_test.go
+++ b/pkg/yurthub/server/certificate_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/certificate/hubself"
+)
+
+func TestUpdateTokenHandler(t *testing.T) {
+	certMgr := &hubself.FakeYurtHubCertManager{}
+
+	testcases := map[string]struct {
+		body       map[string]string
+		statusCode int
+	}{
+		"failed to update join token": {
+			body:       map[string]string{},
+			statusCode: http.StatusBadRequest,
+		},
+		"update join token normally": {
+			body: map[string]string{
+				tokenKey: "123456",
+			},
+			statusCode: http.StatusOK,
+		},
+	}
+
+	for k, tt := range testcases {
+		t.Run(k, func(t *testing.T) {
+			body, _ := json.Marshal(tt.body)
+			req, err := http.NewRequest("POST", "", bytes.NewReader(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp := httptest.NewRecorder()
+			updateTokenHandler(certMgr).ServeHTTP(resp, req)
+
+			if resp.Code != tt.statusCode {
+				t.Errorf("expect status code %d, but got %d", tt.statusCode, resp.Code)
+			}
+		})
+	}
+}

--- a/pkg/yurthub/server/nonresource_test.go
+++ b/pkg/yurthub/server/nonresource_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The OpenYurt Authors.
+Copyright 2022 The OpenYurt Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,19 +17,113 @@ limitations under the License.
 package server
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
+	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakerest "k8s.io/client-go/rest/fake"
+
+	"github.com/openyurtio/openyurt/cmd/yurthub/app/config"
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+	"github.com/openyurtio/openyurt/pkg/yurthub/healthchecker"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/rest"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
 )
 
 var rootDir = "/tmp/cache-local"
 
-func TestNonResourceInfoCache(t *testing.T) {
+func TestLocalCacheHandler(t *testing.T) {
+	dStorage, err := disk.NewDiskStorage(rootDir)
+	if err != nil {
+		t.Errorf("disk initialize error: %v", err)
+	}
+
+	sw := cachemanager.NewStorageWrapper(dStorage)
+	u, _ := url.Parse("https://10.10.10.113:6443")
+	fakeHealthChecker := healthchecker.NewFakeChecker(false, nil)
+	cfg := &config.YurtHubConfiguration{
+		RemoteServers: []*url.URL{u},
+	}
+
+	rcm, err := rest.NewRestConfigManager(cfg, nil, fakeHealthChecker)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testcases := map[string]struct {
+		path             string
+		initData         []byte
+		statusCode       int
+		metav1StatusCode int
+	}{
+		"failed to get from local cache": {
+			path:             "/version",
+			initData:         []byte{},
+			statusCode:       http.StatusOK,
+			metav1StatusCode: http.StatusInternalServerError,
+		},
+		"get from local cache normally": {
+			path:       "/version",
+			initData:   []byte("v1.0.0"),
+			statusCode: http.StatusOK,
+		},
+	}
+
+	for k, tt := range testcases {
+		t.Run(k, func(t *testing.T) {
+			key := fmt.Sprintf("non-reosurce-info%s", tt.path)
+			sw.UpdateRaw(key, tt.initData)
+
+			req, err := http.NewRequest("GET", "", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp := httptest.NewRecorder()
+			localCacheHandler(nonResourceHandler, rcm, sw, tt.path).ServeHTTP(resp, req)
+
+			if resp.Code != tt.statusCode {
+				t.Errorf("expect status code %d, but got %d", tt.statusCode, resp.Code)
+			}
+
+			b, _ := ioutil.ReadAll(resp.Body)
+			if tt.metav1StatusCode != 0 {
+				var status metav1.Status
+				err := json.Unmarshal(b, &status)
+				if err != nil {
+					t.Errorf("failed to unmarshal response, %v", err)
+				}
+
+				if int(status.Code) != tt.metav1StatusCode {
+					t.Errorf("expect metav1 status code %d, but got %d", tt.metav1StatusCode, status.Code)
+				}
+
+			} else {
+				if !bytes.Equal(b, tt.initData) {
+					t.Errorf("expect response data %v, but got %v", tt.initData, b)
+				}
+
+			}
+
+			if err := sw.Delete(key); err != nil {
+				t.Errorf("failed to remove %s, %v", key, err)
+			}
+		})
+	}
+}
+
+func TestNonResourceHandler(t *testing.T) {
 	dStorage, err := disk.NewDiskStorage(rootDir)
 	if err != nil {
 		t.Errorf("disk initialize error: %v", err)
@@ -38,83 +132,78 @@ func TestNonResourceInfoCache(t *testing.T) {
 	sw := cachemanager.NewStorageWrapper(dStorage)
 
 	testcases := map[string]struct {
-		Accept      string
-		Verb        string
-		Path        string
-		Code        int
-		ContentType string
-		Response    string
+		path             string
+		initData         []byte
+		err              error
+		statusCode       int
+		metav1StatusCode int
 	}{
-		"version info": {
-			Accept:      "application/json",
-			Verb:        "GET",
-			Path:        "/version",
-			Code:        http.StatusOK,
-			ContentType: "application/json",
-			Response:    "fake-non-resource-info-/version",
+		"get non resource normally": {
+			path:       "/apis/discovery.k8s.io/v1",
+			initData:   []byte("fake resource"),
+			statusCode: http.StatusOK,
 		},
-
-		"discovery v1": {
-			Accept:      "application/json",
-			Verb:        "GET",
-			Path:        "/apis/discovery.k8s.io/v1",
-			Code:        http.StatusOK,
-			ContentType: "application/json",
-			Response:    "fake-non-resource-info-/apis/discovery.k8s.io/v1",
-		},
-		"discovery v1beta1": {
-			Accept:      "application/json",
-			Verb:        "GET",
-			Path:        "/apis/discovery.k8s.io/v1beta1",
-			Code:        http.StatusOK,
-			ContentType: "application/json",
-			Response:    "fake-non-resource-info-/apis/discovery.k8s.io/v1beta1",
+		"failed to get non resource": {
+			path:             "/apis/discovery.k8s.io/v1beta1",
+			err:              errors.New("fake error"),
+			statusCode:       http.StatusOK,
+			metav1StatusCode: http.StatusInternalServerError,
 		},
 	}
 
 	for k, tt := range testcases {
-		//test for caching the response
 		t.Run(k, func(t *testing.T) {
-			var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				cacheNonResourceInfo(w, req, sw, fmt.Sprintf("non-reosurce-info%s", req.URL.Path), req.URL.Path, true)
-			})
-			req, _ := http.NewRequest(tt.Verb, tt.Path, nil)
-			if len(tt.Accept) != 0 {
-				req.Header.Set("Accept", tt.Accept)
+			fakeClient := &fakerest.RESTClient{
+				Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+					if tt.err == nil {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       ioutil.NopCloser(strings.NewReader(string(tt.initData))),
+						}, nil
+					} else {
+						return nil, tt.err
+					}
+				}),
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				GroupVersion:         schema.GroupVersion{Group: "discovery.k8s.io", Version: "v1"},
+				VersionedAPIPath:     tt.path,
+			}
+			var kubeClient kubernetes.Clientset
+			kubeClient.DiscoveryClient = discovery.NewDiscoveryClient(fakeClient)
+
+			req, err := http.NewRequest("GET", "", nil)
+			if err != nil {
+				t.Fatal(err)
 			}
 			resp := httptest.NewRecorder()
-			handler.ServeHTTP(resp, req)
-			result := resp.Result()
-			if result.StatusCode != tt.Code {
-				t.Errorf("got status code %d, but expect %d", result.StatusCode, tt.Code)
-			}
-			if string(resp.Body.Bytes()) != tt.Response {
-				t.Errorf("got response %s, but expect %s", string(resp.Body.Bytes()), tt.Response)
+			nonResourceHandler(&kubeClient, sw, tt.path).ServeHTTP(resp, req)
+
+			if resp.Code != tt.statusCode {
+				t.Errorf("expect status code %d, but got %d", tt.statusCode, resp.Code)
 			}
 
-		})
+			b, _ := ioutil.ReadAll(resp.Body)
+			if tt.metav1StatusCode != 0 {
+				var status metav1.Status
+				err := json.Unmarshal(b, &status)
+				if err != nil {
+					t.Errorf("failed to unmarshal response, %v", err)
+				}
 
-		//test for query the cache
-		t.Run(k, func(t *testing.T) {
-			var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				cacheNonResourceInfo(w, req, sw, fmt.Sprintf("non-reosurce-info%s", req.URL.Path), req.URL.Path, false)
-			})
-			req, _ := http.NewRequest(tt.Verb, tt.Path, nil)
-			if len(tt.Accept) != 0 {
-				req.Header.Set("Accept", tt.Accept)
-			}
-			resp := httptest.NewRecorder()
-			handler.ServeHTTP(resp, req)
-			result := resp.Result()
-			if result.StatusCode != tt.Code {
-				t.Errorf("got status code %d, but expect %d", result.StatusCode, tt.Code)
-			}
-			if string(resp.Body.Bytes()) != tt.Response {
-				t.Errorf("got response %s, but expect %s", string(resp.Body.Bytes()), tt.Response)
+				if int(status.Code) != tt.metav1StatusCode {
+					t.Errorf("expect metav1 status code %d, but got %d", tt.metav1StatusCode, status.Code)
+				}
+
+			} else {
+				if !bytes.Equal(b, tt.initData) {
+					t.Errorf("expect response data %v, but got %v", tt.initData, b)
+				}
 			}
 
+			key := fmt.Sprintf("non-reosurce-info%s", tt.path)
+			if err := sw.Delete(key); err != nil {
+				t.Errorf("failed to remove %s, %v", key, err)
+			}
 		})
 	}
-
-	os.RemoveAll(rootDir)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:
Like coredns component will post non resource request to kube-apiserver through yurthub, but yurthub can not handle non resource request when cloud-edge line off, so coredns can not recover when cloud-edge disconnected.

this pull request is used for solving the above problem.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
