### PR TITLE
fix: re-list when target change

### DIFF
--- a/pkg/yurthub/proxy/pool/pool.go
+++ b/pkg/yurthub/proxy/pool/pool.go
@@ -164,6 +164,7 @@ func (pp *PoolCoordinatorProxy) poolWatch(rw http.ResponseWriter, req *http.Requ
 				case <-t.C:
 					if !pp.isCoordinatorReady() {
 						klog.Infof("notified the pool coordinator is not ready for handling request, cancel watch %s", hubutil.ReqString(req))
+						util.ReListWatchReq(rw, req)
 						poolServeCancel()
 						return
 					}


### PR DESCRIPTION
Force re-list pool-scope resource when proxy change between loadbalancer and pool-coordinator