### PR TITLE
fix: leader yurthub cannot proxy heartbeat

### DIFF
--- a/charts/openyurt/templates/pool-coordinator.yaml
+++ b/charts/openyurt/templates/pool-coordinator.yaml
@@ -201,3 +201,29 @@ spec:
                     - secret:
                         name: pool-coordinator-static-certs
                 name: pool-coordinator-certs
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openyurt:pool-coordinator:node-lease-proxy-client 
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openyurt:pool-coordinator:node-lease-proxy-client
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openyurt:pool-coordinator:node-lease-proxy-client
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: openyurt:pool-coordinator:node-lease-proxy-client

--- a/pkg/yurthub/poolcoordinator/certmanager/certmanager_test.go
+++ b/pkg/yurthub/poolcoordinator/certmanager/certmanager_test.go
@@ -55,7 +55,7 @@ WOkCYynzE8EVrosIUIko+6IopX5wheTJ0IcU4yCQNo+avzYKMFztVh6eQLoe7afq
 GFQ=
 -----END CERTIFICATE-----
 `
-	certByte = `-----BEGIN CERTIFICATE-----
+	coordinatorCertByte = `-----BEGIN CERTIFICATE-----
 MIIDLjCCAhagAwIBAgIIDOMcH2sIQDowDQYJKoZIhvcNAQELBQAwFTETMBEGA1UE
 AxMKa3ViZXJuZXRlczAeFw0yMjEyMjgwMzM4MjNaFw0yMzEyMjgwMzM4MjNaMEEx
 FzAVBgNVBAoTDnN5c3RlbTptYXN0ZXJzMSYwJAYDVQQDEx1rdWJlLWFwaXNlcnZl
@@ -76,7 +76,7 @@ ip2++hBi1NIyUYAhdktGas6FZPORtn+kvVs5A/V88EacqkWqVWRW0582gcyL8uJD
 QXo=
 -----END CERTIFICATE-----
 `
-	keyByte = `-----BEGIN RSA PRIVATE KEY-----
+	coordinatorKeyByte = `-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAxS0kRp057jeo9MDOmEn558leaROBux1IcYjsGKCoJc6BDyQR
 5NBIhWpMum+mQnV8Ka/oJs01CqsAFIi8f2g+jUBNjTgSt4BbmSsd1IVo487VP9Ov
 JLIbs1bmKQRmiOIgEURDUHYluklYIewOyloHsEwj/IqCuzZG6dOqAt3xU+gbP5AW
