### PR TITLE
Fix: sa.key missing position bug.

### DIFF
--- a/pkg/controller/poolcoordinator/cert/poolcoordinator_cert_manager.go
+++ b/pkg/controller/poolcoordinator/cert/poolcoordinator_cert_manager.go
@@ -332,7 +332,7 @@ func initPoolCoordinator(clientSet client.Interface, stopCh <-chan struct{}) err
 	}
 
 	// 4. prepare sa key pairs
-	if err := initSAKeyPair(clientSet, PoolcoordinatorStaticSecertName, "sa"); err != nil {
+	if err := initSAKeyPair(clientSet, "sa", PoolcoordinatorStaticSecertName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fix bug of missing key "sa.key" in "pool-coordinator-static-certs" secret , which is put to "pool-coordinator-static-certs" key in "sa" secret.