### PR TITLE
improve e2e tests for supporting mac env and coredns autonomy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ TARGET_PLATFORMS ?= linux/amd64
 IMAGE_REPO ?= openyurt
 IMAGE_TAG ?= $(shell git describe --abbrev=0 --tags)
 GIT_COMMIT = $(shell git rev-parse HEAD)
+ENABLE_AUTONOMY_TESTS ?=true
 
 ifeq ($(shell git tag --points-at ${GIT_COMMIT}),)
 GIT_VERSION=$(IMAGE_TAG)-$(shell echo ${GIT_COMMIT} | cut -c 1-7)
@@ -70,9 +71,6 @@ verify-mod:
 	hack/make-rules/verify_mod.sh
 
 # Start up OpenYurt cluster on local machine based on a Kind cluster
-# And you can run the following command on different env by specify TARGET_PLATFORMS, default platform is linux/amd64
-#   - on centos env: make local-up-openyurt
-#   - on MACBook Pro M1: make local-up-openyurt TARGET_PLATFORMS=linux/arm64
 local-up-openyurt:
 	KUBERNETESVERSION=${KUBERNETESVERSION} YURT_VERSION=$(GIT_VERSION) bash hack/make-rules/local-up-openyurt.sh
 
@@ -83,8 +81,12 @@ local-up-openyurt:
 docker-build-and-up-openyurt: docker-build
 	KUBERNETESVERSION=${KUBERNETESVERSION} YURT_VERSION=$(GIT_VERSION) bash hack/make-rules/local-up-openyurt.sh
 
+# Start up e2e tests for OpenYurt
+# And you can run the following command on different env by specify TARGET_PLATFORMS, default platform is linux/amd64
+#   - on centos env: make e2e-tests
+#   - on MACBook Pro M1: make e2e-tests TARGET_PLATFORMS=linux/arm64
 e2e-tests:
-	bash hack/make-rules/run-e2e-tests.sh
+	ENABLE_AUTONOMY_TESTS=${ENABLE_AUTONOMY_TESTS} TARGET_PLATFORMS=${TARGET_PLATFORMS} hack/make-rules/run-e2e-tests.sh
 
 install-golint: ## check golint if not exist install golint tools
 ifeq (, $(shell which golangci-lint))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
improve e2e tests as following:
1. add a parameter `ENABLE_AUTONOMY_TESTS` for enabling or disabling autonomy e2e tests, default is: true(enable autonomy e2e tests)
2. add a parameter `TARGET_PLATFORMS` for specifying platform that run e2e tests. for example: the command for running e2e tests on mac env: make e2e-tests TARGET_PLATFORMS=linux/arm64
3. enable autonomy tests for CoreDNS component.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
