### PR TITLE
add nodeportisolation filter in yurthub

### DIFF
--- a/pkg/yurthub/filter/constant.go
+++ b/pkg/yurthub/filter/constant.go
@@ -33,6 +33,10 @@ const (
 	// in order to make kube-proxy to use InClusterConfig to access kube-apiserver.
 	InClusterConfigFilterName = "inclusterconfig"
 
+	// NodePortIsolationName filter is used to discard or keep NodePort service in specified NodePool
+	// in order to make NodePort will not be listened by kube-proxy component in specified NodePool.
+	NodePortIsolationName = "nodeportisolation"
+
 	// SkipDiscardServiceAnnotation is annotation used by LB service.
 	// If end users want to use specified LB service at the edge side,
 	// End users should add annotation["openyurt.io/skip-discard"]="true" for LB service.
@@ -49,5 +53,6 @@ var (
 		DiscardCloudServiceFilterName: "kube-proxy",
 		ServiceTopologyFilterName:     "kube-proxy, coredns, nginx-ingress-controller",
 		InClusterConfigFilterName:     "kubelet",
+		NodePortIsolationName:         "kube-proxy",
 	}
 )

--- a/pkg/yurthub/filter/initializer/initializer.go
+++ b/pkg/yurthub/filter/initializer/initializer.go
@@ -40,6 +40,11 @@ type WantsNodeName interface {
 	SetNodeName(nodeName string) error
 }
 
