### PR TITLE
fix: ide reconciler convert error and ServiceEnable return value wrong

### DIFF
--- a/pkg/controller/daemonpodupdater/daemon_pod_updater_controller.go
+++ b/pkg/controller/daemonpodupdater/daemon_pod_updater_controller.go
@@ -173,8 +173,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// 2. Watch for deletion of pods. The reason we watch is that we don't want a daemon set to delete
 	// more pods until all the effects (expectations) of a daemon set's delete have been observed.
+	updater := r.(*ReconcileDaemonpodupdater)
 	if err := c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.Funcs{
-		DeleteFunc: r.(*ReconcileDaemonpodupdater).deletePod,
+		DeleteFunc: updater.deletePod,
 	}); err != nil {
 		return err
 	}

--- a/pkg/yurtadm/util/initsystem/initsystem_windows.go
+++ b/pkg/yurtadm/util/initsystem/initsystem_windows.go
@@ -55,19 +55,19 @@ func (sysd WindowsInitSystem) ServiceIsEnabled(service string) bool {
 func (sysd WindowsInitSystem) ServiceEnable(service string) error {
 	m, err := mgr.Connect()
 	if err != nil {
-		return false
+		return err
 	}
 	defer m.Disconnect()
 
 	s, err := m.OpenService(service)
 	if err != nil {
-		return false
+		return err
 	}
 	defer s.Close()
 
 	c, err := s.Config()
 	if err != nil {
-		return false
+		return err
 	}
 	c.StartType = mgr.StartAutomatic
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

* Goland Code Inspection cannot recognize function type conversion after type assertion(Cannot use 'r.(*ReconcileDaemonpodupdater).deletePod' (type func(ReconcileDaemonpodupdater, event.DeleteEvent, workqueue.RateLimitingInterface)) as the type func(event.DeleteEvent, workqueue.RateLimitingInterface)). split type assertion out to fix this.
* WindowsInitSystem ServiceEnable return value is wrong

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
