### PR TITLE
Feature: yurtadm reset/join modification. Do not remove k8s binaries, add flag for using local cni binaries.

### DIFF
--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -271,7 +271,7 @@ func newJoinData(args []string, opt *joinOptions) (*joinData, error) {
 			Organizations: opt.organizations,
 		},
 		kubernetesResourceServer: opt.kubernetesResourceServer,
-		reuseCNIBin:           opt.reuseCNIBin,
+		reuseCNIBin:              opt.reuseCNIBin,
 	}
 
 	// parse node labels

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -52,6 +52,7 @@ type joinOptions struct {
 	nodeLabels               string
 	kubernetesResourceServer string
 	yurthubServer            string
+	reuseCNIBin              bool
 }
 
 // newJoinOptions returns a struct ready for being used for creating cmd join flags.
@@ -66,6 +67,7 @@ func newJoinOptions() *joinOptions {
 		ignorePreflightErrors:    make([]string, 0),
 		kubernetesResourceServer: yurtconstants.DefaultKubernetesResourceServer,
 		yurthubServer:            yurtconstants.DefaultYurtHubServerAddr,
+		reuseCNIBin:              false,
 	}
 }
 
@@ -156,6 +158,10 @@ func addJoinConfigFlags(flagSet *flag.FlagSet, joinOptions *joinOptions) {
 		&joinOptions.yurthubServer, yurtconstants.YurtHubServerAddr, joinOptions.yurthubServer,
 		"Sets the address for yurthub server addr",
 	)
+	flagSet.BoolVar(
+		&joinOptions.reuseCNIBin, yurtconstants.ReuseCNIBin, false,
+		"Whether to reuse local CNI binaries or to download new ones",
+	)
 }
 
 func newJoinerWithJoinData(o *joinData, in io.Reader, out io.Writer, outErr io.Writer) *nodeJoiner {
@@ -201,6 +207,7 @@ type joinData struct {
 	nodeLabels               map[string]string
 	kubernetesResourceServer string
 	yurthubServer            string
+	reuseCNIBin              bool
 }
 
 // newJoinData returns a new joinData struct to be used for the execution of the kubeadm join workflow.
@@ -264,6 +271,7 @@ func newJoinData(args []string, opt *joinOptions) (*joinData, error) {
 			Organizations: opt.organizations,
 		},
 		kubernetesResourceServer: opt.kubernetesResourceServer,
+		reuseCNIBin:           opt.reuseCNIBin,
 	}
 
 	// parse node labels
@@ -365,4 +373,8 @@ func (j *joinData) NodeLabels() map[string]string {
 
 func (j *joinData) KubernetesResourceServer() string {
 	return j.kubernetesResourceServer
+}
+
+func (j *joinData) ReuseCNIBin() bool {
+	return j.reuseCNIBin
 }

--- a/pkg/yurtadm/cmd/join/join_test.go
+++ b/pkg/yurtadm/cmd/join/join_test.go
@@ -56,6 +56,7 @@ func TestNewJoinOptions(t *testing.T) {
 				ignorePreflightErrors:    make([]string, 0),
 				kubernetesResourceServer: yurtconstants.DefaultKubernetesResourceServer,
 				yurthubServer:            yurtconstants.DefaultYurtHubServerAddr,
+				reuseCNIBin:              false,
 			},
 		},
 	}

--- a/pkg/yurtadm/cmd/join/joindata/data.go
+++ b/pkg/yurtadm/cmd/join/joindata/data.go
@@ -43,4 +43,5 @@ type YurtJoinData interface {
 	NodeLabels() map[string]string
 	IgnorePreflightErrors() sets.String
 	KubernetesResourceServer() string
+	ReuseCNIBin() bool
 }

