### PR TITLE
bugfix: yurt-controller-manager cannot restart

### DIFF
--- a/pkg/webhook/poolcoordinator_webhook.go
+++ b/pkg/webhook/poolcoordinator_webhook.go
@@ -586,18 +586,16 @@ func (h *PoolCoordinatorWebhook) ensureValidatingConfiguration(certs *Certs) {
 		if _, err := h.client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
 			context.TODO(), h.validatingConfigurationName, metav1.GetOptions{}); err != nil {
 			if errors.IsNotFound(err) {
-				klog.Infof("validatewebhookconfiguratiion %s not found, create it.", h.validatingConfigurationName)
+				klog.Infof("validatewebhookconfiguration %s not found, create it.", h.validatingConfigurationName)
 				if _, err = h.client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(
 					context.TODO(), config, metav1.CreateOptions{}); err != nil {
 					klog.Fatal(err)
 				}
+			} else {
+				klog.Fatalf("failed to get validatewebhookconfiguration %s, %v", h.validatingConfigurationName, err)
 			}
 		} else {
-			klog.Infof("validatingwebhookconfiguratiion %s already exists, update it.", h.validatingConfigurationName)
-			if _, err = h.client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(
-				context.TODO(), config, metav1.UpdateOptions{}); err != nil {
-				klog.Fatal(err)
-			}
+			klog.Infof("validatewebhookconfiguration %s has already existed, skip create", h.validatingConfigurationName)
 		}
 	}
 }
@@ -639,18 +637,16 @@ func (h *PoolCoordinatorWebhook) ensureMutatingConfiguration(certs *Certs) {
 		if _, err := h.client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(
 			context.TODO(), h.mutatingConfigurationName, metav1.GetOptions{}); err != nil {
 			if errors.IsNotFound(err) {
-				klog.Infof("validatewebhookconfiguratiion %s not found, create it.", h.mutatingConfigurationName)
+				klog.Infof("mutatingwebhookconfiguration %s not found, create it.", h.mutatingConfigurationName)
 				if _, err = h.client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(
 					context.TODO(), config, metav1.CreateOptions{}); err != nil {
 					klog.Fatal(err)
 				}
+			} else {
+				klog.Fatalf("failed to get mutatingwebhookconfiguration %s, %v", h.mutatingConfigurationName, err)
 			}
 		} else {
-			klog.Infof("validatingwebhookconfiguratiion %s already exists, update it.", h.mutatingConfigurationName)
-			if _, err = h.client.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(
-				context.TODO(), config, metav1.UpdateOptions{}); err != nil {
-				klog.Fatal(err)
-			}
+			klog.Infof("mutatingwebhookconfiguration %s has already existed, skip create", h.mutatingConfigurationName)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

When yurt-controller-manager restart, it will encounter fatal error and exit because the mutatingwebhookconfiguration and validatingwebhookconfiguration has already exists.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
