### PR TITLE
optimize staticpod controller for upgrade info

### DIFF
--- a/pkg/controller/staticpod/config/types.go
+++ b/pkg/controller/staticpod/config/types.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package config
 
-// StaticPodControllerConfiguration contains elements describing GatewayController.
+// StaticPodControllerConfiguration contains elements describing StaticPodController.
 type StaticPodControllerConfiguration struct {
 	// UpgradeWorkerImage specify the image used to execute the upgrade task
 	UpgradeWorkerImage string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
There are some double counting in the existing code on upgrde info, and the calculation part is scattered and the parameter assignment is not uniform.
![image](https://user-images.githubusercontent.com/70508195/235078292-9469daae-a7f0-4065-8dce-667e4e788082.png)
![image](https://user-images.githubusercontent.com/70508195/235078370-12922e76-88a5-4838-8bed-0ee0252b10e9.png)


So this pr is used to optimized the upgrade info, and keep the computation in one place, rather than spreading it out.

Meanwhile, peel off the relevant calculation from staticpod_controller to upgrade_info, make the responsibilities clearer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
