### PR TITLE
add inclusterconfig filter for commenting kube-proxy configmap

### DIFF
--- a/pkg/yurtctl/cmd/yurttest/kindinit/init_test.go
+++ b/pkg/yurtctl/cmd/yurttest/kindinit/init_test.go
@@ -652,28 +652,6 @@ func TestInitializer_ConfigureCoreDnsAddon(t *testing.T) {
 		t.Errorf("failed to configure core dns addon")
 	}
 }
-func TestInitializer_ConfigureKubeProxyAddon(t *testing.T) {
-	var fakeOut io.Writer
-	initializer := newKindInitializer(fakeOut, newKindOptions().Config())
-
-	case1 := struct {
-		configObj *corev1.ConfigMap
-		want      interface{}
-	}{
-		configObj: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "kube-proxy"},
-			Data: map[string]string{
-				"config.conf": "{ cd .. \n kubeconfig:  \n  cluster",
-			},
-		},
-		want: nil,
-	}
-	initializer.kubeClient = clientsetfake.NewSimpleClientset(case1.configObj)
-	err := initializer.ConfigureKubeProxyAddon()
-	if err != case1.want {
-		t.Errorf("failed to configure core dns addon")
-	}
-}
 
 func TestInitializer_ConfigureAddons(t *testing.T) {
 
@@ -682,7 +660,6 @@ func TestInitializer_ConfigureAddons(t *testing.T) {
 
 	case1 := struct {
 		coreDnsConfigObj *corev1.ConfigMap
-		proxyConfigObj   *corev1.ConfigMap
 		serviceObj       *corev1.Service
 		podObj           *corev1.Pod
 		deploymentObj    *v1.Deployment
@@ -695,13 +672,6 @@ func TestInitializer_ConfigureAddons(t *testing.T) {
 				"Corefile": "{ cd .. \n hosts /etc/edge/tunnels-nodes \n  kubernetes cluster.local {",
 			},
 		},
-		proxyConfigObj: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "kube-proxy"},
-			Data: map[string]string{
-				"config.conf": "{ cd .. \n kubeconfig:  \n  cluster",
-			},
-		},
-
 		serviceObj: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   "kube-system",