--- a/pkg/yurtadm/cmd/join/phases/prepare.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare.go
@@ -54,10 +54,8 @@ func RunPrepare(data joindata.YurtJoinData) error {
 	if err := yurtadmutil.CheckAndInstallKubeadm(data.KubernetesResourceServer(), data.KubernetesVersion()); err != nil {
 		return err
 	}
-	if !data.ReuseCNIBin() {
-		if err := yurtadmutil.CheckAndInstallKubernetesCni(); err != nil {
-			return err
-		}
+	if err := yurtadmutil.CheckAndInstallKubernetesCni(data.ReuseCNIBin()); err != nil {
+		return err
 	}
 	if err := yurtadmutil.SetKubeletService(); err != nil {
 		return err

--- a/pkg/yurtadm/cmd/join/phases/prepare.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare.go
@@ -54,7 +54,7 @@ func RunPrepare(data joindata.YurtJoinData) error {
 	if err := yurtadmutil.CheckAndInstallKubeadm(data.KubernetesResourceServer(), data.KubernetesVersion()); err != nil {
 		return err
 	}
-	if err := yurtadmutil.CheckAndInstallKubernetesCni(); err != nil {
+	if !(data.ReuseCNIBin()) && (err := yurtadmutil.CheckAndInstallKubernetesCni(); err != nil) {
 		return err
 	}
 	if err := yurtadmutil.SetKubeletService(); err != nil {

--- a/pkg/yurtadm/cmd/join/phases/prepare.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare.go
@@ -54,8 +54,10 @@ func RunPrepare(data joindata.YurtJoinData) error {
 	if err := yurtadmutil.CheckAndInstallKubeadm(data.KubernetesResourceServer(), data.KubernetesVersion()); err != nil {
 		return err
 	}
-	if !(data.ReuseCNIBin()) && (err := yurtadmutil.CheckAndInstallKubernetesCni(); err != nil) {
-		return err
+	if !data.ReuseCNIBin() {
+		if err := yurtadmutil.CheckAndInstallKubernetesCni(); err != nil {
+			return err
+		}
 	}
 	if err := yurtadmutil.SetKubeletService(); err != nil {
 		return err

--- a/pkg/yurtadm/cmd/reset/phases/cleanyurtfile.go
+++ b/pkg/yurtadm/cmd/reset/phases/cleanyurtfile.go
@@ -26,20 +26,12 @@ import (
 )
 
 func RunCleanYurtFile() error {
-	for _, comp := range []string{"kubectl", "kubeadm", "kubelet"} {
-		target := fmt.Sprintf("/usr/bin/%s", comp)
-		if err := os.RemoveAll(target); err != nil {
-			klog.Warningf("Clean file %s fail: %v, please clean it manually.", target, err)
-		}
-	}
-
 	for _, file := range []string{constants.KubeletWorkdir,
 		constants.YurttunnelAgentWorkdir,
 		constants.YurttunnelServerWorkdir,
 		constants.YurtHubWorkdir,
 		constants.KubeletSvcPath,
 		constants.KubeletServiceFilepath,
-		constants.KubeCniDir,
 		constants.KubeletConfigureDir,
 		constants.SysctlK8sConfig} {
 		if err := os.RemoveAll(file); err != nil {

--- a/pkg/yurtadm/cmd/reset/phases/cleanyurtfile.go
+++ b/pkg/yurtadm/cmd/reset/phases/cleanyurtfile.go
@@ -17,7 +17,6 @@ limitations under the License.
 package phases
 
 import (
-	"fmt"
 	"os"
 
 	"k8s.io/klog/v2"

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -109,6 +109,8 @@ const (
 	YurtHubImage = "yurthub-image"
 	// YurtHubServerAddr flag set the address of yurthub server (not proxy server!)
 	YurtHubServerAddr = "yurthub-server-addr"
+	// ReuseCNIBin flag sets whether to reuse local CNI binaries or not.
+	ReuseCNIBin = "reuse-cni-bin"
 
 	ServerHealthzServer          = "127.0.0.1:10267"
 	ServerHealthzURLPath         = "/v1/healthz"

--- a/pkg/yurtadm/util/kubernetes/kubernetes.go
+++ b/pkg/yurtadm/util/kubernetes/kubernetes.go
@@ -144,11 +144,17 @@ func CheckAndInstallKubelet(kubernetesResourceServer, clusterVersion string) err
 }
 
 // CheckAndInstallKubernetesCni install kubernetes-cni, skip install if they exist.
-func CheckAndInstallKubernetesCni() error {
-	if _, err := os.Stat(constants.KubeCniDir); err == nil {
-		klog.Infof("Cni dir %s already exist, skip install.", constants.KubeCniDir)
-		return nil
+func CheckAndInstallKubernetesCni(reuseCNIBin bool) error {
+	if reuseCNIBin {
+		if _, err := os.Stat(constants.KubeCniDir); err == nil {
+			klog.Infof("Cni dir %s exists, reuse the CNI binaries.", constants.KubeCniDir)
+			return nil
+		} else {
+			klog.Errorf("Cni dir %s does not exist, cannot reuse the CNI binaries!", constants.KubeCniDir)
+			return err
+		}
 	}
+
 	//download and install kubernetes-cni
 	cniUrl := fmt.Sprintf(constants.CniUrlFormat, constants.KubeCniVersion, runtime.GOARCH, constants.KubeCniVersion)
 	savePath := fmt.Sprintf("%s/cni-plugins-linux-%s-%s.tgz", constants.TmpDownloadDir, runtime.GOARCH, constants.KubeCniVersion)


### PR DESCRIPTION
/kind feature

yurtadm reset/join modification. Do not remove k8s binaries, add flag for using local cni binaries.

Fixes #1095


- Do not remove `kubeadm/kubelet/kubelet` and cni binaries on `yurtadm reset`.
- Add new flag `--reuse-cni-bin` for `yurtadm join`. It determines whether to reuse local CNI binaries or not. Default value is `false`.
