### PR TITLE
Fix: pool-coordinator chart format,  default service name, max body size .etc

### DIFF
--- a/charts/openyurt/templates/pool-coordinator.yaml
+++ b/charts/openyurt/templates/pool-coordinator.yaml
@@ -36,57 +36,6 @@ spec:
   selector:
     k8s-app: pool-coordinator
 ---
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  name: pool-coordinator-init-rbac
-#  namespace: {{ .Release.Namespace | quote }}
-#data:
-#  pool-coordinator-init-rbac.yaml: |
-#    apiVersion: rbac.authorization.k8s.io/v1
-#    kind: ClusterRoleBinding
-#    metadata:
-#      name: openyurt:pool-coordinator:monitoring
-#    roleRef:
-#      apiGroup: rbac.authorization.k8s.io
-#      kind: ClusterRole
-#      name: openyurt:pool-coordinator:monitoring
-#    subjects:
-#    - apiGroup: rbac.authorization.k8s.io
-#      kind: User
-#      name: openyurt:pool-coordinator:monitoring
-#    ---
-#    apiVersion: rbac.authorization.k8s.io/v1
-#    kind: ClusterRoleBinding
-#    metadata:
-#      name: openyurt:pool-coordinator:apiserver
-#    roleRef:
-#      apiGroup: rbac.authorization.k8s.io
-#      kind: ClusterRole
-#      name: openyurt:pool-coordinator:apiserver
-#    subjects:
-#    - apiGroup: rbac.authorization.k8s.io
-#      kind: User
-#      name: openyurt:pool-coordinator:apiserver
-#    ---
-#    apiVersion: rbac.authorization.k8s.io/v1
-#    kind: ClusterRole
-#    metadata:
-#      name: openyurt:pool-coordinator:apiserver
-#    rules:
-#    - apiGroups: [""]
-#      resources:  ["pods/attach", "pods/exec", "pods/portforward", "pods/proxy", "pods/log"]
-#      verbs: ["get", "list"]
-#    ---
-#    apiVersion: rbac.authorization.k8s.io/v1
-#    kind: ClusterRole
-#    metadata:
-#      name: openyurt:pool-coordinator:monitoring
-#    rules:
-#    - apiGroups: [""]
-#      resources: [""]
-#      verbs: ["get", "list", "watch"]
-#---
 apiVersion: apps.openyurt.io/v1alpha1
 kind: YurtAppDaemon
 metadata:
@@ -141,9 +90,6 @@ spec:
                   - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
                 image: "{{ .Values.poolCoordinator.apiserverImage.registry }}/{{ .Values.poolCoordinator.apiserverImage.repository }}:{{ .Values.poolCoordinator.apiserverImage.tag }}"
                 imagePullPolicy: {{ .Values.poolCoordinator.apiserverImage.pullPolicy }}
-                {{- if .Values.imagePullSecrets }}
-                imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
-                {{- end }}
                 livenessProbe:
                   failureThreshold: 8
                   httpGet:
@@ -166,8 +112,10 @@ spec:
                   periodSeconds: 1
                   successThreshold: 1
                   timeoutSeconds: 15
+                {{- if .Values.poolCoordinator.apiserverResources }}
                 resources:
-                  {{- toYaml .Values.poolCoordinator.apiserverResources | nindent 12 }}
+                  {{- toYaml .Values.poolCoordinator.apiserverResources | nindent 18 }}
+                {{- end }}
                 startupProbe:
                   failureThreshold: 24
                   httpGet:
@@ -191,6 +139,7 @@ spec:
                   - --listen-client-urls=https://0.0.0.0:{{ .Values.poolCoordinator.etcdPort }}
                   - --cert-file=/etc/kubernetes/pki/etcd-server.crt
                   - --client-cert-auth=true
+                  - --max-txn-ops=1000
                   - --data-dir=/var/lib/etcd
                   - --key-file=/etc/kubernetes/pki/etcd-server.key
                   - --listen-metrics-urls=http://0.0.0.0:{{ .Values.poolCoordinator.etcdMetricPort }}
