### PR TITLE
Fix: fix dynamicRESTMapper nil pointer bug

### DIFF
--- a/pkg/yurthub/kubernetes/meta/restmapper.go
+++ b/pkg/yurthub/kubernetes/meta/restmapper.go
@@ -77,7 +77,7 @@ func NewDefaultRESTMapperFromScheme() *meta.DefaultRESTMapper {
 }
 
 func NewRESTMapperManager(baseDir string) (*RESTMapperManager, error) {
-	var dm map[schema.GroupVersionResource]schema.GroupVersionKind
+	dm := make(map[schema.GroupVersionResource]schema.GroupVersionKind)
 	cachedFilePath := filepath.Join(baseDir, CacheDynamicRESTMapperKey)
 	// Recover the mapping relationship between GVR and GVK from the hard disk
 	storage := fs.FileSystemOperator{}


### PR DESCRIPTION
Fix bug of RESTMapperManager.dynamicRESTMapper nil pointer.
When `_internal/restmapper/cache-crd-restmapper.conf` exist but is empty, the current implement would cause npe.