### PR TITLE
enhance nodepool autonomy when nodepool is disconnect with cloud

### DIFF
--- a/charts/openyurt/templates/yurt-controller-manager.yaml
+++ b/charts/openyurt/templates/yurt-controller-manager.yaml
@@ -126,6 +126,17 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -159,6 +170,10 @@ spec:
     spec:
       serviceAccountName: yurt-controller-manager
       hostNetwork: true
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       tolerations:
         - operator: "Exists"
       affinity:
@@ -178,3 +193,25 @@ spec:
         imagePullPolicy: {{ .Values.yurtControllerManager.image.pullPolicy }}
         command:
           - yurt-controller-manager
+        ports:
+          - name: webhook-server
+            containerPort: {{ .Values.admissionWebhooks.service.port }}
+            protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "yurt-controller-manager.name" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "yurt-controller-manager.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.admissionWebhooks.service.type }}
+  ports:
+    - port: 443
+      targetPort: {{ .Values.admissionWebhooks.service.port }}
+      protocol: TCP
+      name: https
+  selector:
+    {{ include "yurt-controller-manager.selectorLabels" . | nindent 6 }}

--- a/charts/openyurt/values.yaml
+++ b/charts/openyurt/values.yaml
@@ -36,5 +36,18 @@ poolCoordinator:
       cpu: 100m
       memory: 256Mi
 
+admissionWebhooks:
+  service:
+    type: ClusterIP
+    port: 9443
+  failurePolicy: Fail
+  certificate:
+    mountPath: /tmp/k8s-webhook-server/serving-certs
+  names:
+    validatingWebhookName: vpoolcoordinator.openyurt.io
+    mutatingWebhookName: mpoolcoordinator.openyurt.io
+    webhookPodValidatingPath: /pool-coordinator-webhook-validate
+    webhookPodMutatingPath: /pool-coordinator-webhook-mutate
+
 yurtHub:
   cacheAgents: ""

--- a/cmd/yurt-controller-manager/app/controllermanager.go
+++ b/cmd/yurt-controller-manager/app/controllermanager.go
@@ -30,6 +30,8 @@ import (
 	"os"
 	"time"
 
+	yurtclientset "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/clientset/versioned"
+	yurtinformers "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/informers/externalversions"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -54,8 +56,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-controller-manager/app/options"
 	yurtctrlmgrconfig "github.com/openyurtio/openyurt/pkg/controller/apis/config"
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
-	yurtclientset "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/clientset/versioned"
-	yurtinformers "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/informers/externalversions"
 )
 
 const (
@@ -315,6 +315,7 @@ func NewControllerInitializers() map[string]InitFunc {
 	controllers["daemonpodupdater"] = startDaemonPodUpdaterController
 	controllers["servicetopologycontroller"] = startServiceTopologyController
 	controllers["podbinding"] = startPodBindingController
+	controllers["webhookmanager"] = startWebhookManager
 	return controllers
 }
 

--- a/cmd/yurt-controller-manager/app/core.go
+++ b/cmd/yurt-controller-manager/app/core.go
@@ -25,11 +25,12 @@ import (
 	"net/http"
 
 	"github.com/openyurtio/openyurt/pkg/controller/certificates"
-	daemonpodupdater "github.com/openyurtio/openyurt/pkg/controller/daemonpodupdater"
+	"github.com/openyurtio/openyurt/pkg/controller/daemonpodupdater"
 	poolcoordinatorcertmanager "github.com/openyurtio/openyurt/pkg/controller/poolcoordinator/cert"
 	poolcoordinator "github.com/openyurtio/openyurt/pkg/controller/poolcoordinator/delegatelease"
 	"github.com/openyurtio/openyurt/pkg/controller/poolcoordinator/podbinding"
 	"github.com/openyurtio/openyurt/pkg/controller/servicetopology"
+	"github.com/openyurtio/openyurt/pkg/webhook"
 )
 
 func startPoolCoordinatorCertManager(ctx ControllerContext) (http.Handler, bool, error) {
@@ -94,5 +95,15 @@ func startPodBindingController(ctx ControllerContext) (http.Handler, bool, error
 		ctx.InformerFactory,
 	)
 	go podBindingController.Run(ctx.Stop)
+	return nil, true, nil
+}
+
+func startWebhookManager(ctx ControllerContext) (http.Handler, bool, error) {
+	webhookManager := webhook.NewWebhookManager(
+		ctx.ClientBuilder.ClientOrDie("webhook manager"),
+		ctx.YurtInformerFactory,
+		ctx.InformerFactory,
+	)
+	go webhookManager.Run(ctx.Stop)
 	return nil, true, nil
 }

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -101,3 +101,18 @@ func backupFile(path string) error {
 	_, err = io.Copy(dst, src)
 	return err
 }
+
+func DirExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info.IsDir()
+}
+
+func EnsureDir(dir string) error {
+	if DirExists(dir) {
+		return nil
+	}
+	return os.MkdirAll(dir, 0750)
+}