@@ -198,12 +147,11 @@ spec:
                   - --trusted-ca-file=/etc/kubernetes/pki/ca.crt
                 image: "{{ .Values.poolCoordinator.etcdImage.registry }}/{{ .Values.poolCoordinator.etcdImage.repository }}:{{ .Values.poolCoordinator.etcdImage.tag }}"
                 imagePullPolicy: {{ .Values.poolCoordinator.etcdImage.pullPolicy }}
-                {{- if .Values.imagePullSecrets }}
-                imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
-                {{- end }}
                 name: etcd
+                {{- if .Values.poolCoordinator.etcdResources}}
                 resources:
-                  {{- toYaml .Values.poolCoordinator.etcdResources | nindent 12 }}
+                  {{- toYaml .Values.poolCoordinator.etcdResources | nindent 18 }}
+                {{- end }}
                 startupProbe:
                   failureThreshold: 24
                   httpGet:
@@ -221,33 +169,11 @@ spec:
                   - mountPath: /etc/kubernetes/pki
                     name: pool-coordinator-certs
                     readOnly: true
-#              - image: "{{ .Values.poolCoordinator.kubectlImage.registry }}/{{ .Values.poolCoordinator.kubectlImage.repository }}:{{ .Values.poolCoordinator.kubectlImage.tag }}"
-#                imagePullPolicy: {{ .Values.poolCoordinator.apiserverImage.pullPolicy }}
-#                {{- if .Values.imagePullSecrets }}
-#                imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
-#                {{- end }}
-#                  lifecycle:
-#                    postStart:
-#                      exec:
-#                        command:
-#                          - kubectl
-#                          - apply
-#                          - -f
-#                          - /etc/kubernetes/pool-coordinator-init-rbac.yaml
-#                  name: kubectl
-#                  resources:
-#                    {{- toYaml .Values.poolCoordinator.etcdResources | nindent 12 }}
-#                  securityContext:
-#                    privileged: true
-#                  terminationMessagePath: /dev/termination-log
-#                  terminationMessagePolicy: File
-#                  tty: true
-#                  volumeMounts:
-#                    - mountPath: /root/.kube/
-#                      name: kubeconfig
-#                    - mountPath: /etc/kubernetes/pool-coordinator-init-rbac.yaml
-#                      name: pool-coordinator-init-rbac
             dnsPolicy: ClusterFirst
+            {{- if .Values.imagePullSecrets }}
+            imagePullSecrets:
+            {{ toYaml .Values.imagePullSecrets | nindent 14 }}
+            {{- end }}
             enableServiceLinks: true
             hostNetwork: true
             preemptionPolicy: PreemptLowerPriority
@@ -269,18 +195,9 @@ spec:
               - projected:
                   sources:
                     - secret:
-                        name: dynamic-certs
-                        secretName: pool-coordinator-dynamic-certs
+                        name: pool-coordinator-dynamic-certs
                         defaultMode: 420
                     - secret:
-                        name: static-certs
-                        secretName: pool-coordinator-static-certs
+                        name: pool-coordinator-static-certs
                         defaultMode: 420
                 name: pool-coordinator-certs
-#              - secret:
-#                  secretName: pool-coordinator-self-kubeconfig
-#                  defaultMode: 420
-#                name: kubeconfig
-#              - configMap:
-#                  name: pool-coordinator-init-rbac
-#                name: pool-coordinator-init-rbac

--- a/charts/openyurt/templates/yurt-controller-manager.yaml
+++ b/charts/openyurt/templates/yurt-controller-manager.yaml
@@ -185,8 +185,10 @@ spec:
     spec:
       serviceAccountName: yurt-controller-manager
       hostNetwork: true
+      imagePullSecrets:
+        - name: regsecret
       tolerations:
-      - operator: "Exists"
+        - operator: "Exists"
       affinity:
         nodeAffinity:
           # we prefer allocating ecm on cloud node
