### PR TITLE
generate coordinator client and pass through SubjectAccessReview according to secret

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -96,6 +96,7 @@ type YurtHubConfiguration struct {
 	FilterManager                     *manager.Manager
 	CertIPs                           []net.IP
 	MinRequestTimeout                 time.Duration
+	EnableCoordinator                 bool
 	CoordinatorServerURL              *url.URL
 	CoordinatorStoragePrefix          string
 	CoordinatorStorageAddr            string // ip:port
@@ -110,9 +111,12 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		return nil, err
 	}
 
-	CoordinatorServerURL, err := url.Parse(options.CoordinatorServerAddr)
-	if err != nil {
-		return nil, err
+	var coordinatorServerURL *url.URL
+	if options.EnableCoordinator {
+		coordinatorServerURL, err = url.Parse(options.CoordinatorServerAddr)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	hubCertOrgs := make([]string, 0)
@@ -202,7 +206,8 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		FilterManager:                     filterManager,
 		CertIPs:                           certIPs,
 		MinRequestTimeout:                 options.MinRequestTimeout,
-		CoordinatorServerURL:              CoordinatorServerURL,
+		EnableCoordinator:                 options.EnableCoordinator,
+		CoordinatorServerURL:              coordinatorServerURL,
 		CoordinatorStoragePrefix:          options.CoordinatorStoragePrefix,
 		CoordinatorStorageAddr:            options.CoordinatorStorageAddr,
 		LeaderElection:                    options.LeaderElection,

--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -78,6 +79,7 @@ type YurtHubConfiguration struct {
 	MaxRequestInFlight                int
 	JoinToken                         string
 	RootDir                           string
+	CoordinatorPKIDir                 string
 	EnableProfiling                   bool
 	EnableDummyIf                     bool
 	EnableIptables                    bool
@@ -88,24 +90,27 @@ type YurtHubConfiguration struct {
 	TLSConfig                         *tls.Config
 	SharedFactory                     informers.SharedInformerFactory
 	YurtSharedFactory                 yurtinformers.SharedInformerFactory
+	YurtClient                        kubernetes.Interface
 	WorkingMode                       util.WorkingMode
 	KubeletHealthGracePeriod          time.Duration
 	FilterManager                     *manager.Manager
 	CertIPs                           []net.IP
-	CoordinatorServer                 *url.URL
 	MinRequestTimeout                 time.Duration
+	CoordinatorServerURL              *url.URL
 	CoordinatorStoragePrefix          string
 	CoordinatorStorageAddr            string // ip:port
-	CoordinatorStorageCaFile          string
-	CoordinatorStorageCertFile        string
-	CoordinatorStorageKeyFile         string
-	LeaderElection                    componentbaseconfig.LeaderElectionConfiguration
 	CoordinatorClient                 kubernetes.Interface
+	LeaderElection                    componentbaseconfig.LeaderElectionConfiguration
 }
 
 // Complete converts *options.YurtHubOptions to *YurtHubConfiguration
 func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 	us, err := parseRemoteServers(options.ServerAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	CoordinatorServerURL, err := url.Parse(options.CoordinatorServerAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -181,6 +186,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		MaxRequestInFlight:                options.MaxRequestInFlight,
 		JoinToken:                         options.JoinToken,
 		RootDir:                           options.RootDir,
+		CoordinatorPKIDir:                 filepath.Join(options.RootDir, "poolcoordinator"),
 		EnableProfiling:                   options.EnableProfiling,
 		EnableDummyIf:                     options.EnableDummyIf,
 		EnableIptables:                    options.EnableIptables,
@@ -191,15 +197,14 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		RESTMapperManager:                 restMapperManager,
 		SharedFactory:                     sharedFactory,
 		YurtSharedFactory:                 yurtSharedFactory,
+		YurtClient:                        proxiedClient,
 		KubeletHealthGracePeriod:          options.KubeletHealthGracePeriod,
 		FilterManager:                     filterManager,
 		CertIPs:                           certIPs,
 		MinRequestTimeout:                 options.MinRequestTimeout,
+		CoordinatorServerURL:              CoordinatorServerURL,
 		CoordinatorStoragePrefix:          options.CoordinatorStoragePrefix,
 		CoordinatorStorageAddr:            options.CoordinatorStorageAddr,
-		CoordinatorStorageCaFile:          options.CoordinatorStorageCaFile,
-		CoordinatorStorageCertFile:        options.CoordinatorStorageCertFile,
-		CoordinatorStorageKeyFile:         options.CoordinatorStorageKeyFile,
 		LeaderElection:                    options.LeaderElection,
 	}
 

--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -43,46 +43,44 @@ const (
 
 // YurtHubOptions is the main settings for the yurthub
 type YurtHubOptions struct {
-	ServerAddr                 string
-	YurtHubHost                string // YurtHub server host (e.g.: expose metrics API)
-	YurtHubProxyHost           string // YurtHub proxy server host
-	YurtHubPort                string
-	YurtHubProxyPort           string
-	YurtHubProxySecurePort     string
-	GCFrequency                int
-	YurtHubCertOrganizations   string
-	KubeletRootCAFilePath      string
-	KubeletPairFilePath        string
-	NodeName                   string
-	NodePoolName               string
-	LBMode                     string
-	HeartbeatFailedRetry       int
-	HeartbeatHealthyThreshold  int
-	HeartbeatTimeoutSeconds    int
-	HeartbeatIntervalSeconds   int
-	MaxRequestInFlight         int
-	JoinToken                  string
-	RootDir                    string
-	Version                    bool
-	EnableProfiling            bool
-	EnableDummyIf              bool
-	EnableIptables             bool
-	HubAgentDummyIfIP          string
-	HubAgentDummyIfName        string
-	DiskCachePath              string
-	AccessServerThroughHub     bool
-	EnableResourceFilter       bool
-	DisabledResourceFilters    []string
-	WorkingMode                string
-	KubeletHealthGracePeriod   time.Duration
-	CoordinatorStoragePrefix   string
-	CoordinatorStorageAddr     string
-	CoordinatorStorageCaFile   string
-	CoordinatorStorageCertFile string
-	CoordinatorStorageKeyFile  string
-	EnableNodePool             bool
-	MinRequestTimeout          time.Duration
-	LeaderElection             componentbaseconfig.LeaderElectionConfiguration
+	ServerAddr                string
+	YurtHubHost               string // YurtHub server host (e.g.: expose metrics API)
+	YurtHubProxyHost          string // YurtHub proxy server host
+	YurtHubPort               string
+	YurtHubProxyPort          string
+	YurtHubProxySecurePort    string
+	GCFrequency               int
+	YurtHubCertOrganizations  string
+	KubeletRootCAFilePath     string
+	KubeletPairFilePath       string
+	NodeName                  string
+	NodePoolName              string
+	LBMode                    string
+	HeartbeatFailedRetry      int
+	HeartbeatHealthyThreshold int
+	HeartbeatTimeoutSeconds   int
+	HeartbeatIntervalSeconds  int
+	MaxRequestInFlight        int
+	JoinToken                 string
+	RootDir                   string
+	Version                   bool
+	EnableProfiling           bool
+	EnableDummyIf             bool
+	EnableIptables            bool
+	HubAgentDummyIfIP         string
+	HubAgentDummyIfName       string
+	DiskCachePath             string
+	AccessServerThroughHub    bool
+	EnableResourceFilter      bool
+	DisabledResourceFilters   []string
+	WorkingMode               string
+	KubeletHealthGracePeriod  time.Duration
+	CoordinatorServerAddr     string
+	CoordinatorStoragePrefix  string
+	CoordinatorStorageAddr    string
+	EnableNodePool            bool
+	MinRequestTimeout         time.Duration
+	LeaderElection            componentbaseconfig.LeaderElectionConfiguration
 }
 
 // NewYurtHubOptions creates a new YurtHubOptions with a default config.
@@ -190,11 +188,9 @@ func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.KubeletHealthGracePeriod, "kubelet-health-grace-period", o.KubeletHealthGracePeriod, "the amount of time which we allow kubelet to be unresponsive before stop renew node lease")
 	fs.BoolVar(&o.EnableNodePool, "enable-node-pool", o.EnableNodePool, "enable list/watch nodepools resource or not for filters(only used for testing)")
 	fs.DurationVar(&o.MinRequestTimeout, "min-request-timeout", o.MinRequestTimeout, "An optional field indicating at least how long a proxy handler must keep a request open before timing it out. Currently only honored by the local watch request handler(use request parameter timeoutSeconds firstly), which picks a randomized value above this number as the connection timeout, to spread out load.")
+	fs.StringVar(&o.CoordinatorServerAddr, "coordinator-server-addr", o.CoordinatorServerAddr, "Coordinator APIServer address in format https://host:port")
 	fs.StringVar(&o.CoordinatorStoragePrefix, "coordinator-storage-prefix", o.CoordinatorStoragePrefix, "Pool-Coordinator etcd storage prefix, same as etcd-prefix of Kube-APIServer")
-	fs.StringVar(&o.CoordinatorStorageAddr, "coordinator-storage-addr", o.CoordinatorStorageAddr, "Address of Pool-Coordinator etcd, in the format ip:port")
-	fs.StringVar(&o.CoordinatorStorageCaFile, "coordinator-storage-ca", o.CoordinatorStorageCaFile, "CA file path to communicate with Pool-Coordinator etcd")
-	fs.StringVar(&o.CoordinatorStorageCertFile, "coordinator-storage-cert", o.CoordinatorStorageCertFile, "Cert file path to communicate with Pool-Coordinator etcd")
-	fs.StringVar(&o.CoordinatorStorageKeyFile, "coordinator-storage-key", o.CoordinatorStorageKeyFile, "Key file path to communicate with Pool-Coordinator etcd")
+	fs.StringVar(&o.CoordinatorStorageAddr, "coordinator-storage-addr", o.CoordinatorStorageAddr, "Address of Pool-Coordinator etcd, in the format host:port")
 	bindFlags(&o.LeaderElection, fs)
 }
 

--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -75,6 +75,7 @@ type YurtHubOptions struct {
 	DisabledResourceFilters   []string
 	WorkingMode               string
 	KubeletHealthGracePeriod  time.Duration
+	EnableCoordinator         bool
 	CoordinatorServerAddr     string
 	CoordinatorStoragePrefix  string
 	CoordinatorStorageAddr    string
@@ -188,6 +189,7 @@ func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.KubeletHealthGracePeriod, "kubelet-health-grace-period", o.KubeletHealthGracePeriod, "the amount of time which we allow kubelet to be unresponsive before stop renew node lease")
 	fs.BoolVar(&o.EnableNodePool, "enable-node-pool", o.EnableNodePool, "enable list/watch nodepools resource or not for filters(only used for testing)")
 	fs.DurationVar(&o.MinRequestTimeout, "min-request-timeout", o.MinRequestTimeout, "An optional field indicating at least how long a proxy handler must keep a request open before timing it out. Currently only honored by the local watch request handler(use request parameter timeoutSeconds firstly), which picks a randomized value above this number as the connection timeout, to spread out load.")
+	fs.BoolVar(&o.EnableCoordinator, "enable-coordinator", o.EnableCoordinator, "make yurthub aware of the pool coordinator")
 	fs.StringVar(&o.CoordinatorServerAddr, "coordinator-server-addr", o.CoordinatorServerAddr, "Coordinator APIServer address in format https://host:port")
 	fs.StringVar(&o.CoordinatorStoragePrefix, "coordinator-storage-prefix", o.CoordinatorStoragePrefix, "Pool-Coordinator etcd storage prefix, same as etcd-prefix of Kube-APIServer")
 	fs.StringVar(&o.CoordinatorStorageAddr, "coordinator-storage-addr", o.CoordinatorStorageAddr, "Address of Pool-Coordinator etcd, in the format host:port")

--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -40,6 +40,7 @@ import (
 	hubrest "github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/rest"
 	"github.com/openyurtio/openyurt/pkg/yurthub/network"
 	"github.com/openyurtio/openyurt/pkg/yurthub/poolcoordinator"
+	coordinatorcertmgr "github.com/openyurtio/openyurt/pkg/yurthub/poolcoordinator/certmanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/proxy"
 	"github.com/openyurtio/openyurt/pkg/yurthub/server"
 	"github.com/openyurtio/openyurt/pkg/yurthub/tenant"
@@ -117,32 +118,25 @@ func Run(ctx context.Context, cfg *config.YurtHubConfiguration) error {
 	}
 	trace++
 
-	klog.Infof("%d. prepare for health checker clients", trace)
-	cloudClients, coordinatorClient, err := createClients(cfg.HeartbeatTimeoutSeconds, cfg.RemoteServers, cfg.CoordinatorServer, transportManager)
+	klog.Infof("%d. prepare cloud kube clients", trace)
+	cloudClients, err := createClients(cfg.HeartbeatTimeoutSeconds, cfg.RemoteServers, cfg.CoordinatorServerURL, transportManager)
 	if err != nil {
-		return fmt.Errorf("failed to create health checker clients, %w", err)
+		return fmt.Errorf("failed to create cloud clients, %w", err)
 	}
 	trace++
 
 	var cloudHealthChecker healthchecker.MultipleBackendsHealthChecker
-	var coordinatorHealthChecker healthchecker.HealthChecker
 	if cfg.WorkingMode == util.WorkingModeEdge {
 		klog.Infof("%d. create health checkers for remote servers and pool coordinator", trace)
 		cloudHealthChecker, err = healthchecker.NewCloudAPIServerHealthChecker(cfg, cloudClients, ctx.Done())
 		if err != nil {
 			return fmt.Errorf("could not new cloud health checker, %w", err)
 		}
-		coordinatorHealthChecker, err = healthchecker.NewCoordinatorHealthChecker(cfg, coordinatorClient, cloudHealthChecker, ctx.Done())
-		if err != nil {
-			return fmt.Errorf("failed to create coordinator health checker, %v", err)
-		}
-
 	} else {
 		klog.Infof("%d. disable health checker for node %s because it is a cloud node", trace, cfg.NodeName)
-		// In cloud mode, cloud health checker and pool coordinator health checker are not needed.
+		// In cloud mode, cloud health checker is not needed.
 		// This fake checker will always report that the cloud is healthy and pool coordinator is unhealthy.
 		cloudHealthChecker = healthchecker.NewFakeChecker(true, make(map[string]int))
-		coordinatorHealthChecker = healthchecker.NewFakeChecker(false, make(map[string]int))
 	}
 	trace++
 
@@ -186,28 +180,26 @@ func Run(ctx context.Context, cfg *config.YurtHubConfiguration) error {
 	tenantMgr := tenant.New(cfg.YurtHubCertOrganizations, cfg.SharedFactory, ctx.Done())
 	trace++
 
-	klog.Infof("%d. create yurthub elector", trace)
-	elector, err := poolcoordinator.NewHubElector(cfg, coordinatorClient, coordinatorHealthChecker, cloudHealthChecker, ctx.Done())
-	if err != nil {
-		klog.Errorf("failed to create hub elector, %v", err)
-	}
-	elector.Run(ctx.Done())
-	trace++
-
-	// TODO: cloud client load balance
-	klog.Infof("%d. create coordinator", trace)
-	coordinator, err := poolcoordinator.NewCoordinator(ctx, cfg, restConfigMgr, transportManager, elector)
-	if err != nil {
-		klog.Errorf("failed to create coordinator, %v", err)
-	}
-	coordinator.Run()
-	trace++
-
 	klog.Infof("%d. new reverse proxy handler for remote servers", trace)
-	yurtProxyHandler, err := proxy.NewYurtReverseProxyHandler(cfg, cacheMgr, transportManager, coordinator, cloudHealthChecker, coordinatorHealthChecker, tenantMgr, ctx.Done())
+	// We temporarily set the coordinator as fake coordinator, which will always think the poolcoodinator
+	// is unready and unhealthy. When the poolcoordinator is actually enabled and running, it will be replaced
+	// with the real coordinator.
+	// We use such machanism to initiate the coordinator, because the coordinator needs client to communicate with
+	// coordinator server and the client will not be initiated until the secret informer syncs. The informer factory
+	// will start bellow which is after we create the proxy handler. So we just use a fake coordinator to make it
+	// work around and initiate the coordinator in an async way. See coordinatorRun, which takes the responsibility of
+	// initiating the coordinator.
+	// The same reason for fake coordinator health checker.
+	var coordinator poolcoordinator.Coordinator = &poolcoordinator.FakeCoordinator{}
+	var coordinatorHealthChecker healthchecker.HealthChecker = healthchecker.NewFakeChecker(false, make(map[string]int))
+	yurtProxyHandler, err := proxy.NewYurtReverseProxyHandler(cfg, cacheMgr, transportManager, &coordinator, cloudHealthChecker, &coordinatorHealthChecker, tenantMgr, ctx.Done())
 	if err != nil {
 		return fmt.Errorf("could not create reverse proxy handler, %w", err)
 	}
+	trace++
+
+	klog.Infof("%d. start to initinate the coordinator asynchronously", trace)
+	go coordinatorRun(ctx, cfg, restConfigMgr, cloudHealthChecker, &coordinator, &coordinatorHealthChecker)
 	trace++
 
 	if cfg.EnableDummyIf {
@@ -237,8 +229,7 @@ func Run(ctx context.Context, cfg *config.YurtHubConfiguration) error {
 
 // createClients will create clients for all cloud APIServer and client for pool coordinator
 // It will return a map, mapping cloud APIServer URL to its client, and a pool coordinator client
-func createClients(heartbeatTimeoutSeconds int, remoteServers []*url.URL, coordinatorServer *url.URL, tp transport.Interface) (map[string]kubernetes.Interface, kubernetes.Interface, error) {
-	var coordinatorClient kubernetes.Interface
+func createClients(heartbeatTimeoutSeconds int, remoteServers []*url.URL, coordinatorServer *url.URL, tp transport.Interface) (map[string]kubernetes.Interface, error) {
 	cloudClients := make(map[string]kubernetes.Interface)
 	for i := range remoteServers {
 		restConf := &rest.Config{
@@ -248,21 +239,81 @@ func createClients(heartbeatTimeoutSeconds int, remoteServers []*url.URL, coordi
 		}
 		c, err := kubernetes.NewForConfig(restConf)
 		if err != nil {
-			return cloudClients, coordinatorClient, err
+			return cloudClients, err
 		}
 		cloudClients[remoteServers[i].String()] = c
 	}
+	return cloudClients, nil
+}
 
-	cfg := &rest.Config{
-		Host:      coordinatorServer.String(),
-		Transport: tp.CurrentTransport(),
-		Timeout:   time.Duration(heartbeatTimeoutSeconds) * time.Second,
-	}
-	c, err := kubernetes.NewForConfig(cfg)
+func coordinatorRun(ctx context.Context,
+	cfg *config.YurtHubConfiguration,
+	restConfigMgr *hubrest.RestConfigManager,
+	cloudHealthChecker healthchecker.MultipleBackendsHealthChecker,
+	coordinator *poolcoordinator.Coordinator,
+	coordinatorHealthChecker *healthchecker.HealthChecker) {
+	coordinatorCertManager, err := coordinatorcertmgr.NewCertManager(cfg.CoordinatorPKIDir, cfg.YurtClient, cfg.SharedFactory)
 	if err != nil {
-		return cloudClients, coordinatorClient, err
+		klog.Errorf("failed to create coordinator cert manager, %v", err)
+		return
 	}
-	coordinatorClient = c
+	coordinatorTransportMgr, err := poolCoordinatorTransportMgrGetter(cfg.HeartbeatTimeoutSeconds, cfg.CoordinatorServerURL, coordinatorCertManager, ctx.Done())
+	if err != nil {
+		klog.Errorf("failed to create coordinator transport manager, %v", err)
+		return
+	}
 
-	return cloudClients, coordinatorClient, nil
+	coordinatorClient, err := kubernetes.NewForConfig(&rest.Config{
+		Host:      cfg.CoordinatorServerURL.String(),
+		Transport: coordinatorTransportMgr.CurrentTransport(),
+		Timeout:   time.Duration(cfg.HeartbeatTimeoutSeconds),
+	})
+	if err != nil {
+		klog.Errorf("failed to get coordinator client for pool coordinator, %v", err)
+		return
+	}
+
+	coorHealthChecker, err := healthchecker.NewCoordinatorHealthChecker(cfg, coordinatorClient, cloudHealthChecker, ctx.Done())
+	if err != nil {
+		klog.Errorf("failed to create coordinator health checker, %v", err)
+		return
+	}
+
+	var elector *poolcoordinator.HubElector
+	elector, err = poolcoordinator.NewHubElector(cfg, coordinatorClient, coorHealthChecker, cloudHealthChecker, ctx.Done())
+	if err != nil {
+		klog.Errorf("failed to create hub elector, %v", err)
+		return
+	}
+	elector.Run(ctx.Done())
+
+	coor, err := poolcoordinator.NewCoordinator(ctx, cfg, restConfigMgr, coordinatorCertManager, coordinatorTransportMgr, elector)
+	if err != nil {
+		klog.Errorf("failed to create coordinator, %v", err)
+		return
+	}
+	coor.Run()
+	// Initiate the coordinator and coordinator health checker in reverse proxy handler,
+	//  which are temporarily set as fake.
+	*coordinator = coor
+	*coordinatorHealthChecker = coorHealthChecker
+}
+
+func poolCoordinatorTransportMgrGetter(heartbeatTimeoutSeconds int, coordinatorServer *url.URL, coordinatorCertMgr *coordinatorcertmgr.CertManager, stopCh <-chan struct{}) (transport.Interface, error) {
+	err := wait.PollImmediate(5*time.Second, 4*time.Minute, func() (done bool, err error) {
+		if coordinatorCertMgr.Current() != nil {
+			return true, nil
+		}
+		klog.Infof("waiting for preparing coordinator client certificate")
+		return false, nil
+	})
+	if err != nil {
+		klog.Errorf("timeout when waiting for coordinator client certificate")
+	}
+
+	coordinatorTransportMgr, err := transport.NewTransportManager(coordinatorCertMgr, stopCh)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transport manager for pool coordinator, %v", err)
+	}
+	return coordinatorTransportMgr, nil
 }

--- a/pkg/yurthub/healthchecker/health_checker.go
+++ b/pkg/yurthub/healthchecker/health_checker.go
@@ -65,7 +65,7 @@ func NewCoordinatorHealthChecker(cfg *config.YurtHubConfiguration, checkerClient
 		heartbeatInterval:        cfg.HeartbeatIntervalSeconds,
 	}
 	chc.coordinatorProber = newProber(checkerClient,
-		cfg.CoordinatorServer.String(),
+		cfg.CoordinatorServerURL.String(),
 		cfg.NodeName,
 		cfg.HeartbeatFailedRetry,
 		cfg.HeartbeatHealthyThreshold,

--- a/pkg/yurthub/healthchecker/health_checker_test.go
+++ b/pkg/yurthub/healthchecker/health_checker_test.go
@@ -176,7 +176,7 @@ func TestNewCoordinatorHealthChecker(t *testing.T) {
 	for k, tt := range testcases {
 		t.Run(k, func(t *testing.T) {
 			cfg := &config.YurtHubConfiguration{
-				CoordinatorServer:         &url.URL{Host: "127.0.0.1:18080"},
+				CoordinatorServerURL:      &url.URL{Host: "127.0.0.1:18080"},
 				NodeName:                  node.Name,
 				HeartbeatFailedRetry:      2,
 				HeartbeatHealthyThreshold: 1,

--- a/pkg/yurthub/poolcoordinator/certmanager/certmanager.go
+++ b/pkg/yurthub/poolcoordinator/certmanager/certmanager.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certmanager
+
+import (
+	"crypto/tls"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/poolcoordinator/constants"
+	"github.com/openyurtio/openyurt/pkg/yurthub/util/fs"
+)
+
+type CertFileType string
+
+var (
+	RootCA            CertFileType = "CA"
+	YurthubClientCert CertFileType = "YurthubClientCert"
+	YurthubClientKey  CertFileType = "YurthubClientKey"
+)
+
+var certFileNames = map[CertFileType]string{
+	RootCA:            "pool-coordinator-ca.crt",
+	YurthubClientCert: "pool-coordinator-yurthub-client.crt",
+	YurthubClientKey:  "pool-coordinator-yurthub-client.key",
+}
+
+func NewCertManager(caFilePath string, yurtClient kubernetes.Interface, yurtInformerFactory informers.SharedInformerFactory) (*CertManager, error) {
+	store := fs.FileSystemOperator{}
+	dir, _ := filepath.Split(caFilePath)
+	if err := store.CreateDir(dir); err != nil && err != fs.ErrExists {
+		return nil, fmt.Errorf("failed to create dir %s, %v", dir, err)
+	}
+
+	certMgr := &CertManager{
+		pkiDir: dir,
+		store:  store,
+	}
+
+	// try to use last cert files when restart.
+	certPath, keyPath := certMgr.GetFilePath(YurthubClientCert), certMgr.GetFilePath(YurthubClientKey)
+	if cert, err := tls.LoadX509KeyPair(certPath, keyPath); err == nil {
+		certMgr.cert = &cert
+	}
+
+	secretInformerFunc := func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+		tweakListOptions := func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.Set{"metadata.name": constants.PoolCoordinatorClientSecretName}.String()
+		}
+		return coreinformers.NewFilteredSecretInformer(yurtClient, constants.PoolCoordinatorClientSecretNamespace, 0, nil, tweakListOptions)
+	}
+	secretInformer := yurtInformerFactory.InformerFor(&corev1.Secret{}, secretInformerFunc)
+	secretInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			klog.V(4).Infof("notify secret add event for %s", constants.PoolCoordinatorClientSecretName)
+			secret := obj.(*corev1.Secret)
+			certMgr.updateCerts(secret)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			klog.V(4).Infof("notify secret update event for %s", constants.PoolCoordinatorClientSecretName)
+			secret := newObj.(*corev1.Secret)
+			certMgr.updateCerts(secret)
+		},
+		DeleteFunc: func(_ interface{}) {
+			klog.V(4).Infof("notify secret delete event for %s", constants.PoolCoordinatorClientSecretName)
+			certMgr.deleteCerts()
+		},
+	})
+
+	return certMgr, nil
+}
+
+type CertManager struct {
+	sync.Mutex
+	pkiDir string
+	cert   *tls.Certificate
+	store  fs.FileSystemOperator
+}
+
+func (c *CertManager) Current() *tls.Certificate {
+	c.Lock()
+	defer c.Unlock()
+	return c.cert
+}
+
+func (c *CertManager) GetCaFile() string {
+	return c.GetFilePath(RootCA)
+}
+
+func (c *CertManager) GetFilePath(t CertFileType) string {
+	return filepath.Join(c.pkiDir, certFileNames[t])
+}
+
+func (c *CertManager) updateCerts(secret *corev1.Secret) {
+	ca := secret.Data["ca.crt"]
+	coordinatorClientCrt := secret.Data["pool-coordinator-yurthub-client.crt"]
+	coordinatorClientKey := secret.Data["pool-coordinator-yurthub-client.key"]
+
+	cert, err := tls.X509KeyPair(coordinatorClientCrt, coordinatorClientKey)
+	if err != nil {
+		klog.Errorf("failed to create tls certificate for coordinator, %v", err)
+		return
+	}
+
+	caPath := c.GetCaFile()
+	certPath := c.GetFilePath(YurthubClientCert)
+	keyPath := c.GetFilePath(YurthubClientKey)
+
+	c.Lock()
+	defer c.Unlock()
+	// TODO: The following updates should rollback on failure,
+	// making the certs in-memory and certs on disk consistent.
+	if err := c.createOrUpdateFile(caPath, ca); err != nil {
+		klog.Errorf("failed to update ca, %v", err)
+	}
+	if err := c.createOrUpdateFile(keyPath, coordinatorClientKey); err != nil {
+		klog.Errorf("failed to update client key, %v", err)
+	}
+	if err := c.createOrUpdateFile(certPath, coordinatorClientCrt); err != nil {
+		klog.Errorf("failed to update client cert, %v", err)
+	}
+	c.cert = &cert
+}
+
+func (c *CertManager) deleteCerts() {
+	c.cert = nil
+}
+
+func (c *CertManager) createOrUpdateFile(path string, data []byte) error {
+	if err := c.store.Write(path, data); err == fs.ErrNotExists {
+		if err := c.store.CreateFile(path, data); err != nil {
+			return fmt.Errorf("failed to create file at %s, %v", path, err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to update file at %s, %v", path, err)
+	}
+	return nil
+}

--- a/pkg/yurthub/poolcoordinator/certmanager/certmanager.go
+++ b/pkg/yurthub/poolcoordinator/certmanager/certmanager.go
@@ -50,7 +50,7 @@ var certFileNames = map[CertFileType]string{
 	YurthubClientKey:  "pool-coordinator-yurthub-client.key",
 }
 
-func NewCertManager(caFilePath string, yurtClient kubernetes.Interface, yurtInformerFactory informers.SharedInformerFactory) (*CertManager, error) {
+func NewCertManager(caFilePath string, yurtClient kubernetes.Interface, informerFactory informers.SharedInformerFactory) (*CertManager, error) {
 	store := fs.FileSystemOperator{}
 	dir, _ := filepath.Split(caFilePath)
 	if err := store.CreateDir(dir); err != nil && err != fs.ErrExists {
@@ -74,7 +74,7 @@ func NewCertManager(caFilePath string, yurtClient kubernetes.Interface, yurtInfo
 		}
 		return coreinformers.NewFilteredSecretInformer(yurtClient, constants.PoolCoordinatorClientSecretNamespace, 0, nil, tweakListOptions)
 	}
-	secretInformer := yurtInformerFactory.InformerFor(&corev1.Secret{}, secretInformerFunc)
+	secretInformer := informerFactory.InformerFor(&corev1.Secret{}, secretInformerFunc)
 	secretInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			klog.V(4).Infof("notify secret add event for %s", constants.PoolCoordinatorClientSecretName)

--- a/pkg/yurthub/poolcoordinator/constants/constants.go
+++ b/pkg/yurthub/poolcoordinator/constants/constants.go
@@ -35,5 +35,7 @@ var (
 )
 
 const (
-	DefaultPoolScopedUserAgent = "leader-yurthub"
+	DefaultPoolScopedUserAgent           = "leader-yurthub"
+	PoolCoordinatorClientSecretName      = "pool-coordinator-yurthub-certs"
+	PoolCoordinatorClientSecretNamespace = "kube-system"
 )

--- a/pkg/yurthub/poolcoordinator/fake_coordinator.go
+++ b/pkg/yurthub/poolcoordinator/fake_coordinator.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package poolcoordinator
+
+import "github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+
+type FakeCoordinator struct{}
+
+var _ Coordinator = &FakeCoordinator{}
+
+func (fc *FakeCoordinator) Run() {}
+
+func (fc *FakeCoordinator) IsReady() (cachemanager.CacheManager, bool) {
+	return nil, false
+}
+
+func (fc *FakeCoordinator) IsHealthy() (cachemanager.CacheManager, bool) {
+	return nil, false
+}

--- a/pkg/yurthub/proxy/pool/pool.go
+++ b/pkg/yurthub/proxy/pool/pool.go
@@ -245,12 +245,12 @@ func (pp *PoolCoordinatorProxy) cacheResponse(req *http.Request, resp *http.Resp
 		req = req.WithContext(ctx)
 		wrapPrc, _ := hubutil.NewGZipReaderCloser(resp.Header, resp.Body, req, "cache-manager")
 
-		rc, prc := hubutil.NewDualReadCloser(req, wrapPrc, false)
+		rc, prc := hubutil.NewDualReadCloser(req, wrapPrc, true)
 		go func(req *http.Request, prc io.ReadCloser, stopCh <-chan struct{}) {
 			if err := pp.localCacheMgr.CacheResponse(req, prc, stopCh); err != nil {
 				klog.Errorf("failed to cache req %s in local cache when cluster is unhealthy, %v", hubutil.ReqString(req), err)
 			}
 		}(req, prc, ctx.Done())
-		req.Body = rc
+		resp.Body = rc
 	}
 }

--- a/pkg/yurthub/proxy/remote/loadbalancer.go
+++ b/pkg/yurthub/proxy/remote/loadbalancer.go
@@ -132,7 +132,7 @@ type loadBalancer struct {
 	algo          loadBalancerAlgo
 	localCacheMgr cachemanager.CacheManager
 	filterManager *manager.Manager
-	coordinator   *poolcoordinator.Coordinator
+	coordinator   poolcoordinator.Coordinator
 	workingMode   hubutil.WorkingMode
 	stopCh        <-chan struct{}
 }
@@ -143,7 +143,7 @@ func NewLoadBalancer(
 	remoteServers []*url.URL,
 	localCacheMgr cachemanager.CacheManager,
 	transportMgr transport.Interface,
-	coordinator *poolcoordinator.Coordinator,
+	coordinator poolcoordinator.Coordinator,
 	healthChecker healthchecker.MultipleBackendsHealthChecker,
 	filterManager *manager.Manager,
 	workingMode hubutil.WorkingMode,
@@ -207,7 +207,7 @@ func (lb *loadBalancer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			for {
 				select {
 				case <-t.C:
-					if _, isReady := (*lb.coordinator).IsReady(); isReady {
+					if _, isReady := lb.coordinator.IsReady(); isReady {
 						klog.Infof("notified the pool coordinator is ready, cancel the req %s making it handled by pool coordinator", hubutil.ReqString(req))
 						cloudServeCancel()
 						return
@@ -326,7 +326,7 @@ func (lb *loadBalancer) cacheResponse(req *http.Request, resp *http.Response) {
 		wrapPrc, _ := hubutil.NewGZipReaderCloser(resp.Header, resp.Body, req, "cache-manager")
 		resp.Body = wrapPrc
 
-		poolCacheManager, isHealthy := (*lb.coordinator).IsHealthy()
+		poolCacheManager, isHealthy := lb.coordinator.IsHealthy()
 		if isHealthy && poolCacheManager != nil {
 			if !isLeaderHubUserAgent(ctx) {
 				if isRequestOfNodeAndPod(ctx) {

--- a/pkg/yurthub/proxy/remote/loadbalancer.go
+++ b/pkg/yurthub/proxy/remote/loadbalancer.go
@@ -207,7 +207,7 @@ func (lb *loadBalancer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			for {
 				select {
 				case <-t.C:
-					if _, isReady := lb.coordinator.IsReady(); isReady {
+					if _, isReady := (*lb.coordinator).IsReady(); isReady {
 						klog.Infof("notified the pool coordinator is ready, cancel the req %s making it handled by pool coordinator", hubutil.ReqString(req))
 						cloudServeCancel()
 						return
@@ -326,7 +326,7 @@ func (lb *loadBalancer) cacheResponse(req *http.Request, resp *http.Response) {
 		wrapPrc, _ := hubutil.NewGZipReaderCloser(resp.Header, resp.Body, req, "cache-manager")
 		resp.Body = wrapPrc
 
-		poolCacheManager, isHealthy := lb.coordinator.IsHealthy()
+		poolCacheManager, isHealthy := (*lb.coordinator).IsHealthy()
 		if isHealthy && poolCacheManager != nil {
 			if !isLeaderHubUserAgent(ctx) {
 				if isRequestOfNodeAndPod(ctx) {

--- a/pkg/yurthub/proxy/remote/loadbalancer.go
+++ b/pkg/yurthub/proxy/remote/loadbalancer.go
@@ -360,31 +360,31 @@ func (lb *loadBalancer) cacheResponse(req *http.Request, resp *http.Response) {
 func (lb *loadBalancer) cacheToLocal(req *http.Request, resp *http.Response) {
 	ctx := req.Context()
 	req = req.WithContext(ctx)
-	rc, prc := hubutil.NewDualReadCloser(req, resp.Body, false)
+	rc, prc := hubutil.NewDualReadCloser(req, resp.Body, true)
 	go func(req *http.Request, prc io.ReadCloser, stopCh <-chan struct{}) {
 		if err := lb.localCacheMgr.CacheResponse(req, prc, stopCh); err != nil {
 			klog.Errorf("failed to cache req %s in local cache when cluster is unhealthy, %v", hubutil.ReqString(req), err)
 		}
 	}(req, prc, ctx.Done())
-	req.Body = rc
+	resp.Body = rc
 }
 
 func (lb *loadBalancer) cacheToPool(req *http.Request, resp *http.Response, poolCacheManager cachemanager.CacheManager) {
 	ctx := req.Context()
 	req = req.WithContext(ctx)
-	rc, prc := hubutil.NewDualReadCloser(req, resp.Body, false)
+	rc, prc := hubutil.NewDualReadCloser(req, resp.Body, true)
 	go func(req *http.Request, prc io.ReadCloser, stopCh <-chan struct{}) {
 		if err := poolCacheManager.CacheResponse(req, prc, stopCh); err != nil {
 			klog.Errorf("failed to cache req %s in local cache when cluster is unhealthy, %v", hubutil.ReqString(req), err)
 		}
 	}(req, prc, ctx.Done())
-	req.Body = rc
+	resp.Body = rc
 }
 
 func (lb *loadBalancer) cacheToLocalAndPool(req *http.Request, resp *http.Response, poolCacheMgr cachemanager.CacheManager) {
 	ctx := req.Context()
 	req = req.WithContext(ctx)
-	rc, prc1, prc2 := hubutil.NewTripleReadCloser(req, resp.Body, false)
+	rc, prc1, prc2 := hubutil.NewTripleReadCloser(req, resp.Body, true)
 	go func(req *http.Request, prc io.ReadCloser, stopCh <-chan struct{}) {
 		if err := lb.localCacheMgr.CacheResponse(req, prc, stopCh); err != nil {
 			klog.Errorf("failed to cache req %s in local cache when cluster is unhealthy, %v", hubutil.ReqString(req), err)
@@ -398,7 +398,7 @@ func (lb *loadBalancer) cacheToLocalAndPool(req *http.Request, resp *http.Respon
 			}
 		}(req, prc2, ctx.Done())
 	}
-	req.Body = rc
+	resp.Body = rc
 }
 
 func isLeaderHubUserAgent(reqCtx context.Context) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

/kine bug
/kind feature


#### What this PR does / why we need it:

The following works has been done in this pr:
1. generate coordinator client according to ca, cert and key in the secret to communicate with coordinator
2. deliver SubjectAccessReview request to coresponding APIServer(Coordinator or Cloud APIServer) according to the Group value in it.
3. add `--enable-pool-coordinator` to enable the yurthub be aware of the pool-coordinator. If disabled, yurthub will work without pool-coordinator and no module about coordinator will start in yurthub.
4. fix bug that cannot cache response when proxying request, currently yurthub can work without `--enable-pool-coordinator`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #778 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
