### PR TITLE
fix yurthub memory leak

### DIFF
--- a/pkg/yurthub/poolcoordinator/coordinator.go
+++ b/pkg/yurthub/poolcoordinator/coordinator.go
@@ -288,9 +288,9 @@ func (coordinator *coordinator) Run() {
 					continue
 				}
 
-				klog.Infof("coordinator newCloudLeaseClient success.")
 				if err := coordinator.poolCacheSyncManager.EnsureStart(); err != nil {
 					klog.Errorf("failed to sync pool-scoped resource, %v", err)
+					cancelEtcdStorage()
 					coordinator.statusInfoChan <- electorStatusInfo
 					continue
 				}
@@ -299,9 +299,11 @@ func (coordinator *coordinator) Run() {
 				nodeLeaseProxyClient, err := coordinator.newNodeLeaseProxyClient()
 				if err != nil {
 					klog.Errorf("cloud not get cloud lease client when becoming leader yurthub, %v", err)
+					cancelEtcdStorage()
 					coordinator.statusInfoChan <- electorStatusInfo
 					continue
 				}
+				klog.Infof("coordinator newCloudLeaseClient success.")
 				coordinator.delegateNodeLeaseManager.EnsureStartWithHandler(cache.FilteringResourceEventHandler{
 					FilterFunc: ifDelegateHeartBeat,
 					Handler: cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:
When yurthub connect with pool-coordinator etcd failed, and keep try again, the goroutine of grpc is increase all the while, and memory of yurthub also increase, and kubelet will restart it when is happen OOM.
![0efec082db7f88f00fa4934ba4ba366](https://github.com/openyurtio/openyurt/assets/70508195/cd6e5f15-ecf6-4b47-978a-4c4a516eee89)

![e50ee49fda9b174b93760f01bf9c10e](https://github.com/openyurtio/openyurt/assets/70508195/c14b3cfa-5e6c-4bbc-b4b7-c656513204c9)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