--- a/pkg/webhook/certs.go
+++ b/pkg/webhook/certs.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"time"
+
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+)
+
+type Certs struct {
+	// PEM encoded private key
+	Key []byte
+	// PEM encoded serving certificate
+	Cert []byte
+	// PEM encoded CA private key
+	CAKey []byte
+	// PEM encoded CA certificate
+	CACert []byte
+	// Resource version of the certs
+	ResourceVersion string
+}
+
+const (
+	rsaKeySize = 2048
+)
+
+// GenerateCerts generate a suite of self signed CA and server cert
+func GenerateCerts(serviceNamespace, serviceName string) *Certs {
+	certs := &Certs{}
+	certs.generate(serviceNamespace, serviceName)
+	return certs
+}
+
+func (c *Certs) generate(serviceNamespace, serviceName string) error {
+	caKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
+	if err != nil {
+		return fmt.Errorf("failed to create CA private key: %v", err)
+	}
+	caCert, err := cert.NewSelfSignedCACert(cert.Config{CommonName: "yurt-webhooks-cert-ca"}, caKey)
+	if err != nil {
+		return fmt.Errorf("failed to create CA cert: %v", err)
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
+	if err != nil {
+		return fmt.Errorf("failed to create private key: %v", err)
+	}
+
+	commonName := ServiceToCommonName(serviceNamespace, serviceName)
+	hostIP := net.ParseIP(commonName)
+	var altIPs []net.IP
+	if hostIP.To4() != nil {
+		altIPs = append(altIPs, hostIP.To4())
+	}
+	dnsNames := []string{serviceName, fmt.Sprintf("%s.%s", serviceName, serviceNamespace), commonName}
+	signedCert, err := NewSignedCert(
+		cert.Config{
+			CommonName: commonName,
+			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			AltNames:   cert.AltNames{IPs: altIPs, DNSNames: dnsNames},
+		},
+		key, caCert, caKey,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create cert: %v", err)
+	}
+
+	c.Key = EncodePrivateKeyPEM(key)
+	c.Cert = EncodeCertPEM(signedCert)
+	c.CAKey = EncodePrivateKeyPEM(caKey)
+	c.CACert = EncodeCertPEM(caCert)
+
+	return nil
+}
+
+func NewSignedCert(cfg cert.Config, key crypto.Signer, caCert *x509.Certificate, caKey crypto.Signer) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.CommonName) == 0 {
+		return nil, errors.New("must specify a CommonName")
+	}
+	if len(cfg.Usages) == 0 {
+		return nil, errors.New("must specify at least one ExtKeyUsage")
+	}
+
+	certTmpl := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		DNSNames:     cfg.AltNames.DNSNames,
+		IPAddresses:  cfg.AltNames.IPs,
+		SerialNumber: serial,
+		NotBefore:    caCert.NotBefore,
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365 * 100).UTC(),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  cfg.Usages,
+	}
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(certDERBytes)
+}
+
+// EncodePrivateKeyPEM returns PEM-encoded private key data
+func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	block := pem.Block{
+		Type:  keyutil.RSAPrivateKeyBlockType,
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return pem.EncodeToMemory(&block)
+}
+
+// EncodeCertPEM returns PEM-endcoded certificate data
+func EncodeCertPEM(ct *x509.Certificate) []byte {
+	block := pem.Block{
+		Type:  cert.CertificateBlockType,
+		Bytes: ct.Raw,
+	}
+	return pem.EncodeToMemory(&block)
+}
+
+// serviceToCommonName generates the CommonName for the certificate when using a k8s service.
+func ServiceToCommonName(serviceNamespace, serviceName string) string {
+	return fmt.Sprintf("%s.%s.svc", serviceName, serviceNamespace)
+}

