### PR TITLE
fix coordinator sync problem and update ready condition

### DIFF
--- a/pkg/yurthub/poolcoordinator/coordinator.go
+++ b/pkg/yurthub/poolcoordinator/coordinator.go
@@ -299,8 +299,7 @@ func (coordinator *coordinator) IsReady() (cachemanager.CacheManager, bool) {
 	// If electStatus is not PendingHub, it means pool-coordinator is healthy.
 	coordinator.Lock()
 	defer coordinator.Unlock()
-	// fixme:  coordinator.isPoolCacheSynced now is not considered
-	if coordinator.electStatus != PendingHub && !coordinator.needUploadLocalCache {
+	if coordinator.electStatus != PendingHub && coordinator.isPoolCacheSynced && !coordinator.needUploadLocalCache {
 		return coordinator.poolCacheManager, true
 	}
 	return nil, false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

1. make updating coordinator fields as atomic operation
2. add isPoolCacheSynced as one condition of pool-coordinator ready, fix what we didn't do in #1131

As discussed in https://github.com/openyurtio/openyurt/pull/1126#discussion_r1064148395:

We should make the update of coordinator as an atomic operation to avoid undefined situation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
