### PR TITLE
retry deleting test ns after reconnecting cloud node

### DIFF
--- a/test/e2e/common/ns/ns.go
+++ b/test/e2e/common/ns/ns.go
@@ -19,7 +19,6 @@ package ns
 import (
 	"context"
 
-	"github.com/onsi/gomega"
 	apiv1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,8 +32,8 @@ func DeleteNameSpace(c clientset.Interface, ns string) (err error) {
 	err = c.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
 	})
-	if !apierrs.IsNotFound(err) {
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to delete created namespaces:"+ns)
+	if err != nil && !apierrs.IsNotFound(err) {
+		return
 	}
 	err = util.WaitForNamespacesDeleted(c, []string{ns}, util.DefaultNamespaceDeletionTimeout)
 	return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

 /kind bug


#### What this PR does / why we need it:

After execution of `docker reconnect` to reconnect the cloud node, there may have a little before the cloud node can be actually visited. So, we'd better keep retry when deleting namespace.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1054 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