--- a/pkg/webhook/pool_coordinator_webhook.go
+++ b/pkg/webhook/pool_coordinator_webhook.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	yurtinformers "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/informers/externalversions"
+	yurtlisters "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/listers/apps/v1alpha1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/informers/core/v1"
+	client "k8s.io/client-go/kubernetes"
+	leaselisterv1 "k8s.io/client-go/listers/coordination/v1"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+type PoolCoordinatorWebhook struct {
+	client         client.Interface
+	nodeInformer   v1.NodeInformer
+	nodeSynced     cache.InformerSynced
+	nodeLister     listerv1.NodeLister
+	nodePoolSynced cache.InformerSynced
+	nodePoolLister yurtlisters.NodePoolLister
+	leaseSynced    cache.InformerSynced
+	leaseLister    leaselisterv1.LeaseNamespaceLister
+}
+
+func NewPoolcoordinatorWebhook(kc client.Interface,
+	yurtInformers yurtinformers.SharedInformerFactory,
+	informerFactory informers.SharedInformerFactory) *PoolCoordinatorWebhook {
+
+	nodePoolInformer := yurtInformers.Apps().V1alpha1().NodePools()
+	leaseInformer := informerFactory.Coordination().V1().Leases()
+	h := &PoolCoordinatorWebhook{
+		client:         kc,
+		nodeInformer:   informerFactory.Core().V1().Nodes(),
+		nodePoolSynced: nodePoolInformer.Informer().HasSynced,
+		nodePoolLister: nodePoolInformer.Lister(),
+		leaseSynced:    leaseInformer.Informer().HasSynced,
+		leaseLister:    leaseInformer.Lister().Leases(corev1.NamespaceNodeLease),
+	}
+	h.nodeSynced = h.nodeInformer.Informer().HasSynced
+	h.nodeLister = h.nodeInformer.Lister()
+
+	return h
+}
+
+func (h *PoolCoordinatorWebhook) Init(certs *Certs, stopCH <-chan struct{}) {
+	if !cache.WaitForCacheSync(stopCH, h.nodeSynced, h.nodePoolSynced, h.leaseSynced) {
+		klog.Error("sync poolcoordinator webhook timeout")
+	}
+
+	h.ensureValidatingConfiguration(certs)
+}
+
+func (h *PoolCoordinatorWebhook) Handler() []Handler {
+	return []Handler{
+		{ValidatePath, h.serveValidatePods},
+	}
+}
+
+func (h *PoolCoordinatorWebhook) ensureValidatingConfiguration(certs *Certs) {
+	fail := admissionregistrationv1.Fail
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	validatingConfigurationName := GetEnv(EnvPodValidatingConfigurationName, DefaultPodValidatingConfigurationName)
+	validatingPath := GetEnv(EnvPodValidatingPath, DefaultPodValidatingPath)
+	config := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: validatingConfigurationName,
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name: GetEnv(EnvPodValidatingName, DefaultPodValidatingName),
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				CABundle: certs.CACert,
+				Service: &admissionregistrationv1.ServiceReference{
+					Name:      GetEnv(EnvServiceName, DefaultServiceName),
+					Namespace: GetEnv(EnvNamespace, DefaultNamespace),
+					Path:      &validatingPath,
+				},
+			},
+			Rules: []admissionregistrationv1.RuleWithOperations{
+				{Operations: []admissionregistrationv1.OperationType{
+					admissionregistrationv1.Delete},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				}},
+			FailurePolicy:           &fail,
+			SideEffects:             &sideEffects,
+			AdmissionReviewVersions: []string{"v1"},
+		}},
+	}
+
+	oldConfig, err := h.client.AdmissionregistrationV1().ValidatingWebhookConfigurations().
+		Get(context.TODO(), validatingConfigurationName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Infof("validateWebhookConfiguration %s not found, create it.", validatingConfigurationName)
+			if _, err = h.client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(
+				context.TODO(), config, metav1.CreateOptions{}); err != nil {
+				klog.Fatal(err)
+			}
+		}
+	} else {
+		klog.Infof("validateWebhookConfiguration %s already exists, update it.", validatingConfigurationName)
+		oldConfig.Webhooks = config.Webhooks
+		if _, err = h.client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(
+			context.TODO(), oldConfig, metav1.UpdateOptions{}); err != nil {
+			klog.Fatal(err)
+		}
+	}
+}
+
+// ServeValidatePods validates an admission request and then writes an admission
+func (h *PoolCoordinatorWebhook) serveValidatePods(w http.ResponseWriter, r *http.Request) {
+	klog.Infof("poolcoordinator webhook uri: %s", r.RequestURI)
+
+	pa, err := h.NewPodAdmission(r)
+	if err != nil {
+		klog.Error(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	out, err := pa.validateReview()
+	if err != nil {
+		e := fmt.Sprintf("could not generate admission response: %v", err)
+		klog.Error(e)
+		http.Error(w, e, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", DefaultContentType)
+
+	jout, err := json.Marshal(out)
+	if err != nil {
+		e := fmt.Sprintf("could not parse admission response: %v", err)
+		klog.Error(e)
+		http.Error(w, e, http.StatusInternalServerError)
+		return
+	}
+
+	klog.Infof("sending response: %s", jout)
+	fmt.Fprintf(w, "%s", jout)
+}
+
+func (h *PoolCoordinatorWebhook) NewPodAdmission(r *http.Request) (*PodAdmission, error) {
+	admissionReview, err := ParseRequest(*r)
+	if err != nil {
+		return nil, err
+	}
+
+	req := admissionReview.Request
+	if req.Kind.Kind != "Pod" {
+		return nil, fmt.Errorf("only pods are supported")
+	}
+
+	pod := &corev1.Pod{}
+	if req.Operation == admissionv1.Delete || req.Operation == admissionv1.Update {
+		err = json.Unmarshal(req.OldObject.Raw, pod)
+	} else {
+		err = json.Unmarshal(req.Object.Raw, pod)
+	}
+	if err != nil {
+		klog.Errorf("json unmarshal to pod error: %+v", err)
+		return nil, err
+	}
+
+	nodeName := pod.Spec.NodeName
+	klog.Infof("pod %s is on node: %s\n", pod.Name, nodeName)
+	node, err := h.nodeLister.Get(nodeName)
+	if err != nil {
+		klog.Errorf("nodeLister get node %s error: %+v", nodeName, err)
+		return nil, err
+	}
+
+	pa := &PodAdmission{
+		request:        req,
+		pod:            pod,
+		node:           node,
+		leaseLister:    h.leaseLister,
+		nodePoolLister: h.nodePoolLister,
+	}
+	klog.Infof("name: %s, namespace: %s, operation: %s, from: %v", req.Name, req.Namespace, req.Operation, &req.UserInfo)
+	return pa, nil
+}
+
+type PodAdmission struct {
+	request        *admissionv1.AdmissionRequest
+	pod            *corev1.Pod
+	node           *corev1.Node
+	leaseLister    leaselisterv1.LeaseNamespaceLister
+	nodePoolLister yurtlisters.NodePoolLister
+}
+
+func (pa *PodAdmission) validateReview() (*admissionv1.AdmissionReview, error) {
+	if pa.request.Kind.Kind != "Pod" {
+		err := fmt.Errorf("only pods are supported here")
+		return ReviewResponse(pa.request.UID, false, http.StatusBadRequest, ""), err
+	}
+
+	if pa.request.Operation != admissionv1.Delete {
+		reason := fmt.Sprintf("Operation %v is accepted always", pa.request.Operation)
+		return ReviewResponse(pa.request.UID, true, http.StatusAccepted, reason), nil
+	}
+
+	isValid, msg := pa.validateDelete()
+	klog.Infof("validateDelete result: %+v, msg: %+v", isValid, msg)
+	if !isValid {
+		return ReviewResponse(pa.request.UID, false, http.StatusForbidden, msg), nil
+	}
+	return ReviewResponse(pa.request.UID, true, http.StatusAccepted, msg), nil
+}
+
+// validateDelete returns true if a pod is valid to delete/evict
+func (pa *PodAdmission) validateDelete() (bool, string) {
+	if !pa.userIsNodeController() {
+		return true, msgPodNormalDelete
+	}
+
+	// get number of nodes in node pool
+	var nodePoolName string
+	if pa.node.Labels != nil {
+		if name, ok := pa.node.Labels[LabelCurrentNodePool]; ok {
+			nodePoolName = name
+		}
+	}
+	if nodePoolName == "" {
+		return true, msgNodeNotInNodePool
+	}
+
+	nodePool, err := pa.nodePoolLister.Get(nodePoolName)
+	if err != nil {
+		klog.Errorf("validateDelete get nodePool %s error: %+v", nodePoolName, err)
+		return false, msgNodePoolStatusError
+	}
+	nodeNumber := len(nodePool.Status.Nodes)
+
+	// check number of ready nodes in node pool
+	readyNumber := CountAliveNode(pa.leaseLister, nodePool.Status.Nodes)
+
+	// When number of ready nodes in node pool is below a configurable parameter,
+	// we don't allow pods to move within the pool any more.
+	// This threshold defaults to one third of the number of pool's nodes.
+	threshold := GetPoolReadyNodeNumberRatioThreshold()
+	if float64(readyNumber)/float64(nodeNumber) < threshold {
+		return false, msgPoolHasTooFewReadyNodes
+	}
+	return true, msgPodAvailablePoolAndNodeIsNotAlive
+}
+
+func (pa *PodAdmission) userIsNodeController() bool {
+	return strings.Contains(pa.request.UserInfo.Username, "system:serviceaccount:kube-system:node-controller")
+}

--- a/pkg/webhook/util.go
+++ b/pkg/webhook/util.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	leaselisterv1 "k8s.io/client-go/listers/coordination/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/controller/poolcoordinator/constant"
+	"github.com/openyurtio/openyurt/pkg/yurthub/util"
+)
+
+const (
+	EnvCertDirName                       = "WEBHOOK_CERT_DIR"
+	EnvServicePort                       = "WEBHOOK_SERVICE_PORT"
+	EnvPoolReadyNodeNumberRatioThreshold = "WEBHOOK_POOL_READY_NODE_NUMBER_RATIO_THRESHOLD"
+	EnvNamespace                         = "WEBHOOK_NAMESPACE"
+	EnvServiceName                       = "WEBHOOK_SERVICE_NAME"
+	EnvPodValidatingConfigurationName    = "WEBHOOK_POD_VALIDATING_CONFIGURATION_NAME"
+	EnvPodValidatingName                 = "WEBHOOK_POD_VALIDATING_NAME"
+	EnvPodValidatingPath                 = "WEBHOOK_POD_VALIDATING_PATH"
+
+	DefaultCertDir                           = "/tmp/k8s-webhook-server/serving-certs"
+	DefaultServicePort                       = "9443"
+	DefaultContentType                       = "application/json"
+	DefaultNamespace                         = "kube-system"
+	DefaultServiceName                       = "yurt-controller-manager-webhook"
+	DefaultPodValidatingConfigurationName    = "yurt-controller-manager"
+	DefaultPodValidatingName                 = "vpoolcoordinator.openyurt.io"
+	DefaultPodValidatingPath                 = "/pool-coordinator-webhook-validate"
+	DefaultPoolReadyNodeNumberRatioThreshold = 0.35
+
+	ValidatePath = "/pool-coordinator-webhook-validate"
+	MutatePath   = "/pool-coordinator-webhook-mutate"
+
+	NodeLeaseDurationSeconds = 40
+
+	// LabelCurrentNodePool indicates which nodepool the node is currently belonging to
+	LabelCurrentNodePool = "apps.openyurt.io/nodepool"
+)
+
+const (
+	msgNodeNotInNodePool                 string = "node is not in nodePool"
+	msgNodePoolStatusError               string = "get nodePool info error"
+	msgPoolHasTooFewReadyNodes           string = "nodePool has too few ready nodes"
+	msgPodAvailablePoolAndNodeIsNotAlive string = "node is not alive in a pool, eviction approved"
+	msgPodNormalDelete                   string = "delete operation is not node controller, delete approved"
+)
+
+func GetEnv(key, defaultValue string) string {
+	if p := os.Getenv(key); len(p) > 0 {
+		return p
+	}
+	return defaultValue
+}
+
+func GetPoolReadyNodeNumberRatioThreshold() float64 {
+	if p := os.Getenv(EnvPoolReadyNodeNumberRatioThreshold); len(p) > 0 {
+		num, err := strconv.ParseFloat(p, 64)
+		if err != nil {
+			klog.Errorf("GetPoolReadyNodeNumberRatioThreshold ParseFloat num %s error: %+v", p, err)
+			return 0
+		}
+		return num
+	}
+	return DefaultPoolReadyNodeNumberRatioThreshold
+}
+
+// ParseRequest extracts an AdmissionReview from an http.Request if possible
+func ParseRequest(r http.Request) (*admissionv1.AdmissionReview, error) {
+	contentType := r.Header.Get("Content-Type")
+	if contentType != DefaultContentType {
+		return nil, fmt.Errorf("Content-Type: %q should be %q", contentType, contentType)
+	}
+
+	var buf bytes.Buffer
+	if n, err := buf.ReadFrom(r.Body); err != nil || n == 0 {
+		return nil, fmt.Errorf("failed to read admission request %s, read %d bytes, %v", util.ReqString(&r), n, err)
+	}
+
+	var a admissionv1.AdmissionReview
+	if err := json.Unmarshal(buf.Bytes(), &a); err != nil {
+		return nil, fmt.Errorf("could not parse admission review request: %v", err)
+	}
+
+	if a.Request == nil {
+		return nil, fmt.Errorf("admission review can't be used: Request field is nil")
+	}
+
+	return &a, nil
+}
+
+// ReviewResponse builds an admission review with given parameter
+func ReviewResponse(uid types.UID, allowed bool, httpCode int32, reason string) *admissionv1.AdmissionReview {
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Response: &admissionv1.AdmissionResponse{
+			UID:     uid,
+			Allowed: allowed,
+			Result: &metav1.Status{
+				Code:    httpCode,
+				Message: reason,
+			},
+		},
+	}
+}
+
+// PatchReviewResponse builds an admission review with given json patch
+func PatchReviewResponse(uid types.UID, patch []byte) (*admissionv1.AdmissionReview, error) {
+	patchType := admissionv1.PatchTypeJSONPatch
+
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Response: &admissionv1.AdmissionResponse{
+			UID:       uid,
+			Allowed:   true,
+			PatchType: &patchType,
+			Patch:     patch,
+		},
+	}, nil
+}
+
+// NodeIsAlive return true if node is alive, otherwise is false
+func NodeIsAlive(leaseLister leaselisterv1.LeaseNamespaceLister, nodeName string) bool {
+	lease, err := leaseLister.Get(nodeName)
+	if err != nil {
+		klog.Errorf("NodeIsAlive get node %s lease error: %+v", nodeName, err)
+		return false
+	}
+
+	// check lease update time
+	diff := time.Now().Sub(lease.Spec.RenewTime.Time)
+	if diff.Seconds() > NodeLeaseDurationSeconds {
+		return false
+	}
+
+	// check lease if delegate or not
+	if lease.Annotations != nil && lease.Annotations[constant.DelegateHeartBeat] == "true" {
+		return false
+	}
+	return true
+}
+
+// CountAliveNode return number of node alive
+func CountAliveNode(leaseLister leaselisterv1.LeaseNamespaceLister, nodes []string) int {
+	cnt := 0
+	for _, n := range nodes {
+		if NodeIsAlive(leaseLister, n) {
+			cnt++
+		}
+	}
+	return cnt
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	yurtinformers "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/informers/externalversions"
+	"k8s.io/client-go/informers"
+	client "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/util/file"
+)
+
+type Handler struct {
+	Path        string
+	HttpHandler func(http.ResponseWriter, *http.Request)
+}
+
+type Webhook interface {
+	Handler() []Handler
+	Init(*Certs, <-chan struct{})
+}
+
+type WebhookManager struct {
+	client   client.Interface
+	certDir  string
+	webhooks []Webhook
+}
+
+func NewWebhookManager(kc client.Interface,
+	yurtInformers yurtinformers.SharedInformerFactory,
+	informerFactory informers.SharedInformerFactory) *WebhookManager {
+
+	m := &WebhookManager{}
+	m.certDir = GetEnv(EnvCertDirName, DefaultCertDir)
+
+	h := NewPoolcoordinatorWebhook(kc, yurtInformers, informerFactory)
+	m.addWebhook(h)
+
+	return m
+}
+
+func (m *WebhookManager) addWebhook(webhook Webhook) {
+	m.webhooks = append(m.webhooks, webhook)
+}
+
+func (m *WebhookManager) Run(stopCH <-chan struct{}) {
+	err := file.EnsureDir(m.certDir)
+	if err != nil {
+		klog.Error(err)
+	}
+	crt := m.certDir + "/tls.crt"
+	key := m.certDir + "/tls.key"
+
+	certs := GenerateCerts(GetEnv(EnvNamespace, DefaultNamespace), GetEnv(EnvServiceName, DefaultServiceName))
+	err = os.WriteFile(crt, certs.Cert, 0660)
+	if err != nil {
+		klog.Error(err)
+	}
+	err = os.WriteFile(key, certs.Key, 0660)
+	if err != nil {
+		klog.Error(err)
+	}
+
+	for {
+		crtExist, _ := file.FileExists(crt)
+		keyExist, _ := file.FileExists(key)
+		if crtExist && keyExist {
+			klog.Info("tls key and cert is ok")
+			break
+		} else {
+			klog.Info("Waiting for tls key and cert...")
+			time.Sleep(time.Second)
+		}
+	}
+
+	for _, h := range m.webhooks {
+		h.Init(certs, stopCH)
+		for _, hh := range h.Handler() {
+			http.HandleFunc(hh.Path, hh.HttpHandler)
+		}
+	}
+
+	servicePort := GetEnv(EnvServicePort, DefaultServicePort)
+	klog.Infof("Listening on port %s ...", servicePort)
+	klog.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%s", servicePort), crt, key, nil))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
On the current situation, when nodepool disconnect with cloud, if node does not open autonomy, the pod in node wil be evict. In another way, if the node open autonomy, when node actually down, the pod binding controller will not evict the pod, it`s different from nodepool governance.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1197 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

/assign @rambohe-ch

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
