### PR TITLE
fix: pool-coordinator cannot be rescheduled when its node fails (#1212)

### DIFF
--- a/charts/openyurt/templates/pool-coordinator.yaml
+++ b/charts/openyurt/templates/pool-coordinator.yaml
@@ -186,9 +186,6 @@ spec:
               seccompProfile:
                 type: RuntimeDefault
             terminationGracePeriodSeconds: 30
-            tolerations:
-              - effect: NoExecute
-                operator: Exists
             volumes:
               - emptyDir:
                   medium: Memory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> /kind bug

#### What this PR does / why we need it:
when the node disconnects from all nodes except itself, pool-coordinator in this node can be rescheduled into a healthy node.

#### Which issue(s) this PR fixes:
Fixes #1212

#### Special notes for your reviewer:
/assign @rambohe-ch
/assign @Congrool

#### Does this PR introduce a user-facing change?
```release-note
Since charts/openyurt/templates/pool-coordinator.yaml is changed, users should upgrade the running pool-coordinator.
```

