### PR TITLE
add timeout config in yurthub to handle those watch requests without …

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -91,6 +91,7 @@ type YurtHubConfiguration struct {
 	FilterManager                     *manager.Manager
 	CertIPs                           []net.IP
 	CoordinatorServer                 *url.URL
+	MinRequestTimeout                 time.Duration
 }
 
 // Complete converts *options.YurtHubOptions to *YurtHubConfiguration
@@ -174,6 +175,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		KubeletHealthGracePeriod:          options.KubeletHealthGracePeriod,
 		FilterManager:                     filterManager,
 		CertIPs:                           certIPs,
+		MinRequestTimeout:                 options.MinRequestTimeout,
 	}
 
 	return cfg, nil

--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -73,6 +73,7 @@ type YurtHubOptions struct {
 	WorkingMode               string
 	KubeletHealthGracePeriod  time.Duration
 	EnableNodePool            bool
+	MinRequestTimeout         time.Duration
 }
 
 // NewYurtHubOptions creates a new YurtHubOptions with a default config.
@@ -104,6 +105,7 @@ func NewYurtHubOptions() *YurtHubOptions {
 		WorkingMode:               string(util.WorkingModeEdge),
 		KubeletHealthGracePeriod:  time.Second * 40,
 		EnableNodePool:            true,
+		MinRequestTimeout:         time.Second * 1800,
 	}
 	return o
 }
@@ -168,6 +170,7 @@ func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.WorkingMode, "working-mode", o.WorkingMode, "the working mode of yurthub(edge, cloud).")
 	fs.DurationVar(&o.KubeletHealthGracePeriod, "kubelet-health-grace-period", o.KubeletHealthGracePeriod, "the amount of time which we allow kubelet to be unresponsive before stop renew node lease")
 	fs.BoolVar(&o.EnableNodePool, "enable-node-pool", o.EnableNodePool, "enable list/watch nodepools resource or not for filters(only used for testing)")
+	fs.DurationVar(&o.MinRequestTimeout, "min-request-timeout", o.MinRequestTimeout, "An optional field indicating at least how long a proxy handler must keep a request open before timing it out. Currently only honored by the local watch request handler(use request parameter timeoutSeconds firstly), which picks a randomized value above this number as the connection timeout, to spread out load.")
 }
 
 // verifyDummyIP verify the specified ip is valid or not and set the default ip if empty

--- a/pkg/yurthub/proxy/proxy.go
+++ b/pkg/yurthub/proxy/proxy.go
@@ -77,7 +77,7 @@ func NewYurtReverseProxyHandler(
 	// When yurthub is working in cloud mode, cacheMgr will be set to nil which means the local cache is disabled,
 	// so we don't need to create a LocalProxy.
 	if cacheMgr != nil {
-		localProxy = local.NewLocalProxy(cacheMgr, healthChecker.IsHealthy)
+		localProxy = local.NewLocalProxy(cacheMgr, healthChecker.IsHealthy, yurtHubCfg.MinRequestTimeout)
 		localProxy = local.WithFakeTokenInject(localProxy, yurtHubCfg.SerializerManager)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:
When yurthub takes charge of apiserver and if there is no timeoutSeconds parameter in watch requests, yurthub returns immediately. This causes the requester to retry watch request frantically. Also both yurthub and requester begin rolling logs.
So to add a new startup option for yurthub to define the default watch timeout and also give a default value(1800s like apiserver) to this option.

#### Does this PR introduce a user-facing change?
```release-note
A new optional arg "--min-request-timeout" is added in yurthub startup command. If not set, the default value is 1800s.
```