@@ -104,6 +104,31 @@ pe7HLwKBgF9lHHhy76nDW8VMlcEtYIZf329VoqeTMUmvDWFyHAWuY4ZQ4ugAoBUK
 otCqT57JeYWq2hEFromJoSiBgai7weO/E2lAR2Qs99uEPp45q9JQ
 -----END RSA PRIVATE KEY-----
 `
+
+	nodeLeaseProxyCertByte = `-----BEGIN CERTIFICATE-----
+MIICizCCAXOgAwIBAgIRAMh6sQhKTUmBgJ8fAO6pN9swDQYJKoZIhvcNAQELBQAw
+FTETMBEGA1UEAxMKa3ViZXJuZXRlczAeFw0yMzAxMjkxNTM5NDFaFw0yNDAxMjkx
+NTM5NDFaMGAxIjAgBgNVBAoTGW9wZW55dXJ0OnBvb2wtY29vcmRpbmF0b3IxOjA4
+BgNVBAMTMW9wZW55dXJ0OnBvb2wtY29vcmRpbmF0b3I6bm9kZS1sZWFzZS1wcm94
+eS1jbGllbnQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATVqaIIvc5cuNkWtNTs
+v6ddKSD3uwq2rBPtOwR2htPAoI2YN6PCYC/RMJGJ4U4ZidEqTj1JDeoCIEUv6KOg
+bBzlo1YwVDAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwDAYD
+VR0TAQH/BAIwADAfBgNVHSMEGDAWgBRgN+htjKYJdOgZ8ZREdjf1Vc4G+DANBgkq
+hkiG9w0BAQsFAAOCAQEA0ZUhvSck6pLXfqpyBAPkv3OPd+Rnwc9FZg5//rXNC4Ae
+Hn3TzqGctUu+MRM+SzDucg9qR8pLTMUajz91gkm2+8I7l/2qmDT0Ey3FBd4/2fhk
+NQCAy6JUBwVGw58cnoGDi4fvrekHkNYJFOrJWWU89oYWLwrSylCp+UV8EXd9UbQ7
+txgzlOfCjH/TIUdUrlpr3fQXk9HRYyNAbh9tNLm2UbBQuW3hWnqClT6TuZ3r3YIF
+MCCMCOMTneKvNTSci1fGNyd6C12w4Hj+ox+pURJrZ1SUCsAK1EfSIBr1hLWh/f72
+iBBcMK8JlrYBxggAgvJJawWOqVI32Xq1qTJEs5K50w==
+-----END CERTIFICATE-----
+	`
+
+	nodeLeaseProxyKeyByte = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIJWSAemqKwLTHpW0fe2J1uJk8eUUE3YrC6oET3rHpiDsoAoGCCqGSM49
+AwEHoUQDQgAE1amiCL3OXLjZFrTU7L+nXSkg97sKtqwT7TsEdobTwKCNmDejwmAv
+0TCRieFOGYnRKk49SQ3qAiBFL+ijoGwc5Q==
+-----END EC PRIVATE KEY-----
+	`
 
 	newCertByte = `-----BEGIN CERTIFICATE-----
 MIIDKDCCAhCgAwIBAgIIYxZk3ye/TxMwDQYJKoZIhvcNAQELBQAwEjEQMA4GA1UE
@@ -154,6 +179,12 @@ KAGM4g6DY68asv37ATNrYjLZ0MGsArWhKXsbxiR9CrzrNFVVtVIc6g==
 -----END RSA PRIVATE KEY-----`
 )
 
+type expectFile struct {
+	FilePath string
+	Data     []byte
+	Exists   bool
+}
+
 var (
 	fileStore             = fs.FileSystemOperator{}
 	secretGVR             = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
@@ -168,8 +199,8 @@ var (
 		},
 		Data: map[string][]byte{
 			"ca.crt":                              []byte(caByte),
-			"pool-coordinator-yurthub-client.crt": []byte(certByte),
-			"pool-coordinator-yurthub-client.key": []byte(keyByte),
+			"pool-coordinator-yurthub-client.crt": []byte(coordinatorCertByte),
+			"pool-coordinator-yurthub-client.key": []byte(coordinatorKeyByte),
 		},
 	}
 
@@ -204,7 +235,7 @@ func TestSecretAdd(t *testing.T) {
 		// Expect to timeout which indicates the CertManager does not save the cert
 		// that is not pool-coordinator-yurthub-certs.
 		err = wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-			if certMgr.cert != nil {
+			if certMgr.secret != nil {
 				return false, fmt.Errorf("unexpect cert initialization")
 			}
 
@@ -238,7 +269,32 @@ func TestSecretAdd(t *testing.T) {
 		}
 
 		err = wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-			return checkSecret(certMgr, poolCoordinatorSecret)
+			return checkSecret(certMgr, poolCoordinatorSecret, []expectFile{
+				{
+					FilePath: certMgr.GetFilePath(RootCA),
+					Data:     poolCoordinatorSecret.Data["ca.crt"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(YurthubClientCert),
+					Data:     poolCoordinatorSecret.Data["pool-coordinator-yurthub-client.crt"],
+					Exists:   true,
+				},
+				{
+
+					FilePath: certMgr.GetFilePath(YurthubClientKey),
+					Data:     poolCoordinatorSecret.Data["pool-coordinator-yurthub-client.key"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientCert),
+					Exists:   false,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientKey),
+					Exists:   false,
+				},
+			})
 		})
 
 		if err != nil {
@@ -264,12 +320,38 @@ func TestSecretUpdate(t *testing.T) {
 		}
 
 		err = wait.Poll(50*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-			return checkSecret(certMgr, poolCoordinatorSecret)
+			return checkSecret(certMgr, poolCoordinatorSecret, []expectFile{
+				{
+					FilePath: certMgr.GetFilePath(RootCA),
+					Data:     poolCoordinatorSecret.Data["ca.crt"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(YurthubClientCert),
+					Data:     poolCoordinatorSecret.Data["pool-coordinator-yurthub-client.crt"],
+					Exists:   true,
+				},
+				{
+
+					FilePath: certMgr.GetFilePath(YurthubClientKey),
+					Data:     poolCoordinatorSecret.Data["pool-coordinator-yurthub-client.key"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientCert),
+					Exists:   false,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientKey),
+					Exists:   false,
+				},
+			})
 		})
 		if err != nil {
 			t.Errorf("failed to wait cert manager to be initialized, %v", err)
 		}
 
