### PR TITLE
bugfix: add ignore preflight errors to adapt kubeadm before version 1.23.0

### DIFF
--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -177,6 +177,7 @@ nodeRegistration:
   name: {{.name}}
   ignorePreflightErrors:
     - FileAvailable--etc-kubernetes-kubelet.conf
+    - DirAvailable--etc-kubernetes-manifests
     {{- range $index, $value := .ignorePreflightErrors}}
     - {{$value}}
     {{- end}}


### PR DESCRIPTION

Signed-off-by: HIHIA <283304489@qq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When the refactored `yurtadm join` running, we create the yaml file of YurtHub Static Pod to the `/etc/kubernetes/manifests` folder before calling `kubeadm join`.
In the case of `kubeadm join` before `1.23.0`, the `/etc/kubernetes/manifests` folder is checked to see if it has been created. So we need to add a preflight error ignored for this folder to adapt to the situation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1091 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