@@ -763,7 +733,7 @@ func TestInitializer_ConfigureAddons(t *testing.T) {
 
 	var fakeOut io.Writer
 	initializer := newKindInitializer(fakeOut, newKindOptions().Config())
-	client := clientsetfake.NewSimpleClientset(case1.coreDnsConfigObj, case1.proxyConfigObj, case1.serviceObj, case1.podObj, case1.deploymentObj)
+	client := clientsetfake.NewSimpleClientset(case1.coreDnsConfigObj, case1.serviceObj, case1.podObj, case1.deploymentObj)
 	for i := range case1.nodeObjs {
 		client.Tracker().Add(case1.nodeObjs[i])
 	}

--- a/pkg/yurthub/filter/constant.go
+++ b/pkg/yurthub/filter/constant.go
@@ -29,6 +29,10 @@ const (
 	// on kube-proxy list/watch service request from edge nodes.
 	DiscardCloudServiceFilterName = "discardcloudservice"
 
+	// InClusterConfigFilterName filter is used to comment kubeconfig in kube-system/kube-proxy configmap
+	// in order to make kube-proxy to use InClusterConfig to access kube-apiserver.
+	InClusterConfigFilterName = "inclusterconfig"
+
 	// SkipDiscardServiceAnnotation is annotation used by LB service.
 	// If end users want to use specified LB service at the edge side,
 	// End users should add annotation["openyurt.io/skip-discard"]="true" for LB service.
@@ -44,5 +48,6 @@ var (
 		MasterServiceFilterName:       "kubelet",
 		DiscardCloudServiceFilterName: "kube-proxy",
 		ServiceTopologyFilterName:     "kube-proxy, coredns, nginx-ingress-controller",
+		InClusterConfigFilterName:     "kubelet",
 	}
 )

--- a/pkg/yurthub/filter/inclusterconfig/filter.go
+++ b/pkg/yurthub/filter/inclusterconfig/filter.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inclusterconfig
+
+import (
+	"io"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
+)
+
+// Register registers a filter
+func Register(filters *filter.Filters, sm *serializer.SerializerManager) {
+	filters.Register(filter.InClusterConfigFilterName, func() (filter.Runner, error) {
+		return NewFilter(sm), nil
+	})
+}
+
+func NewFilter(sm *serializer.SerializerManager) *inClusterConfigFilter {
+	return &inClusterConfigFilter{
+		serializerManager: sm,
+	}
+}
+
+type inClusterConfigFilter struct {
+	serializerManager *serializer.SerializerManager
+}
+
+func (iccf *inClusterConfigFilter) Name() string {
+	return filter.InClusterConfigFilterName
+}
+
+func (iccf *inClusterConfigFilter) SupportedResourceAndVerbs() map[string]sets.String {
+	return map[string]sets.String{
+		"configmaps": sets.NewString("get", "list", "watch"),
+	}
+}
+
+func (iccf *inClusterConfigFilter) Filter(req *http.Request, rc io.ReadCloser, stopCh <-chan struct{}) (int, io.ReadCloser, error) {
+	handler := NewInClusterConfigFilterHandler()
+	return filter.NewFilterReadCloser(req, iccf.serializerManager, rc, handler, iccf.Name(), stopCh)
+}

--- a/pkg/yurthub/filter/inclusterconfig/handler.go
+++ b/pkg/yurthub/filter/inclusterconfig/handler.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inclusterconfig
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+)
+
+const (
+	KubeProxyConfigMapNamespace = "kube-system"
+	KubeProxyConfigMapName      = "kube-proxy"
+	KubeProxyDataKey            = "config.conf"
+	KubeProxyKubeConfigStr      = "kubeconfig"
+)
+
+type inClusterConfigFilterHandler struct{}
+
+func NewInClusterConfigFilterHandler() filter.ObjectHandler {
+	return &inClusterConfigFilterHandler{}
+}
+
+// RuntimeObjectFilter comments kubeconfig in kube-system/kube-proxy configmap in the response object
+func (fh *inClusterConfigFilterHandler) RuntimeObjectFilter(obj runtime.Object) (runtime.Object, bool) {
+	switch v := obj.(type) {
+	case *v1.ConfigMapList:
+		for i := range v.Items {
+			newCM, mutated := mutateKubeProxyConfigMap(&v.Items[i])
+			if mutated {
+				v.Items[i] = *newCM
+				break
+			}
+		}
+		return v, false
+	case *v1.ConfigMap:
+		cm, _ := mutateKubeProxyConfigMap(v)
+		return cm, false
+	default:
+		return v, false
+	}
+}
+
+func mutateKubeProxyConfigMap(cm *v1.ConfigMap) (*v1.ConfigMap, bool) {
+	mutated := false
+	if cm.Namespace == KubeProxyConfigMapNamespace && cm.Name == KubeProxyConfigMapName {
+		if cm.Data != nil && len(cm.Data[KubeProxyDataKey]) != 0 {
+			parts := make([]string, 0)
+			for _, line := range strings.Split(cm.Data[KubeProxyDataKey], "\n") {
+				items := strings.Split(strings.Trim(line, " "), ":")
+				if len(items) == 2 && items[0] == KubeProxyKubeConfigStr {
+					parts = append(parts, strings.Replace(line, KubeProxyKubeConfigStr, fmt.Sprintf("#%s", KubeProxyKubeConfigStr), 1))
+					mutated = true
+				} else {
+					parts = append(parts, line)
+				}
+			}
+			if mutated {
+				cm.Data[KubeProxyDataKey] = strings.Join(parts, "\n")
+				klog.Infof("kubeconfig in configmap(%s/%s) has been commented, new config.conf: \n%s\n", cm.Namespace, cm.Name, cm.Data[KubeProxyDataKey])
+			}
+		}
+	}
+
+	return cm, mutated
+}

