### PR TITLE
optimize yurthub kubelet node cache operator

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -74,6 +74,7 @@ type YurtHubConfiguration struct {
 	HeartbeatIntervalSeconds        int
 	MaxRequestInFlight              int
 	EnableProfiling                 bool
+	CacheManager                    cachemanager.CacheManager
 	StorageWrapper                  cachemanager.StorageWrapper
 	SerializerManager               *serializer.SerializerManager
 	RESTMapperManager               *meta.RESTMapperManager
@@ -139,7 +140,8 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 	}
 	tenantNs := util.ParseTenantNsFromOrgs(options.YurtHubCertOrganizations)
 	registerInformers(options, sharedFactory, yurtSharedFactory, workingMode, tenantNs)
-	filterManager, err := manager.NewFilterManager(options, sharedFactory, yurtSharedFactory, serializerManager, storageWrapper, us[0].Host)
+	cacheManager := cachemanager.NewCacheManager(storageWrapper, serializerManager, restMapperManager, sharedFactory)
+	filterManager, err := manager.NewFilterManager(options, sharedFactory, yurtSharedFactory, serializerManager, cacheManager, us[0].Host)
 	if err != nil {
 		klog.Errorf("could not create filter manager, %v", err)
 		return nil, err
@@ -157,6 +159,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		MaxRequestInFlight:        options.MaxRequestInFlight,
 		EnableProfiling:           options.EnableProfiling,
 		WorkingMode:               workingMode,
+		CacheManager:              cacheManager,
 		StorageWrapper:            storageWrapper,
 		SerializerManager:         serializerManager,
 		RESTMapperManager:         restMapperManager,

--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -128,7 +128,7 @@ func Run(ctx context.Context, cfg *config.YurtHubConfiguration) error {
 	var cacheMgr cachemanager.CacheManager
 	if cfg.WorkingMode == util.WorkingModeEdge {
 		klog.Infof("%d. new cache manager with storage wrapper and serializer manager", trace)
-		cacheMgr = cachemanager.NewCacheManager(cfg.StorageWrapper, cfg.SerializerManager, cfg.RESTMapperManager, cfg.SharedFactory)
+		cacheMgr = cfg.CacheManager
 	} else {
 		klog.Infof("%d. disable cache manager for node %s because it is a cloud node", trace, cfg.NodeName)
 	}

--- a/pkg/yurthub/filter/initializer/initializer.go
+++ b/pkg/yurthub/filter/initializer/initializer.go
@@ -45,9 +45,9 @@ type WantsNodePoolName interface {
 	SetNodePoolName(nodePoolName string) error
 }
 
-// WantsStorageWrapper is an interface for setting StorageWrapper
-type WantsStorageWrapper interface {
-	SetStorageWrapper(s cachemanager.StorageWrapper) error
+// WantsCacheManager is an interface for setting CacheManager
+type WantsCacheManager interface {
+	SetCacheManager(c cachemanager.CacheManager) error
 }
 
 // WantsMasterServiceAddr is an interface for setting mutated master service address
@@ -65,7 +65,7 @@ type WantsWorkingMode interface {
 type genericFilterInitializer struct {
 	factory           informers.SharedInformerFactory
 	yurtFactory       yurtinformers.SharedInformerFactory
-	storageWrapper    cachemanager.StorageWrapper
+	cacheManager      cachemanager.CacheManager
 	nodeName          string
 	nodePoolName      string
 	masterServiceHost string
@@ -76,13 +76,13 @@ type genericFilterInitializer struct {
 // New creates an filterInitializer object
 func New(factory informers.SharedInformerFactory,
 	yurtFactory yurtinformers.SharedInformerFactory,
-	sw cachemanager.StorageWrapper,
+	cacheManager cachemanager.CacheManager,
 	nodeName, nodePoolName, masterServiceHost, masterServicePort string,
 	workingMode util.WorkingMode) *genericFilterInitializer {
 	return &genericFilterInitializer{
 		factory:           factory,
 		yurtFactory:       yurtFactory,
-		storageWrapper:    sw,
+		cacheManager:      cacheManager,
 		nodeName:          nodeName,
 		masterServiceHost: masterServiceHost,
 		masterServicePort: masterServicePort,
@@ -132,8 +132,8 @@ func (fi *genericFilterInitializer) Initialize(ins filter.ObjectFilter) error {
 		}
 	}
 
-	if wants, ok := ins.(WantsStorageWrapper); ok {
-		if err := wants.SetStorageWrapper(fi.storageWrapper); err != nil {
+	if wants, ok := ins.(WantsCacheManager); ok {
+		if err := wants.SetCacheManager(fi.cacheManager); err != nil {
 			return err
 		}
 	}

--- a/pkg/yurthub/filter/manager/manager.go
+++ b/pkg/yurthub/filter/manager/manager.go
@@ -48,7 +48,7 @@ func NewFilterManager(options *options.YurtHubOptions,
 	sharedFactory informers.SharedInformerFactory,
 	yurtSharedFactory yurtinformers.SharedInformerFactory,
 	serializerManager *serializer.SerializerManager,
-	storageWrapper cachemanager.StorageWrapper,
+	cacheManager cachemanager.CacheManager,
 	apiserverAddr string) (*Manager, error) {
 	if !options.EnableResourceFilter {
 		return nil, nil
@@ -70,7 +70,7 @@ func NewFilterManager(options *options.YurtHubOptions,
 		}
 	}
 
-	objFilters, err := createObjectFilters(filters, sharedFactory, yurtSharedFactory, storageWrapper, util.WorkingMode(options.WorkingMode), options.NodeName, options.NodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort)
+	objFilters, err := createObjectFilters(filters, sharedFactory, yurtSharedFactory, cacheManager, util.WorkingMode(options.WorkingMode), options.NodeName, options.NodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort)
 	if err != nil {
 		return nil, err
 	}
@@ -114,14 +114,14 @@ func (m *Manager) FindResponseFilter(req *http.Request) (filter.ResponseFilter, 
 func createObjectFilters(filters *filter.Filters,
 	sharedFactory informers.SharedInformerFactory,
 	yurtSharedFactory yurtinformers.SharedInformerFactory,
-	storageWrapper cachemanager.StorageWrapper,
+	cacheManager cachemanager.CacheManager,
 	workingMode util.WorkingMode,
 	nodeName, nodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort string) ([]filter.ObjectFilter, error) {
 	if filters == nil {
 		return nil, nil
 	}
 
-	genericInitializer := initializer.New(sharedFactory, yurtSharedFactory, storageWrapper, nodeName, nodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort, workingMode)
+	genericInitializer := initializer.New(sharedFactory, yurtSharedFactory, cacheManager, nodeName, nodePoolName, mutatedMasterServiceHost, mutatedMasterServicePort, workingMode)
 	initializerChain := filter.Initializers{}
 	initializerChain = append(initializerChain, genericInitializer)
 	return filters.NewFromFilters(initializerChain)

--- a/pkg/yurthub/filter/manager/manager_test.go
+++ b/pkg/yurthub/filter/manager/manager_test.go
@@ -50,6 +50,7 @@ func TestFindResponseFilter(t *testing.T) {
 		t.Fatalf("could not create storage manager, %v", err)
 	}
 	storageWrapper := cachemanager.NewStorageWrapper(storageManager)
+	cacheManager := cachemanager.NewCacheManager(storageWrapper, serializerManager, nil, sharedFactory)
 	apiserverAddr := "127.0.0.1:6443"
 	stopper := make(chan struct{})
 	defer close(stopper)
@@ -140,7 +141,7 @@ func TestFindResponseFilter(t *testing.T) {
 			}
 			options.DisabledResourceFilters = append(options.DisabledResourceFilters, tt.disabledResourceFilters...)
 
-			mgr, _ := NewFilterManager(options, sharedFactory, yurtSharedFactory, serializerManager, storageWrapper, apiserverAddr)
+			mgr, _ := NewFilterManager(options, sharedFactory, yurtSharedFactory, serializerManager, cacheManager, apiserverAddr)
 			if tt.mgrIsNil && mgr != nil {
 				t.Errorf("expect manager is nil, but got not nil: %v", mgr)
 			} else {

--- a/pkg/yurthub/filter/nodeportisolation/filter_test.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter_test.go
@@ -19,6 +19,7 @@ package nodeportisolation
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/util"
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
 	hubutil "github.com/openyurtio/openyurt/pkg/yurthub/util"
 )
@@ -103,7 +105,7 @@ func TestSetSharedInformerFactory(t *testing.T) {
 	}
 }
 
-func TestSetStorageWrapper(t *testing.T) {
+func TestSetCacheManager(t *testing.T) {
 	nif := &nodePortIsolationFilter{
 		workingMode: "edge",
 		nodeName:    "foo",
@@ -113,8 +115,12 @@ func TestSetStorageWrapper(t *testing.T) {
 		t.Fatalf("could not create storage manager, %v", err)
 	}
 	storageWrapper := cachemanager.NewStorageWrapper(storageManager)
+	serializerManager := serializer.NewSerializerManager()
+	fakeClient := &fake.Clientset{}
+	sharedFactory := informers.NewSharedInformerFactory(fakeClient, 24*time.Hour)
+	cacheManager := cachemanager.NewCacheManager(storageWrapper, serializerManager, nil, sharedFactory)
 
-	if err := nif.SetStorageWrapper(storageWrapper); err != nil {
+	if err := nif.SetCacheManager(cacheManager); err != nil {
 		t.Errorf("expect nil, but got %v", err)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
In current mode， yurthub has some error when i delete a pod, and the service will find other pods that is in different nodepools:
```
I0427 07:28:00.977257 1 storage.go:562] key(kubelet/nodes.v1.core/host-fbdb5f) storage is pending, just skip it
W0427 07:28:00.977286 1 handler.go:172] skip serviceTopologyFilterHandler, failed to get current node host-fbdb5f, err: specified key is under accessing
```
And i add some logs for serviceTopology, it can show us some details:
```
I0515 08:54:53.202876       1 filter.go:236] -----------, StreamResponseFilter: coredns watch endpoints: https://127.0.0.1:6443/api/v1/endpoints?allowWatchBookmarks=true&resourceVersion=106522&timeout=8m27s&timeoutSeconds=507&watch=true[servicetopology]
I0515 08:54:53.203097       1 filter.go:236] -----------, StreamResponseFilter: nginx-ingress-controller watch endpoints: https://127.0.0.1:6443/api/v1/endpoints?allowWatchBookmarks=true&labelSelector=OWNER%21%3DTILLER&resourceVersion=106522&timeout=7m45s&timeoutSeconds=465&watch=true[servicetopology]
I0515 08:54:53.371902       1 filter.go:236] -----------, StreamResponseFilter: coredns watch endpoints: https://127.0.0.1:6443/api/v1/endpoints?allowWatchBookmarks=true&resourceVersion=106522&timeout=8m27s&timeoutSeconds=507&watch=true[servicetopology]
I0515 08:54:53.374220       1 filter.go:236] -----------, StreamResponseFilter: nginx-ingress-controller watch endpoints: https://127.0.0.1:6443/api/v1/endpoints?allowWatchBookmarks=true&labelSelector=OWNER%21%3DTILLER&resourceVersion=106522&timeout=7m45s&timeoutSeconds=465&watch=true[servicetopology]
I0515 08:54:53.378348       1 filter.go:236] -----------, StreamResponseFilter: kube-proxy watch endpointslices: https://127.0.0.1:6443/apis/discovery.k8s.io/v1beta1/endpointslices?allowWatchBookmarks=true&labelSelector=%21service.kubernetes.io%2Fheadless%2C%21service.kubernetes.io%2Fservice-proxy-name&resourceVersion=95879&timeout=7m15s&timeoutSeconds=435&watch=true[servicetopology]
I0515 08:54:53.381507       1 cache_manager.go:439] pod(kubelet/pods.v1.core/edgex-system/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp) is MODIFIED
I0515 08:54:53.382361       1 util.go:293] start proxying: post /api/v1/namespaces/edgex-system/events, in flight requests: 57
I0515 08:54:53.384234       1 util.go:293] start proxying: get /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp, in flight requests: 58
I0515 08:54:53.399293       1 util.go:252] kubelet get pods: /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp with status code 200, spent 14.95904ms
I0515 08:54:53.404357       1 util.go:252] kubelet create events: /api/v1/namespaces/edgex-system/events with status code 201, spent 21.91904ms
I0515 08:54:53.413732       1 cache_manager.go:439] pod(kubelet/pods.v1.core/edgex-system/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-7q5fw) is ADDED
I0515 08:54:53.418958       1 util.go:293] start proxying: get /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-7q5fw, in flight requests: 57
I0515 08:54:53.431835       1 util.go:252] kubelet get pods: /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-7q5fw with status code 200, spent 12.79584ms
I0515 08:54:53.434748       1 util.go:293] start proxying: patch /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-7q5fw/status, in flight requests: 57
I0515 08:54:53.464499       1 util.go:252] kubelet patch pods: /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-7q5fw/status with status code 200, spent 29.65184ms
I0515 08:54:53.472085       1 cache_manager.go:439] pod(kubelet/pods.v1.core/edgex-system/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-7q5fw) is MODIFIED
I0515 08:54:53.522483       1 filter.go:236] -----------, StreamResponseFilter: nginx-ingress-controller watch endpoints: https://127.0.0.1:6443/api/v1/endpoints?allowWatchBookmarks=true&labelSelector=OWNER%21%3DTILLER&resourceVersion=106522&timeout=7m45s&timeoutSeconds=465&watch=true[servicetopology]
I0515 08:54:53.523581       1 filter.go:236] -----------, StreamResponseFilter: coredns watch endpoints: https://127.0.0.1:6443/api/v1/endpoints?allowWatchBookmarks=true&resourceVersion=106522&timeout=8m27s&timeoutSeconds=507&watch=true[servicetopology]
I0515 08:54:53.610251       1 util.go:293] start proxying: put /apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/host-63b4e4?timeout=10s, in flight requests: 57
I0515 08:54:53.610532       1 util.go:252] kubelet update leases: /apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/host-63b4e4?timeout=10s with status code 200, spent 180.384µs
I0515 08:54:54.860103       1 util.go:293] start proxying: get /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp, in flight requests: 57
I0515 08:54:54.869684       1 util.go:252] kubelet get pods: /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp with status code 200, spent 9.468416ms
I0515 08:54:54.872070       1 util.go:293] start proxying: patch /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp/status, in flight requests: 57
I0515 08:54:54.904470       1 util.go:252] kubelet patch pods: /api/v1/namespaces/edgex-system/pods/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp/status with status code 200, spent 32.2888ms
I0515 08:54:54.905318       1 storage.go:562] key(kubelet/pods.v1.core/edgex-system/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp) storage is pending, just skip it
I0515 08:54:54.905354       1 cache_manager.go:652] skip to cache watch event because key({rootKey:false path:kubelet/pods.v1.core/edgex-system/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp}) is under processing
I0515 08:54:54.910532       1 cache_manager.go:439] pod(kubelet/pods.v1.core/edgex-system/edgex-redis-nodepool-host-63b4e4-trgcz-79b946796f-d5wvp) is MODIFIED
```
Why we need to save kubelet node object in cache:
 In ServiceTopology and NodePortIsolation filter, handler need to get nodepool information from node,
 in regular mode, Get function will get node object in disk, and it need to get mutex,
 it will be concurrent sometimes, and return an error for 'specified key is under accessing'.
 In the meanwhile, the filter will skip, and unfiltered data will return, it's so terrible for service in multiple nodepools.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
