### PR TITLE
fix nil image registry of pool-coordinator

### DIFF
--- a/charts/openyurt/templates/pool-coordinator.yaml
+++ b/charts/openyurt/templates/pool-coordinator.yaml
@@ -146,7 +146,7 @@ spec:
                   - --listen-metrics-urls=http://0.0.0.0:{{ .Values.poolCoordinator.etcdMetricPort }}
                   - --snapshot-count=10000
                   - --trusted-ca-file=/etc/kubernetes/pki/ca.crt
-                image: "{{ .Values.poolCoordinator.etcdImage.repository }}:{{ .Values.poolCoordinator.etcdImage.tag }}"
+                image: "{{ .Values.poolCoordinator.etcdImage.registry }}/{{ .Values.poolCoordinator.etcdImage.repository }}:{{ .Values.poolCoordinator.etcdImage.tag }}"
                 imagePullPolicy: {{ .Values.imagePullPolicy }}
                 name: etcd
                 {{- if .Values.poolCoordinator.etcdResources}}

--- a/charts/openyurt/values.yaml
+++ b/charts/openyurt/values.yaml
@@ -11,7 +11,8 @@ yurtControllerManager:
 poolCoordinator:
   apiserverSecurePort: 10270
   apiserverImage:
-    repository: registry.k8s.io/kube-apiserver
+    registry: registry.k8s.io
+    repository: kube-apiserver
     tag: v1.22.0
   apiserverResources:
     requests:
@@ -20,7 +21,8 @@ poolCoordinator:
   etcdPort: 12379
   etcdMetricPort: 12381
   etcdImage:
-    repository: registry.k8s.io/etcd
+    registry: registry.k8s.io
+    repository: etcd
     tag: 3.5.0-0
   etcdResources:
     limits:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:

Pool-coordinator APIServer image is 

```
{{ .Values.poolCoordinator.apiserverImage.registry }}/{{ .Values.poolCoordinator.apiserverImage.repository }}:{{ .Values.poolCoordinator.apiserverImage.tag }}
```

But there's no `.Values.poolCoordinator.apiserverImage.registry`, which causes the applied image of apiserver is `/registry.k8s.io/kube-apiserver:v1.22.0` making pool-coordinator fail to run. This pr will solve this problem.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