--- a/pkg/yurthub/filter/inclusterconfig/handler_test.go
+++ b/pkg/yurthub/filter/inclusterconfig/handler_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inclusterconfig
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRuntimeObjectFilter(t *testing.T) {
+	fh := NewInClusterConfigFilterHandler()
+
+	testcases := map[string]struct {
+		responseObject runtime.Object
+		expectObject   runtime.Object
+	}{
+		"kube-proxy configmap": {
+			responseObject: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      KubeProxyConfigMapName,
+					Namespace: KubeProxyConfigMapNamespace,
+				},
+				Data: map[string]string{
+					"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
+				},
+			},
+			expectObject: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      KubeProxyConfigMapName,
+					Namespace: KubeProxyConfigMapNamespace,
+				},
+				Data: map[string]string{
+					"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      #kubeconfig: /var/lib/kube-proxy/kubeconfig.conf\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
+				},
+			},
+		},
+		"kube-proxy configmap without kubeconfig": {
+			responseObject: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      KubeProxyConfigMapName,
+					Namespace: KubeProxyConfigMapNamespace,
+				},
+				Data: map[string]string{
+					"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
+				},
+			},
+			expectObject: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      KubeProxyConfigMapName,
+					Namespace: KubeProxyConfigMapNamespace,
+				},
+				Data: map[string]string{
+					"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
+				},
+			},
+		},
+		"configmapList with kube-proxy configmap": {
+			responseObject: &v1.ConfigMapList{
+				Items: []v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
+						Data: map[string]string{
+							"foo": "bar",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      KubeProxyConfigMapName,
+							Namespace: KubeProxyConfigMapNamespace,
+						},
+						Data: map[string]string{
+							"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
+						},
+					},
+				},
+			},
+			expectObject: &v1.ConfigMapList{
+				Items: []v1.ConfigMap{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: "default",
+						},
+						Data: map[string]string{
+							"foo": "bar",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      KubeProxyConfigMapName,
+							Namespace: KubeProxyConfigMapNamespace,
+						},
+						Data: map[string]string{
+							"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      #kubeconfig: /var/lib/kube-proxy/kubeconfig.conf\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
+						},
+					},
+				},
+			},
+		},
+		"not configmapList": {
+			responseObject: &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pod1",
+							Namespace: KubeProxyConfigMapNamespace,
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectObject: &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pod1",
+							Namespace: KubeProxyConfigMapNamespace,
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			newObj, isNil := fh.RuntimeObjectFilter(tc.responseObject)
+			if tc.expectObject == nil {
+				if !isNil {
+					t.Errorf("RuntimeObjectFilter expect nil obj, but got %v", newObj)
+				}
+			} else if !reflect.DeepEqual(newObj, tc.expectObject) {
+				t.Errorf("RuntimeObjectFilter got error, expected: \n%v\nbut got: \n%v\n, isNil=%v", tc.expectObject, newObj, isNil)
+			}
+		})
+	}
+}

--- a/pkg/yurthub/filter/manager/manager.go
+++ b/pkg/yurthub/filter/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/discardcloudservice"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter/inclusterconfig"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/initializer"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/masterservice"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/servicetopology"
@@ -120,4 +121,5 @@ func registerAllFilters(filters *filter.Filters, sm *serializer.SerializerManage
 	servicetopology.Register(filters, sm)
 	masterservice.Register(filters, sm)
 	discardcloudservice.Register(filters, sm)
+	inclusterconfig.Register(filters, sm)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind feature

#### What this PR does / why we need it:
1. add inclusterconfig filter for commenting kubeconfig setting in `kube-system/kube-proxy` configmap, in order to make kube-proxy on nodes with yurthub(like edge nodes) to use `InClusterConfig` to access kube-apiserver.  at the same time, kube-proxy on master nodes without yurthub can use kubeconfig to access kube-apiserver.

2. delete kube-proxy configure in `yurtctl init test` command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1127 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
