### PR TITLE
fix coredns cannot get /apis/discovery.k8s.io/v1 if cluster does not contain such resource

### DIFF
--- a/pkg/yurthub/server/nonresource_test.go
+++ b/pkg/yurthub/server/nonresource_test.go
@@ -46,6 +46,11 @@ import (
 
 var rootDir = "/tmp/cache-local"
 
+var (
+	notFoundError = errors.New("not found")
+	internalError = errors.New("internal error")
+)
+
 func TestLocalCacheHandler(t *testing.T) {
 	dStorage, err := disk.NewDiskStorage(rootDir)
 	if err != nil {
@@ -70,10 +75,10 @@ func TestLocalCacheHandler(t *testing.T) {
 		statusCode       int
 		metav1StatusCode int
 	}{
-		"failed to get from local cache": {
+		"failed to get from local cache, because it does not exist": {
 			path:             "/version",
 			initData:         nil,
-			statusCode:       http.StatusOK,
+			statusCode:       http.StatusNotFound,
 			metav1StatusCode: http.StatusInternalServerError,
 		},
 		"get from local cache normally": {
@@ -149,11 +154,17 @@ func TestNonResourceHandler(t *testing.T) {
 			initData:   []byte("fake resource"),
 			statusCode: http.StatusOK,
 		},
-		"failed to get non resource": {
+		"failed to get non resource because of internal error": {
 			path:             "/apis/discovery.k8s.io/v1beta1",
-			err:              errors.New("fake error"),
-			statusCode:       http.StatusOK,
+			err:              internalError,
+			statusCode:       http.StatusInternalServerError,
 			metav1StatusCode: http.StatusInternalServerError,
+		},
+		"failed to get non resource because it does not exist": {
+			path:             "/apis/discovery.k8s.io/v1",
+			err:              notFoundError,
+			statusCode:       http.StatusNotFound,
+			metav1StatusCode: http.StatusNotFound,
 		},
 	}
 
@@ -161,13 +172,22 @@ func TestNonResourceHandler(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			fakeClient := &fakerest.RESTClient{
 				Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
-					if tt.err == nil {
+					switch tt.err {
+					case nil:
 						return &http.Response{
 							StatusCode: http.StatusOK,
 							Body:       ioutil.NopCloser(strings.NewReader(string(tt.initData))),
 						}, nil
-					} else {
-						return nil, tt.err
+					case notFoundError:
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+						}, nil
+					default:
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+						}, err
 					}
 				}),
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),


### PR DESCRIPTION
Signed-off-by: Congrool <chpzhangyifei@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

If we use cordns of a high version (e.g. 1.8) but with a k8s cluster of low version (e.g. 1.20), the coredns cannot list/watch endpointslice/v1beta1, because it cannot discover the supported resource version through "GET /apis/discovery.k8s.io/v1" and "GET /apis/discovery.k8s.io/v1beta1".

The reason causing such problem is that yurthub nonresource handler will return http.StatusOK even the APIServer does not contain such resource. It will cause the coredns continuously "GET /apis/discovery.k8s.io/v1" which blocks the list/watch making it unavailable.

```go
func writeErrResponse(path string, err error, w http.ResponseWriter) {
	klog.Errorf("failed to handle %s non resource request, %v", path, err)
	status := responsewriters.ErrorToAPIStatus(err)
	output, err := json.Marshal(status)
	if err != nil {
		http.Error(w, err.Error(), http.StatusInternalServerError)
		return
	}
	writeRawJSON(output, w)
}

func writeRawJSON(output []byte, w http.ResponseWriter) {
	w.Header().Set("Content-Type", "application/json")
	w.WriteHeader(http.StatusOK)
	w.Write(output)
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