@@ -204,10 +206,6 @@ spec:
         imagePullPolicy: {{ .Values.yurtControllerManager.image.pullPolicy }}
         command:
           - yurt-controller-manager
-        {{- if .Values.imagePullSecrets }}
-        imagePullSecrets:
-          {{ toYaml .Values.imagePullSecrets | nindent 10 }}
-        {{- end }}
         ports:
           - name: webhook-server
             containerPort: {{ .Values.admissionWebhooks.service.port }}

--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -114,6 +114,8 @@ func NewYurtHubOptions() *YurtHubOptions {
 		KubeletHealthGracePeriod:  time.Second * 40,
 		EnableNodePool:            true,
 		MinRequestTimeout:         time.Second * 1800,
+		CoordinatorServerAddr:     fmt.Sprintf("https://%s:%s", util.DefaultPoolCoordinatorAPIServerSvcName, util.DefaultPoolCoordinatorAPIServerSvcPort),
+		CoordinatorStorageAddr:    fmt.Sprintf("https://%s:%s", util.DefaultPoolCoordinatorEtcdSvcName, util.DefaultPoolCoordinatorEtcdSvcPort),
 		CoordinatorStoragePrefix:  "/registry",
 		LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:       true,

--- a/pkg/yurthub/storage/etcd/storage.go
+++ b/pkg/yurthub/storage/etcd/storage.go
@@ -42,6 +42,8 @@ const (
 	defaultTimeout                = 5 * time.Second
 	defaultHealthCheckPeriod      = 10 * time.Second
 	defaultDialTimeout            = 10 * time.Second
+	defaultMaxSendSize            = 100 * 1024 * 1024
+	defaultMaxReceiveSize         = 100 * 1024 * 1024
 	defaultComponentCacheFileName = "component-key-cache"
 	defaultRvLen                  = 32
 )
@@ -106,9 +108,11 @@ func NewStorage(ctx context.Context, cfg *EtcdStorageConfig) (storage.Store, err
 	}
 
 	clientConfig := clientv3.Config{
-		Endpoints:   cfg.EtcdEndpoints,
-		TLS:         tlsConfig,
-		DialTimeout: defaultDialTimeout,
+		Endpoints:          cfg.EtcdEndpoints,
+		TLS:                tlsConfig,
+		DialTimeout:        defaultDialTimeout,
+		MaxCallRecvMsgSize: defaultMaxReceiveSize,
+		MaxCallSendMsgSize: defaultMaxSendSize,
 	}
 
 	client, err := clientv3.New(clientConfig)

--- a/pkg/yurthub/util/util.go
+++ b/pkg/yurthub/util/util.go
@@ -73,6 +73,15 @@ const (
 	ProxyListSelector
 	// ProxyPoolScopedResource represents if this request is asking for pool-scoped resources
 	ProxyPoolScopedResource
+	// DefaultPoolCoordinatorEtcdSvcName represents default pool coordinator etcd service
+	DefaultPoolCoordinatorEtcdSvcName = "pool-coordinator-etcd"
+	// DefaultPoolCoordinatorAPIServerSvcName represents default pool coordinator apiServer service
+	DefaultPoolCoordinatorAPIServerSvcName = "pool-coordinator-apiserver"
+	// DefaultPoolCoordinatorEtcdSvcPort represents default pool coordinator etcd port
+	DefaultPoolCoordinatorEtcdSvcPort = "2379"
+	// DefaultPoolCoordinatorAPIServerSvcPort represents default pool coordinator apiServer port
+	DefaultPoolCoordinatorAPIServerSvcPort = "443"
+
 	YurtHubNamespace   = "kube-system"
 	CacheUserAgentsKey = "cache_agents"
 


### PR DESCRIPTION
1. Validate pool-coordinator chart to ensure it is installable.
2. Add default pool coordinator related service name "pool-coordinator-etcd", "pool-coordinator-apiserver", and ports to yurthub default options.
3. Add '--max-txn-ops=1000' to pool-coordinator etcd container command.
4. Add default transfer body size between yurthub and etcd to '100M'