### PR TITLE
Fix: remove deprecated rand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,3 +196,11 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
+
+
+fmt:
+	go fmt ./...
+	find . -name '*.go' | grep -Ev 'vendor|thrift_gen' | xargs goimports -w
+
+vet:
+	GO111MODULE=${GO_MODULE} go list ./... | grep -v "vendor" | xargs go vet

--- a/cmd/yurt-controller-manager/controller-manager.go
+++ b/cmd/yurt-controller-manager/controller-manager.go
@@ -38,7 +38,8 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	newRand.Seed(time.Now().UnixNano())
 
 	command := app.NewControllerManagerCommand()
 

--- a/cmd/yurt-manager/yurt-manager.go
+++ b/cmd/yurt-manager/yurt-manager.go
@@ -30,7 +30,8 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	newRand.Seed(time.Now().UnixNano())
 
 	command := app.NewYurtManagerCommand()
 

--- a/cmd/yurt-node-servant/node-servant.go
+++ b/cmd/yurt-node-servant/node-servant.go
@@ -35,7 +35,8 @@ import (
 // running on specific node, do convert/revert job
 // node-servant convert/revert join/reset, yurtcluster operator shall start a k8s job to run this.
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	newRand.Seed(time.Now().UnixNano())
 
 	version := fmt.Sprintf("%#v", projectinfo.Get())
 	rootCmd := &cobra.Command{

--- a/cmd/yurthub/yurthub.go
+++ b/cmd/yurthub/yurthub.go
@@ -27,7 +27,9 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	newRand.Seed(time.Now().UnixNano())
+
 	cmd := app.NewCmdStartYurtHub(server.SetupSignalContext())
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:

that need a specific result sequence should use NewRand(NewSource(seed))
<img width="742" alt="image" src="https://user-images.githubusercontent.com/18587688/226537442-e727ce29-bedb-4855-8026-b3d8c711c5c3.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".



-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
