### PR TITLE
extend timeout to 2min when reconnecting cloud node after suite

### DIFF
--- a/test/e2e/autonomy/autonomy_test.go
+++ b/test/e2e/autonomy/autonomy_test.go
@@ -258,7 +258,7 @@ var _ = ginkgo.AfterSuite(func() {
 	gomega.Eventually(func() error {
 		_, err = c.Discovery().ServerVersion()
 		return err
-	}).WithTimeout(20 * time.Second).WithPolling(1 * time.Second).Should(gomega.Succeed())
+	}).WithTimeout(120 * time.Second).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
 	ginkgo.By("delete namespace:" + YurtE2ENamespaceName)
 	err = ns.DeleteNameSpace(c, YurtE2ENamespaceName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

#### What this PR does / why we need it:

It seems that 20s is not enough for reconnecting cloud node to kind network. So extend it to 120s.

#### Which issue(s) this PR fixes:

Fixes #1054 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
