### PR TITLE
fix: set default podspec for staticpod podtemplatespec

### DIFF
--- a/pkg/apis/apps/v1alpha1/default.go
+++ b/pkg/apis/apps/v1alpha1/default.go
@@ -222,6 +222,11 @@ func SetDefaultsStaticPod(obj *StaticPod) {
 		obj.Spec.RevisionHistoryLimit = new(int32)
 		*obj.Spec.RevisionHistoryLimit = 10
 	}
+
+	podSpec := &obj.Spec.Template.Spec
+	if podSpec != nil {
+		SetDefaultPodSpec(podSpec)
+	}
 }
 
 // SetDefaultsYurtAppDaemon set default values for YurtAppDaemon.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If not set default `PodSpec` for `staticpod` `PodTemplateSpec`, then when applying `staticpod`, it may be rejected due to `PodTemplateSpec` validation not passing.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
