### PR TITLE
Fix: make rename replace old dir

### DIFF
--- a/pkg/yurthub/util/fs/store.go
+++ b/pkg/yurthub/util/fs/store.go
@@ -253,6 +253,11 @@ func (fs *FileSystemOperator) Rename(oldPath string, newPath string) error {
 	if !IfExists(oldPath) {
 		return ErrNotExists
 	}
+	if IfExists(newPath) {
+		if err := fs.DeleteDir(newPath); err != nil {
+			return err
+		}
+	}
 	if filepath.Dir(oldPath) != filepath.Dir(newPath) {
 		return ErrInvalidPath
 	}

--- a/pkg/yurthub/util/fs/store.go
+++ b/pkg/yurthub/util/fs/store.go
@@ -253,11 +253,13 @@ func (fs *FileSystemOperator) Rename(oldPath string, newPath string) error {
 	if !IfExists(oldPath) {
 		return ErrNotExists
 	}
-	if IfExists(newPath) {
+
+	if ok, err := IsDir(newPath); ok && err == nil {
 		if err := fs.DeleteDir(newPath); err != nil {
 			return err
 		}
 	}
+
 	if filepath.Dir(oldPath) != filepath.Dir(newPath) {
 		return ErrInvalidPath
 	}


### PR DESCRIPTION
Now, 'Rename' function can't handler the condition that 'If file of newPath has already existed, it will be replaced.' , and error would occurs. We should delete newPath if it's existed.