### PR TITLE
inject clusterrolebinding for apiserver in pool-coordinator to enable `kubectl logs` within nodepool scope

### DIFF
--- a/charts/openyurt/templates/pool-coordinator.yaml
+++ b/charts/openyurt/templates/pool-coordinator.yaml
@@ -63,31 +63,84 @@ spec:
             labels:
               k8s-app: pool-coordinator
           spec:
+        initContainers:
+          - image: alpine:3.14
+            name: init-tools
+            command:
+              - /bin/sh
+              - -c
+              - |
+                sed -i "s/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g" /etc/apk/repositories              
+                apk add busybox-static curl
+                cp $(which busybox.static) /tmp/tools/busybox
+                ARCH=$(uname -m)
+                VERSION={{ .Values.poolCoordinator.apiserverImage.tag }}
+                case $ARCH in
+                  x86_64)
+                    URL="https://dl.k8s.io/release/$VERSION/bin/linux/amd64/kubectl"
+                    ;;
+                  armv6l|armv7l)
+                    URL="https://dl.k8s.io/release/$VERSION/bin/linux/arm/kubectl"
+                    ;;
+                  aarch64)
+                    URL="https://dl.k8s.io/release/$VERSION/bin/linux/arm64/kubectl"
+                    ;;
+                  *)
+                    echo "Unsupported architecture: $ARCH"
+                    exit 1
+                    ;;
+                esac
+                echo "Downloading kubectl from $URL"
+                curl -LO $URL
+                chmod +x kubectl
+                mv ./kubectl /tmp/tools/kubectl
+            volumeMounts:
+              - mountPath: /tmp/tools
+                name: rbac-inject-tools            
             containers:
               - command:
-                  - kube-apiserver
-                  - --bind-address=0.0.0.0
-                  - --allow-privileged=true
-                  - --anonymous-auth=true
-                  - --authorization-mode=Node,RBAC
-                  - --client-ca-file=/etc/kubernetes/pki/ca.crt
-                  - --enable-admission-plugins=NodeRestriction
-                  - --enable-bootstrap-token-auth=true
-                  - --disable-admission-plugins=ServiceAccount
-                  - --etcd-cafile=/etc/kubernetes/pki/ca.crt
-                  - --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt
-                  - --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key
-                  - --etcd-servers=https://127.0.0.1:{{ .Values.poolCoordinator.etcdPort }}
-                  - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
-                  - --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key
-                  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-                  - --secure-port={{ .Values.poolCoordinator.apiserverSecurePort }}
-                  - --service-account-issuer=https://kubernetes.default.svc.cluster.local
-                  - --service-account-key-file=/etc/kubernetes/pki/sa.pub
-                  - --service-account-signing-key-file=/etc/kubernetes/pki/sa.key
-                  - --service-cluster-ip-range={{ .Values.poolCoordinator.serviceClusterIPRange }}
-                  - --tls-cert-file=/etc/kubernetes/pki/apiserver.crt
-                  - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
+                - /tmp/tools/busybox
+                - sh
+                - -c
+                - |
+                  KUBECTL="/tmp/tools/kubectl"
+                  SLEEP="/tmp/tools/busybox sleep"
+                  (
+                    ${SLEEP} 5
+                    while true; do
+                      echo "Trying to inject rbac..."
+                      ${KUBECTL} apply -f /tmp/rbac --kubeconfig /etc/kubernetes/pki/admin.conf
+                      if [ $? -eq 0 ]; then
+                        break
+                      fi
+                      ${SLEEP} 1
+                    done
+                    echo "Successfully injected rbac!"
+                  ) &
+
+                  exec kube-apiserver \
+                  --bind-address=0.0.0.0 \
+                  --allow-privileged=true \
+                  --anonymous-auth=true \
+                  --authorization-mode=Node,RBAC \
+                  --client-ca-file=/etc/kubernetes/pki/ca.crt \
+                  --enable-admission-plugins=NodeRestriction \
+                  --enable-bootstrap-token-auth=true \
+                  --disable-admission-plugins=ServiceAccount \
+                  --etcd-cafile=/etc/kubernetes/pki/ca.crt \
+                  --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt \
+                  --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key \
+                  --etcd-servers=https://127.0.0.1:{{ .Values.poolCoordinator.etcdPort }} \
+                  --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt \
+                  --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key \
+                  --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname \
+                  --secure-port={{ .Values.poolCoordinator.apiserverSecurePort }} \
+                  --service-account-issuer=https://kubernetes.default.svc.cluster.local \
+                  --service-account-key-file=/etc/kubernetes/pki/sa.pub \
+                  --service-account-signing-key-file=/etc/kubernetes/pki/sa.key \
+                  --service-cluster-ip-range={{ .Values.poolCoordinator.serviceClusterIPRange }} \
+                  --tls-cert-file=/etc/kubernetes/pki/apiserver.crt \
+                  --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
                 image: "{{ .Values.poolCoordinator.apiserverImage.registry }}/{{ .Values.poolCoordinator.apiserverImage.repository }}:{{ .Values.poolCoordinator.apiserverImage.tag }}"
                 imagePullPolicy: {{ .Values.poolCoordinator.apiserverImage.pullPolicy }}
                 livenessProbe:
@@ -133,6 +186,10 @@ spec:
                   - mountPath: /etc/kubernetes/pki
                     name: pool-coordinator-certs
                     readOnly: true
+                  - mountPath: /tmp/tools
+                    name: rbac-inject-tools
+                  - mountPath: /tmp/rbac
+                    name: rbac-injected                  
               - command:
                   - etcd
                   - --advertise-client-urls=https://0.0.0.0:{{ .Values.poolCoordinator.etcdPort }}
@@ -190,6 +247,8 @@ spec:
               - emptyDir:
                   medium: Memory
                 name: etcd-data
+              - emptyDir:
+                name: rbac-inject-tools
               - projected:
                   defaultMode: 420
                   sources:
@@ -198,6 +257,12 @@ spec:
                     - secret:
                         name: pool-coordinator-static-certs
                 name: pool-coordinator-certs
+              - projected:
+                  defaultMode: 420
+                  sources:
+                    - configMap:
+                        name: pool-coordinator-rbac-injected
+                name: rbac-injected
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -224,3 +289,23 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: openyurt:pool-coordinator:node-lease-proxy-client
+---
+apiVersion: v1
+kind: ConfigMap 
+metadata:
+  name: pool-coordinator-rbac-injected
+  namespace: kube-system
+data:
+  pool-coordinator-apiserver.yaml: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: openyurt:pool-coordinator:apiserver
+    subjects:
+      - kind: User 
+        apiGroup: rbac.authorization.k8s.io
+        name: openyurt:pool-coordinator:apiserver
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:kubelet-api-admin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:

Currently, `kubectl logs` to poolcoordinator cannot work because the apiserver in pool-coordinator is not authorized to access the kubelet server, in other words it cannot get sub-resources `proxy/logs`. This pr will inject relative rbac rule to enable the apiserver to access the kubelet server.

It works in the following step:

1. Using a `initContainer`, which is `alpine:3.14`,  to get necessary tools that are used to inject rbac. Tools include  `busybox.static`, which is a statically linked busybox that can run in kube-apiserver container without any dynamic link lib, and `kubectl` which is actually used to send request to apiserver to create rbac rules.
2. A new configmap is added to provide rbac we need. It will be mounted by kube-apiserver container.
3. kube-apiserver container will also mount the dir that contains tools we previously prepared. The command of this container is changed to run in a shell, which will attempt to use kubectl to create rbac and execute the kube-apiserver command.

#### why not use postStart hook of kube-apiserver container:

After adding postStart hook, the kube-apiserver is too slow to be ready(typically over 20s) and will exit when exceeding the internal [dial timeout](https://github.com/kubernetes/kubernetes/blob/release-1.22/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go#L63-L66)(20s used to dial to etcd and it's unconfigurable). It will cause the pool-coordinator cannot be ready and, of course, the postStart hook cannot get successfully executed.

I've not figured out why adding postStart hook has influence on kube-apiserver. 


#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->

TODOs:
- [x] rbac rules can be injected into apiserver
- [ ] kubeclt logs can work within nodepool

Currently the test `kubeclt logs can work within nodepool` has not got done yet, but I think it can work since we tested it through manually creating rbac into pool-coordinator before releasing openyurt v1.12.