+// WantsNodePoolName is an interface for setting nodePool name
+type WantsNodePoolName interface {
+	SetNodePoolName(nodePoolName string) error
+}
+
 // WantsStorageWrapper is an interface for setting StorageWrapper
 type WantsStorageWrapper interface {
 	SetStorageWrapper(s cachemanager.StorageWrapper) error
@@ -62,6 +67,7 @@ type genericFilterInitializer struct {
 	yurtFactory       yurtinformers.SharedInformerFactory
 	storageWrapper    cachemanager.StorageWrapper
 	nodeName          string
+	nodePoolName      string
 	masterServiceHost string
 	masterServicePort string
 	workingMode       util.WorkingMode
@@ -71,7 +77,7 @@ type genericFilterInitializer struct {
 func New(factory informers.SharedInformerFactory,
 	yurtFactory yurtinformers.SharedInformerFactory,
 	sw cachemanager.StorageWrapper,
-	nodeName, masterServiceHost, masterServicePort string,
+	nodeName, nodePoolName, masterServiceHost, masterServicePort string,
 	workingMode util.WorkingMode) *genericFilterInitializer {
 	return &genericFilterInitializer{
 		factory:           factory,
@@ -94,6 +100,12 @@ func (fi *genericFilterInitializer) Initialize(ins filter.ObjectFilter) error {
 
 	if wants, ok := ins.(WantsNodeName); ok {
 		if err := wants.SetNodeName(fi.nodeName); err != nil {
+			return err
+		}
+	}
+
+	if wants, ok := ins.(WantsNodePoolName); ok {
+		if err := wants.SetNodePoolName(fi.nodePoolName); err != nil {
 			return err
 		}
 	}

--- a/pkg/yurthub/filter/manager/manager.go
+++ b/pkg/yurthub/filter/manager/manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/inclusterconfig"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/initializer"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/masterservice"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter/nodeportisolation"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/servicetopology"
 	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
 	"github.com/openyurtio/openyurt/pkg/yurthub/util"
@@ -69,7 +70,7 @@ func NewFilterManager(options *options.YurtHubOptions,
 		}
 	}
 
-	objFilters, err := createObjectFilters(filters, sharedFactory, yurtSharedFactory, storageWrapper, util.WorkingMode(options.WorkingMode), options.NodeName, mutatedMasterServiceHost, mutatedMasterServicePort)
+	objFilters, err := createObjectFilters(filters, sharedFactory, yurtSharedFactory, storageWrapper, util.WorkingMode(options.WorkingMode), options.NodeName, options.NodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort)
 	if err != nil {
 		return nil, err
 	}
@@ -115,12 +116,12 @@ func createObjectFilters(filters *filter.Filters,
 	yurtSharedFactory yurtinformers.SharedInformerFactory,
 	storageWrapper cachemanager.StorageWrapper,
 	workingMode util.WorkingMode,
-	nodeName, mutatedMasterServiceHost, mutatedMasterServicePort string) ([]filter.ObjectFilter, error) {
+	nodeName, nodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort string) ([]filter.ObjectFilter, error) {
 	if filters == nil {
 		return nil, nil
 	}
 
-	genericInitializer := initializer.New(sharedFactory, yurtSharedFactory, storageWrapper, nodeName, mutatedMasterServiceHost, mutatedMasterServicePort, workingMode)
+	genericInitializer := initializer.New(sharedFactory, yurtSharedFactory, storageWrapper, nodeName, nodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort, workingMode)
 	initializerChain := filter.Initializers{}
 	initializerChain = append(initializerChain, genericInitializer)
 	return filters.NewFromFilters(initializerChain)
@@ -133,4 +134,5 @@ func registerAllFilters(filters *filter.Filters) {
 	masterservice.Register(filters)
 	discardcloudservice.Register(filters)
 	inclusterconfig.Register(filters)
+	nodeportisolation.Register(filters)
 }

--- a/pkg/yurthub/filter/nodeportisolation/filter.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeportisolation
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
+	"github.com/openyurtio/openyurt/pkg/yurthub/util"
+	nodepoolv1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/apis/apps/v1alpha1"
+)
+
+const (
+	ServiceAnnotationNodePortListen = "nodeport.openyurt.io/listen"
+)
+
+// Register registers a filter
+func Register(filters *filter.Filters) {
+	filters.Register(filter.NodePortIsolationName, func() (filter.ObjectFilter, error) {
+		return &nodePortIsolationFilter{}, nil
+	})
+}
+
+type nodePortIsolationFilter struct {
+	nodePoolName string
+	workingMode  util.WorkingMode
+	nodeGetter   filter.NodeGetter
+	nodeSynced   cache.InformerSynced
+	nodeName     string
+}
+
+func (nif *nodePortIsolationFilter) Name() string {
+	return filter.NodePortIsolationName
+}
+
+func (nif *nodePortIsolationFilter) SupportedResourceAndVerbs() map[string]sets.String {
+	return map[string]sets.String{
+		"services": sets.NewString("list", "watch"),
+	}
+}
+
+func (nif *nodePortIsolationFilter) SetNodePoolName(name string) error {
+	nif.nodePoolName = name
+	return nil
+}
+
+func (nif *nodePortIsolationFilter) SetNodeName(nodeName string) error {
+	nif.nodeName = nodeName
+	return nil
+}
+
+func (nif *nodePortIsolationFilter) SetWorkingMode(mode util.WorkingMode) error {
+	nif.workingMode = mode
+	return nil
+}
+
+func (nif *nodePortIsolationFilter) SetSharedInformerFactory(factory informers.SharedInformerFactory) error {
+	if nif.workingMode == util.WorkingModeCloud {
+		klog.Infof("prepare list/watch to sync node(%s) for cloud working mode", nif.nodeName)
+		nif.nodeSynced = factory.Core().V1().Nodes().Informer().HasSynced
+		nif.nodeGetter = factory.Core().V1().Nodes().Lister().Get
+	}
+
+	return nil
+}
+
+func (nif *nodePortIsolationFilter) SetStorageWrapper(s cachemanager.StorageWrapper) error {
+	if s.Name() != disk.StorageName {
+		return fmt.Errorf("nodePortIsolationFilter can only support disk storage currently, cannot use %s", s.Name())
+	}
+
+	if len(nif.nodeName) == 0 {
+		return fmt.Errorf("node name for nodePortIsolationFilter is not set")
+	}
+
+	// hub agent will list/watch node from kube-apiserver when hub agent work as cloud mode
+	if nif.workingMode == util.WorkingModeCloud {
+		return nil
+	}
+	klog.Infof("prepare local disk storage to sync node(%s) for edge working mode", nif.nodeName)
+
+	nodeKey, err := s.KeyFunc(storage.KeyBuildInfo{
+		Component: "kubelet",
+		Name:      nif.nodeName,
+		Resources: "nodes",
+		Group:     "",
+		Version:   "v1",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get node key for %s, %v", nif.nodeName, err)
+	}
+	nif.nodeSynced = func() bool {
+		obj, err := s.Get(nodeKey)
+		if err != nil || obj == nil {
+			return false
+		}
+
+		if _, ok := obj.(*v1.Node); !ok {
+			return false
+		}
+
+		return true
+	}
+
+	nif.nodeGetter = func(name string) (*v1.Node, error) {
+		key, err := s.KeyFunc(storage.KeyBuildInfo{
+			Component: "kubelet",
+			Name:      name,
+			Resources: "nodes",
+			Group:     "",
+			Version:   "v1",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("nodeGetter failed to get node key for %s, %v", name, err)
+		}
+		obj, err := s.Get(key)
+		if err != nil {
+			return nil, err
+		} else if obj == nil {
+			return nil, fmt.Errorf("node(%s) is not ready", name)
+		}
+
+		if node, ok := obj.(*v1.Node); ok {
+			return node, nil
+		}
+
+		return nil, fmt.Errorf("node(%s) is not found", name)
+	}
+
+	return nil
+}
+
+func (nif *nodePortIsolationFilter) Filter(obj runtime.Object, stopCh <-chan struct{}) runtime.Object {
+	if ok := cache.WaitForCacheSync(stopCh, nif.nodeSynced); !ok {
+		return obj
+	}
+
+	switch v := obj.(type) {
+	case *v1.ServiceList:
+		var svcNew []v1.Service
+		for i := range v.Items {
+			svc := nif.isolateNodePortService(&v.Items[i])
+			if svc != nil {
+				svcNew = append(svcNew, *svc)
+			}
+		}
+		v.Items = svcNew
+		return v
+	case *v1.Service:
+		return nif.isolateNodePortService(v)
+	default:
+		return v
+	}
+}
+
+func (nif *nodePortIsolationFilter) isolateNodePortService(svc *v1.Service) *v1.Service {
+	nodePoolName := nif.nodePoolName
+	if len(nodePoolName) == 0 {
+		node, err := nif.nodeGetter(nif.nodeName)
+		if err != nil {
+			klog.Warningf("skip isolateNodePortService filter, failed to get node(%s), %v", nif.nodeName, err)
+			return svc
+		}
+		nodePoolName = node.Labels[nodepoolv1alpha1.LabelCurrentNodePool]
+	}
+
+	// node is not located in NodePool, keep the NodePort service the same as native K8s
+	if len(nodePoolName) == 0 {
+		return svc
+	}
+
+	nsName := fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)
+	if svc.Spec.Type == v1.ServiceTypeNodePort || svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+		if _, ok := svc.Annotations[ServiceAnnotationNodePortListen]; ok {
+			nodePoolConf := getNodePoolConfiguration(svc.Annotations[ServiceAnnotationNodePortListen])
+			if nodePoolConf.Len() != 0 && isNodePoolEnabled(nodePoolConf, nodePoolName) {
+				return svc
+			} else {
+				klog.V(2).Infof("nodePort service(%s) is disabled in nodePool(%s) by nodePortIsolationFilter", nsName, nodePoolName)
+				return nil
+			}
+		}
+	}
+
+	return svc
+}
+
+func getNodePoolConfiguration(v string) sets.String {
+	nodePoolConf := sets.NewString()
+	nodePoolsForValidation := sets.NewString()
+	for _, name := range strings.Split(v, ",") {
+		name = strings.TrimSpace(name)
+		trimmedName := strings.TrimPrefix(name, "-")
+		if len(trimmedName) != 0 && !nodePoolsForValidation.Has(trimmedName) {
+			nodePoolsForValidation.Insert(trimmedName)
+			nodePoolConf.Insert(name)
+		}
+	}
+
+	return nodePoolConf
+}
+
+func isNodePoolEnabled(nodePoolConf sets.String, name string) bool {
+	if nodePoolConf.Has(name) {
+		return true
+	}
+
+	if nodePoolConf.Has(fmt.Sprintf("-%s", name)) {
+		return false
+	}
+
+	if nodePoolConf.Has("*") {
+		return true
+	}
+
+	// the nodepool has not been configured
+	return false
+}

--- a/pkg/yurthub/filter/nodeportisolation/filter_test.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter_test.go
@@ -1,0 +1,510 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeportisolation
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openyurtio/openyurt/pkg/util"
+	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
+	hubutil "github.com/openyurtio/openyurt/pkg/yurthub/util"
+)
+
+func TestName(t *testing.T) {
+	nif := &nodePortIsolationFilter{}
+	if nif.Name() != filter.NodePortIsolationName {
+		t.Errorf("expect %s, but got %s", filter.NodePortIsolationName, nif.Name())
+	}
+}
+
+func TestSupportedResourceAndVerbs(t *testing.T) {
+	nif := &nodePortIsolationFilter{}
+	rvs := nif.SupportedResourceAndVerbs()
+	if len(rvs) != 1 {
+		t.Errorf("supported more than one resources, %v", rvs)
+	}
+
+	for resource, verbs := range rvs {
+		if resource != "services" {
+			t.Errorf("expect resource is services, but got %s", resource)
+		}
+
+		if !verbs.Equal(sets.NewString("list", "watch")) {
+			t.Errorf("expect verbs are list/watch, but got %v", verbs.UnsortedList())
+		}
+	}
+}
+
+func TestSetNodePoolName(t *testing.T) {
+	nif := &nodePortIsolationFilter{}
+	if err := nif.SetNodePoolName("nodepool1"); err != nil {
+		t.Errorf("expect nil, but got %v", err)
+	}
+
+	if nif.nodePoolName != "nodepool1" {
+		t.Errorf("expect nodepool name: nodepool1, but got %s", nif.nodePoolName)
+	}
+}
+
+func TestSetNodeName(t *testing.T) {
+	nif := &nodePortIsolationFilter{}
+	if err := nif.SetNodeName("foo"); err != nil {
+		t.Errorf("expect nil, but got %v", err)
+	}
+
+	if nif.nodeName != "foo" {
+		t.Errorf("expect node name: foo, but got %s", nif.nodePoolName)
+	}
+}
+
+func TestSetWorkingMode(t *testing.T) {
+	nif := &nodePortIsolationFilter{}
+	if err := nif.SetWorkingMode(hubutil.WorkingMode("cloud")); err != nil {
+		t.Errorf("expect nil, but got %v", err)
+	}
+
+	if nif.workingMode != hubutil.WorkingModeCloud {
+		t.Errorf("expect working mode: cloud, but got %s", nif.workingMode)
+	}
+}
+
+func TestSetSharedInformerFactory(t *testing.T) {
+	client := &fake.Clientset{}
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	nif := &nodePortIsolationFilter{
+		workingMode: "cloud",
+	}
+	if err := nif.SetSharedInformerFactory(informerFactory); err != nil {
+		t.Errorf("expect nil, but got %v", err)
+	}
+}
+
+func TestSetStorageWrapper(t *testing.T) {
+	nif := &nodePortIsolationFilter{
+		workingMode: "edge",
+		nodeName:    "foo",
+	}
+	storageManager, err := disk.NewDiskStorage("/tmp/nif-filter")
+	if err != nil {
+		t.Fatalf("could not create storage manager, %v", err)
+	}
+	storageWrapper := cachemanager.NewStorageWrapper(storageManager)
+
+	if err := nif.SetStorageWrapper(storageWrapper); err != nil {
+		t.Errorf("expect nil, but got %v", err)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	nodePoolName := "foo"
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}
+	testcases := map[string]struct {
+		isOrphanNodes bool
+		responseObj   runtime.Object
+		expectObj     runtime.Object
+	}{
+		"enable NodePort service listening on nodes in foo and bar NodePool.": {
+			responseObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "foo, bar",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.187",
+							Type:      corev1.ServiceTypeNodePort,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+			},
+			expectObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "foo, bar",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.187",
+							Type:      corev1.ServiceTypeNodePort,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+			},
+		},
+		"enable NodePort service listening on nodes of all NodePools": {
+			responseObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "foo, *",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.187",
+							Type:      corev1.ServiceTypeNodePort,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+			},
+			expectObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "foo, *",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.187",
+							Type:      corev1.ServiceTypeNodePort,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+			},
+		},
+		"disable NodePort service listening on nodes of all NodePools": {
+			responseObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "-foo,-bar",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.187",
+							Type:      corev1.ServiceTypeNodePort,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "-foo",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeLoadBalancer,
+						},
+					},
+				},
+			},
+			expectObj: &corev1.ServiceList{},
+		},
+		"disable NodePort service listening only on nodes in foo NodePool": {
+			responseObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "-foo,*",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.187",
+							Type:      corev1.ServiceTypeNodePort,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+			},
+			expectObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeClusterIP,
+						},
+					},
+				},
+			},
+		},
+		"disable nodeport service": {
+			responseObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ServiceAnnotationNodePortListen: "-foo",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.96.105.187",
+					Type:      corev1.ServiceTypeNodePort,
+				},
+			},
+			expectObj: nil,
+		},
+		"duplicated node pool configuration": {
+			responseObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ServiceAnnotationNodePortListen: "foo,-foo",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.96.105.187",
+					Type:      corev1.ServiceTypeNodePort,
+				},
+			},
+			expectObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ServiceAnnotationNodePortListen: "foo,-foo",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.96.105.187",
+					Type:      corev1.ServiceTypeNodePort,
+				},
+			},
+		},
+		"disable NodePort service listening on nodes of foo NodePool": {
+			responseObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ServiceAnnotationNodePortListen: "-foo",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.96.105.187",
+					Type:      corev1.ServiceTypeNodePort,
+				},
+			},
+			expectObj: nil,
+		},
+		"enable nodeport service on orphan nodes": {
+			isOrphanNodes: true,
+			responseObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ServiceAnnotationNodePortListen: "-foo,*",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.96.105.187",
+					Type:      corev1.ServiceTypeNodePort,
+				},
+			},
+			expectObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						ServiceAnnotationNodePortListen: "-foo,*",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.96.105.187",
+					Type:      corev1.ServiceTypeNodePort,
+				},
+			},
+		},
+		"disable NodePort service listening if no value configured": {
+			responseObj: &corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc1",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: "",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.187",
+							Type:      corev1.ServiceTypeNodePort,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc2",
+							Namespace: "default",
+							Annotations: map[string]string{
+								ServiceAnnotationNodePortListen: " ",
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "10.96.105.188",
+							Type:      corev1.ServiceTypeLoadBalancer,
+						},
+					},
+				},
+			},
+			expectObj: &corev1.ServiceList{},
+		},
+		"skip podList": {
+			responseObj: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pod1",
+							Namespace: "default",
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectObj: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pod1",
+							Namespace: "default",
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	stopCh := make(<-chan struct{})
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			nif := &nodePortIsolationFilter{}
+			if !tc.isOrphanNodes {
+				nif.nodePoolName = nodePoolName
+			} else {
+				nif.nodeName = "foo"
+				nif.nodeGetter = func(name string) (*corev1.Node, error) {
+					return node, nil
+				}
+			}
+			nif.nodeSynced = func() bool {
+				return true
+			}
+			newObj := nif.Filter(tc.responseObj, stopCh)
+			if tc.expectObj == nil {
+				if !util.IsNil(newObj) {
+					t.Errorf("RuntimeObjectFilter expect nil obj, but got %v", newObj)
+				}
+			} else if !reflect.DeepEqual(newObj, tc.expectObj) {
+				t.Errorf("RuntimeObjectFilter got error, expected: \n%v\nbut got: \n%v\n", tc.expectObj, newObj)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind feature

#### What this PR does / why we need it:
add a new filter named nodeportisolation in yurthub in order to make only nodes in specified nodepool can listen on nodePort of service.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1183 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
