### PR TITLE
Extend timeout for coredns autonomy test

### DIFF
--- a/test/e2e/autonomy/autonomy_test.go
+++ b/test/e2e/autonomy/autonomy_test.go
@@ -197,7 +197,7 @@ var _ = ginkgo.Describe("edge-autonomy"+YurtE2ENamespaceName, ginkgo.Ordered, gi
 					return ""
 				}
 				return string(opBytes)
-			}).WithTimeout(30*time.Second).WithPolling(1*time.Second).Should(gomega.ContainSubstring("NOERROR"), "DNS resolution contains error, coreDNS dig failed")
+			}).WithTimeout(60*time.Second).WithPolling(1*time.Second).Should(gomega.ContainSubstring("NOERROR"), "DNS resolution contains error, coreDNS dig failed")
 		})
 	})
 })

--- a/test/e2e/autonomy/autonomy_test.go
+++ b/test/e2e/autonomy/autonomy_test.go
@@ -215,7 +215,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	_, err = ns.CreateNameSpace(c, YurtE2ENamespaceName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to create namespaces")
 
-	// get Ningx podIP on edge node worker2
+	// get nginx podIP on edge node worker2
 	cs := c
 	podName := "yurt-e2e-test-nginx-openyurt-e2e-test-worker2"
 	ginkgo.By("get pod info:" + podName)
@@ -225,7 +225,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	Edge2NginxPodIP = pod.Status.PodIP
 	klog.Infof("get PodIP of Nginx on edge node 2: %s", Edge2NginxPodIP)
 
-	// get Ningx serviceIP
+	// get nginx serviceIP
 	ginkgo.By("get service info" + NginxServiceName)
 	nginxSvc, err := c.CoreV1().Services(YurtDefaultNamespaceName).Get(context.Background(), NginxServiceName, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to get service : "+NginxServiceName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind test

#### What this PR does / why we need it:
Sometimes, we may find that the coredns autonomy e2e tests fail for timeout. It seems that in the environment of Github Action, 30s is too short for the recovery of coredns. 

Inspect serval cases, it's found that the average time of coredns autonomy test is approximately 48s. So we can extend the timeout to 60s to ensure the test can finish in most cases.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
