### PR TITLE
feat: use real kubernetes server address to yurthub when yurtadm join

### DIFF
--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -107,6 +107,7 @@ const (
 	// ReuseCNIBin flag sets whether to reuse local CNI binaries or not.
 	ReuseCNIBin = "reuse-cni-bin"
 
+	DefaultServerAddr            = "https://127.0.0.1:6443"
 	ServerHealthzServer          = "127.0.0.1:10267"
 	ServerHealthzURLPath         = "/v1/healthz"
 	ServerReadyzURLPath          = "/v1/readyz"

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yurthub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	defaultAddr = `apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openyurt.io/static-pod-hash: 76f4f955b6
+  creationTimestamp: null
+  labels:
+    k8s-app: yurt-hub
+  name: yurt-hub
+  namespace: kube-system
+spec:
+  containers:
+    - command:
+      - yurthub
+      - --v=2
+      - --bind-address=127.0.0.1
+      - --server-addr=https://127.0.0.1:6443
+      - --node-name=$(NODE_NAME)
+      - --bootstrap-file=/var/lib/yurthub/bootstrap-hub.conf
+      - --working-mode=edge
+      - --namespace=kube-system
+      env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+      image: openyurt/yurthub:v1.3.0
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          host: 127.0.0.1
+          path: /v1/healthz
+          port: 10267
+          scheme: HTTP
+        initialDelaySeconds: 300
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 1
+      name: yurt-hub
+      resources:
+        limits:
+          memory: 300Mi
+        requests:
+          cpu: 150m
+          memory: 150Mi
+      securityContext:
+        capabilities:
+          add:
+            - NET_ADMIN
+            - NET_RAW
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /var/lib/yurthub
+          name: hub-dir
+        - mountPath: /etc/kubernetes
+          name: kubernetes
+  dnsPolicy: ClusterFirst
+  hostNetwork: true
+  priority: 2000001000
+  priorityClassName: system-node-critical
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  terminationGracePeriodSeconds: 30
+  volumes:
+    - hostPath:
+        path: /var/lib/yurthub
+        type: DirectoryOrCreate
+      name: hub-dir
+    - hostPath:
+        path: /etc/kubernetes
+        type: Directory
+      name: kubernetes
+status: {}
+`
+
+	setAddr = `apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openyurt.io/static-pod-hash: 76f4f955b6
+  creationTimestamp: null
+  labels:
+    k8s-app: yurt-hub
+  name: yurt-hub
+  namespace: kube-system
+spec:
+  containers:
+    - command:
+      - yurthub
+      - --v=2
+      - --bind-address=127.0.0.1
+      - --server-addr=https://192.0.0.1:6443
+      - --node-name=$(NODE_NAME)
+      - --bootstrap-file=/var/lib/yurthub/bootstrap-hub.conf
+      - --working-mode=edge
+      - --namespace=kube-system
+      env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+      image: openyurt/yurthub:v1.3.0
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          host: 127.0.0.1
+          path: /v1/healthz
+          port: 10267
+          scheme: HTTP
+        initialDelaySeconds: 300
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 1
+      name: yurt-hub
+      resources:
+        limits:
+          memory: 300Mi
+        requests:
+          cpu: 150m
+          memory: 150Mi
+      securityContext:
+        capabilities:
+          add:
+            - NET_ADMIN
+            - NET_RAW
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /var/lib/yurthub
+          name: hub-dir
+        - mountPath: /etc/kubernetes
+          name: kubernetes
+  dnsPolicy: ClusterFirst
+  hostNetwork: true
+  priority: 2000001000
+  priorityClassName: system-node-critical
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  terminationGracePeriodSeconds: 30
+  volumes:
+    - hostPath:
+        path: /var/lib/yurthub
+        type: DirectoryOrCreate
+      name: hub-dir
+    - hostPath:
+        path: /etc/kubernetes
+        type: Directory
+      name: kubernetes
+status: {}
+`
+
+	serverAddrsA = "https://192.0.0.1:6443"
+	serverAddrsB = "https://192.0.0.2:6443"
+)
+
+func Test_useRealServerAddr(t *testing.T) {
+	type args struct {
+		yurthubTemplate       string
+		kubernetesServerAddrs string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "change default server addr",
+			args: args{
+				yurthubTemplate:       defaultAddr,
+				kubernetesServerAddrs: serverAddrsA,
+			},
+			want: setAddr,
+		},
+		{
+			name: " already set server addr",
+			args: args{
+				yurthubTemplate:       setAddr,
+				kubernetesServerAddrs: serverAddrsB,
+			},
+			want: setAddr,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			actualYaml, err := useRealServerAddr(test.args.yurthubTemplate, test.args.kubernetesServerAddrs)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			assert.Equal(t, actualYaml, test.want)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:
In the scenario where the user forgets to set the yurthub server address for the master node, the yurtadm join command should replace the yurthub parameter with the address obtained from the join.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #
#1474 
#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
