### PR TITLE
add tunnelAgentConnectPort to values

### DIFF
--- a/charts/openyurt/templates/yurt-tunnel-server.yaml
+++ b/charts/openyurt/templates/yurt-tunnel-server.yaml
@@ -123,8 +123,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 10262
-      targetPort: 10262
+    - port: {{ .Values.yurtTunnelServer.parameters.tunnelAgentConnectPort }}
+      targetPort: {{ .Values.yurtTunnelServer.parameters.tunnelAgentConnectPort }}
       nodePort: 31008
       name: tcp
   selector:
@@ -202,6 +202,7 @@ spec:
             - --proxy-strategy=destHost
             - --cert-dns-names={{ .Values.yurtTunnelServer.parameters.certDnsNames }}
             - --cert-ips={{ .Values.yurtTunnelServer.parameters.certIps }}
+            - --tunnel-agent-connect-port={{ .Values.yurtTunnelServer.parameters.tunnelAgentConnectPort }}
             - --v=2
           env:
             - name: NODE_IP

--- a/charts/openyurt/values.yaml
+++ b/charts/openyurt/values.yaml
@@ -30,6 +30,7 @@ yurtTunnelServer:
   parameters:
     certDnsNames: ""
     certIps: ""
+    tunnelAgentConnectPort: 10262
   image:
     registry: docker.io
     repository: openyurt/yurt-tunnel-server


### PR DESCRIPTION
Since users generally need to modify tunnelAgentConnectPort, it is recommended to add it to values.yaml for customization @rambohe-ch 