### PR TITLE
use pointer receiver in mocked clientv3.KV to avoid passing lock by value

### DIFF
--- a/pkg/yurthub/storage/etcd/keycache_test.go
+++ b/pkg/yurthub/storage/etcd/keycache_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Test componentKeyCache setup", func() {
 	var f fs.FileSystemOperator
 	var mockedClient *clientv3.Client
 	BeforeEach(func() {
-		kv := etcdmock.KV{}
+		kv := &etcdmock.KV{}
 		kv.On("Get", "/registry/services/endpoints", mock.AnythingOfType("clientv3.OpOption"), mock.AnythingOfType("clientv3.OpOption")).
 			Return(&clientv3.GetResponse{})
 		kv.On("Get", "/registry/endpointslices", mock.AnythingOfType("clientv3.OpOption"), mock.AnythingOfType("clientv3.OpOption")).
@@ -76,7 +76,7 @@ var _ = Describe("Test componentKeyCache setup", func() {
 
 	Context("Test get pool-scoped resource keys from etcd", func() {
 		BeforeEach(func() {
-			kv := etcdmock.KV{}
+			kv := &etcdmock.KV{}
 			kv.On("Get", "/registry/services/endpoints", mock.AnythingOfType("clientv3.OpOption"), mock.AnythingOfType("clientv3.OpOption")).
 				Return(&clientv3.GetResponse{
 					Kvs: []*mvccpb.KeyValue{
@@ -199,7 +199,7 @@ var _ = Describe("Test componentKeyCache function", func() {
 	var fileName string
 	var key1, key2, key3 storageKey
 	BeforeEach(func() {
-		kv := etcdmock.KV{}
+		kv := &etcdmock.KV{}
 		kv.On("Get", "/registry/services/endpoints", mock.AnythingOfType("clientv3.OpOption"), mock.AnythingOfType("clientv3.OpOption")).
 			Return(&clientv3.GetResponse{})
 		kv.On("Get", "/registry/endpointslices", mock.AnythingOfType("clientv3.OpOption"), mock.AnythingOfType("clientv3.OpOption")).

--- a/pkg/yurthub/storage/etcd/mock/kv.go
+++ b/pkg/yurthub/storage/etcd/mock/kv.go
@@ -23,17 +23,17 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-var _ clientv3.KV = KV{}
+var _ clientv3.KV = &KV{}
 
 type KV struct {
 	mock.Mock
 }
 
-func (kv KV) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+func (kv *KV) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
 	return nil, nil
 }
 
-func (kv KV) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+func (kv *KV) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	interfaceOpts := []interface{}{key}
 	for _, opt := range opts {
 		interfaceOpts = append(interfaceOpts, opt)
@@ -43,18 +43,18 @@ func (kv KV) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*c
 	return resp, nil
 }
 
-func (kv KV) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+func (kv *KV) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
 	return nil, nil
 }
 
-func (kv KV) Compact(ctx context.Context, rev int64, opts ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
+func (kv *KV) Compact(ctx context.Context, rev int64, opts ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
 	return nil, nil
 }
 
-func (kv KV) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
+func (kv *KV) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
 	return clientv3.OpResponse{}, nil
 }
 
-func (kv KV) Txn(ctx context.Context) clientv3.Txn {
+func (kv *KV) Txn(ctx context.Context) clientv3.Txn {
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Congrool <chpzhangyifei@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
 /kind bug


#### What this PR does / why we need it:

golangci-lint reports that 

```plain-text
Error: copylocks: Put passes lock by value: github.com/openyurtio/openyurt/pkg/yurthub/storage/etcd/mock.KV contains github.com/stretchr/testify/mock.Mock contains sync.Mutex (govet)
```

This pr will solve the problem.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