+		// test updating existing cert and key
 		newSecret := poolCoordinatorSecret.DeepCopy()
 		newSecret.Data["pool-coordinator-yurthub-client.key"] = []byte(newKeyByte)
 		newSecret.Data["pool-coordinator-yurthub-client.crt"] = []byte(newCertByte)
@@ -278,7 +360,73 @@ func TestSecretUpdate(t *testing.T) {
 		}
 
 		err = wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-			return checkSecret(certMgr, newSecret)
+			return checkSecret(certMgr, newSecret, []expectFile{
+				{
+					FilePath: certMgr.GetFilePath(RootCA),
+					Data:     newSecret.Data["ca.crt"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(YurthubClientCert),
+					Data:     newSecret.Data["pool-coordinator-yurthub-client.crt"],
+					Exists:   true,
+				},
+				{
+
+					FilePath: certMgr.GetFilePath(YurthubClientKey),
+					Data:     newSecret.Data["pool-coordinator-yurthub-client.key"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientCert),
+					Exists:   false,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientKey),
+					Exists:   false,
+				},
+			})
+		})
+		if err != nil {
+			t.Errorf("failed to wait cert manager to be updated, %v", err)
+		}
+
+		// test adding new cert and key
+		newSecret.Data["node-lease-proxy-client.crt"] = []byte(nodeLeaseProxyCertByte)
+		newSecret.Data["node-lease-proxy-client.key"] = []byte(nodeLeaseProxyKeyByte)
+		if err := fakeClient.Tracker().Update(secretGVR, newSecret, newSecret.Namespace); err != nil {
+			t.Errorf("failed to update secret, %v", err)
+		}
+
+		err = wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+			return checkSecret(certMgr, newSecret, []expectFile{
+				{
+					FilePath: certMgr.GetFilePath(RootCA),
+					Data:     newSecret.Data["ca.crt"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(YurthubClientCert),
+					Data:     newSecret.Data["pool-coordinator-yurthub-client.crt"],
+					Exists:   true,
+				},
+				{
+
+					FilePath: certMgr.GetFilePath(YurthubClientKey),
+					Data:     newSecret.Data["pool-coordinator-yurthub-client.key"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientCert),
+					Data:     newSecret.Data["node-lease-proxy-client.crt"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientKey),
+					Data:     newSecret.Data["node-lease-proxy-client.key"],
+					Exists:   true,
+				},
+			})
 		})
 		if err != nil {
 			t.Errorf("failed to wait cert manager to be updated, %v", err)
@@ -303,7 +451,32 @@ func TestSecretDelete(t *testing.T) {
 		}
 
 		err = wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-			return checkSecret(certMgr, poolCoordinatorSecret)
+			return checkSecret(certMgr, poolCoordinatorSecret, []expectFile{
+				{
+					FilePath: certMgr.GetFilePath(RootCA),
+					Data:     poolCoordinatorSecret.Data["ca.crt"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(YurthubClientCert),
+					Data:     poolCoordinatorSecret.Data["pool-coordinator-yurthub-client.crt"],
+					Exists:   true,
+				},
+				{
+
+					FilePath: certMgr.GetFilePath(YurthubClientKey),
+					Data:     poolCoordinatorSecret.Data["pool-coordinator-yurthub-client.key"],
+					Exists:   true,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientCert),
+					Exists:   false,
+				},
+				{
+					FilePath: certMgr.GetFilePath(NodeLeaseProxyClientKey),
+					Exists:   false,
+				},
+			})
 		})
 		if err != nil {
 			t.Errorf("failed to wait cert manager to be initialized, %v", err)
@@ -314,7 +487,7 @@ func TestSecretDelete(t *testing.T) {
 		}
 
 		err = wait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-			if certMgr.cert == nil {
+			if certMgr.coordinatorCert == nil {
 				return true, nil
 			}
 			return false, nil
@@ -342,7 +515,7 @@ func initFakeClientAndCertManager() (*fake.Clientset, *CertManager, func(), erro
 	return fakeClientSet, certMgr, func() { close(stopCh) }, nil
 }
 
-func checkSecret(certMgr *CertManager, secret *corev1.Secret) (bool, error) {
+func checkSecret(certMgr *CertManager, secret *corev1.Secret, expectFiles []expectFile) (bool, error) {
 	if certMgr.secret == nil {
 		return false, nil
 	}
@@ -350,31 +523,19 @@ func checkSecret(certMgr *CertManager, secret *corev1.Secret) (bool, error) {
 		return false, nil
 	}
 
-	files := []struct {
-		path   string
-		expect []byte
-	}{
-		{
-			path:   certMgr.GetFilePath(RootCA),
-			expect: secret.Data["ca.crt"],
-		},
-		{
-			path:   certMgr.GetFilePath(YurthubClientCert),
-			expect: secret.Data["pool-coordinator-yurthub-client.crt"],
-		},
-		{
-			path:   certMgr.GetFilePath(YurthubClientKey),
-			expect: secret.Data["pool-coordinator-yurthub-client.key"],
-		},
-	}
-
-	for _, f := range files {
-		buf, err := fileStore.Read(f.path)
-		if err != nil {
-			return false, fmt.Errorf("failed to read file at %s, %v", f.path, err)
-		}
-		if string(buf) != string(f.expect) {
-			return false, fmt.Errorf("unexpected value of file %s", f.path)
+	for _, f := range expectFiles {
+		buf, err := fileStore.Read(f.FilePath)
+		if f.Exists {
+			if err != nil {
+				return false, fmt.Errorf("failed to read file at %s, %v", f.FilePath, err)
+			}
+			if string(buf) != string(f.Data) {
+				return false, fmt.Errorf("unexpected value of file %s", f.FilePath)
+			}
+		} else {
+			if err != fs.ErrNotExists {
+				return false, fmt.Errorf("file %s should not exist, but got err: %v", f.FilePath, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Congrool <chpzhangyifei@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug



#### What this PR does / why we need it:

Yurthub cannot delegate node lease because the resourceVersion is 0. Thus, the update will always fail.

Note:
Even this pr is merged, leader yurthub may also cannot delegate heartbeat, beacuse of the noderestiction admission plugin. It only allows the node to update its own kube-node-lease with node certificate. See [noderestriction plugin](https://github.com/kubernetes/kubernetes/blob/v1.22.7/plugin/pkg/admission/noderestriction/admission.go#L542-L565)
To enable this capability, we should disable the admission plugin in APIServer command line options, like

```yaml
...
spec:
  containers:
  - command:
    - kube-apiserver
    - --advertise-address=172.19.0.3
    - --allow-privileged=true
    - --authorization-mode=Node,RBAC
    - --client-ca-file=/etc/kubernetes/pki/ca.crt
#   - --enable-admission-plugins=NodeRestriction
    - --enable-bootstrap-token-auth=true
    - --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
    - --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt
    - --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key
    - --etcd-servers=https://127.0.0.1:2379
    - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
    - --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key
    - --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt
    - --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
    - --requestheader-allowed-names=front-proxy-client
    - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
    - --requestheader-extra-headers-prefix=X-Remote-Extra-
    - --requestheader-group-headers=X-Remote-Group
    - --requestheader-username-headers=X-Remote-User
    - --runtime-config=
    - --secure-port=6443
    - --service-account-issuer=https://kubernetes.default.svc.cluster.local
    - --service-account-key-file=/etc/kubernetes/pki/sa.pub
    - --service-account-signing-key-file=/etc/kubernetes/pki/sa.key
    - --service-cluster-ip-range=10.96.0.0/16
    - --tls-cert-file=/etc/kubernetes/pki/apiserver.crt
    - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
    image: k8s.gcr.io/kube-apiserver:v1.22.7
...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
