### PR TITLE
fix yurtstaticset workerpod reset error

### DIFF
--- a/pkg/controller/yurtstaticset/upgradeinfo/upgrade_info.go
+++ b/pkg/controller/yurtstaticset/upgradeinfo/upgrade_info.go
@@ -88,8 +88,9 @@ func New(c client.Client, instance *appsv1alpha1.YurtStaticSet, workerPodName, h
 			}
 		}
 
-		// The name format of worker pods are `WorkerPodName-NodeName-Hash` Todo: may lead to mismatch
-		if strings.Contains(pod.Name, workerPodName) {
+		// The name format of worker pods are `WorkerPodName-YssName-NodeName-Hash`
+		name := workerPodName + instance.Name
+		if strings.Contains(pod.Name, name) {
 			// initialize worker pod info
 			if err := initWorkerPodInfo(nodeName, hash, &podList.Items[i], infos); err != nil {
 				return nil, err

--- a/pkg/controller/yurtstaticset/upgradeinfo/upgrade_info_test.go
+++ b/pkg/controller/yurtstaticset/upgradeinfo/upgrade_info_test.go
@@ -60,7 +60,7 @@ func newNodes(nodeNames []string) []client.Object {
 func newPod(podName string, nodeName string, namespace string, isStaticPod bool) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      UpgradeWorkerPodPrefix + rand.String(10),
+			Name:      UpgradeWorkerPodPrefix + podName + "-" + rand.String(10),
 			Namespace: namespace,
 		},
 		Spec: corev1.PodSpec{NodeName: nodeName},

--- a/pkg/controller/yurtstaticset/yurtstaticset_controller.go
+++ b/pkg/controller/yurtstaticset/yurtstaticset_controller.go
@@ -71,7 +71,7 @@ const (
 	hostPathVolumeSourcePath = hostPathVolumeMountPath
 
 	// UpgradeWorkerPodPrefix is the name prefix of worker pod which used for static pod upgrade
-	UpgradeWorkerPodPrefix     = "yurt-static-set-upgrade-worker-"
+	UpgradeWorkerPodPrefix     = "yss-upgrade-worker-"
 	UpgradeWorkerContainerName = "upgrade-worker"
 
 	ArgTmpl = "/usr/local/bin/node-servant static-pod-upgrade --name=%s --namespace=%s --manifest=%s --hash=%s --mode=%s"
@@ -499,7 +499,7 @@ func (r *ReconcileYurtStaticSet) removeUnusedPods(pods []*corev1.Pod) error {
 func createUpgradeWorker(c client.Client, instance *appsv1alpha1.YurtStaticSet, nodes []string, hash, mode, img string) error {
 	for _, node := range nodes {
 		pod := upgradeWorker.DeepCopy()
-		pod.Name = UpgradeWorkerPodPrefix + util.Hyphen(node, hash)
+		pod.Name = UpgradeWorkerPodPrefix + instance.Name + "-" + util.Hyphen(node, hash)
 		pod.Namespace = instance.Namespace
 		pod.Spec.NodeName = node
 		metav1.SetMetaDataAnnotation(&pod.ObjectMeta, StaticPodHashAnnotation, hash)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:

When user have more than one static pod want to upgrade, and the upgrade worker pod name has the same prefix in different yurtstaticset, when the upgradeinfo want to calculate information, it will confused.

So we need to add yurtstaticset name for worker pod to avoid this condition, and short for worker pod prefix to avoid the worker pod name is too long to make mistake

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
