### PR TITLE
fix conflicts for getting node by local storage in yurthub filters

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -139,7 +139,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 	}
 	tenantNs := util.ParseTenantNsFromOrgs(options.YurtHubCertOrganizations)
 	registerInformers(options, sharedFactory, yurtSharedFactory, workingMode, tenantNs)
-	filterManager, err := manager.NewFilterManager(options, sharedFactory, yurtSharedFactory, serializerManager, storageWrapper, us[0].Host)
+	filterManager, err := manager.NewFilterManager(options, sharedFactory, yurtSharedFactory, proxiedClient, serializerManager, us[0].Host)
 	if err != nil {
 		klog.Errorf("could not create filter manager, %v", err)
 		return nil, err

--- a/pkg/yurthub/filter/filter.go
+++ b/pkg/yurthub/filter/filter.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -274,15 +275,11 @@ func CreateFilterChain(objFilters []ObjectFilter) ObjectFilter {
 }
 
 func (chain filterChain) Name() string {
-	var name string
+	var names []string
 	for i := range chain {
-		if len(name) == 0 {
-			name = chain[i].Name()
-		} else {
-			name = "," + chain[i].Name()
-		}
+		names = append(names, chain[i].Name())
 	}
-	return name
+	return strings.Join(names, ",")
 }
 
 func (chain filterChain) SupportedResourceAndVerbs() map[string]sets.String {

--- a/pkg/yurthub/filter/nodeportisolation/filter.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter.go
@@ -17,22 +17,19 @@ limitations under the License.
 package nodeportisolation
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
-	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+	"github.com/openyurtio/openyurt/pkg/apis/apps"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
-	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
-	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
-	"github.com/openyurtio/openyurt/pkg/yurthub/util"
-	nodepoolv1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/apis/apps/v1alpha1"
 )
 
 const (
@@ -48,10 +45,8 @@ func Register(filters *filter.Filters) {
 
 type nodePortIsolationFilter struct {
 	nodePoolName string
-	workingMode  util.WorkingMode
-	nodeGetter   filter.NodeGetter
-	nodeSynced   cache.InformerSynced
 	nodeName     string
+	client       kubernetes.Interface
 }
 
 func (nif *nodePortIsolationFilter) Name() string {
@@ -74,92 +69,12 @@ func (nif *nodePortIsolationFilter) SetNodeName(nodeName string) error {
 	return nil
 }
 
-func (nif *nodePortIsolationFilter) SetWorkingMode(mode util.WorkingMode) error {
-	nif.workingMode = mode
-	return nil
-}
-
-func (nif *nodePortIsolationFilter) SetSharedInformerFactory(factory informers.SharedInformerFactory) error {
-	if nif.workingMode == util.WorkingModeCloud {
-		klog.Infof("prepare list/watch to sync node(%s) for cloud working mode", nif.nodeName)
-		nif.nodeSynced = factory.Core().V1().Nodes().Informer().HasSynced
-		nif.nodeGetter = factory.Core().V1().Nodes().Lister().Get
-	}
-
-	return nil
-}
-
-func (nif *nodePortIsolationFilter) SetStorageWrapper(s cachemanager.StorageWrapper) error {
-	if s.Name() != disk.StorageName {
-		return fmt.Errorf("nodePortIsolationFilter can only support disk storage currently, cannot use %s", s.Name())
-	}
-
-	if len(nif.nodeName) == 0 {
-		return fmt.Errorf("node name for nodePortIsolationFilter is not set")
-	}
-
-	// hub agent will list/watch node from kube-apiserver when hub agent work as cloud mode
-	if nif.workingMode == util.WorkingModeCloud {
-		return nil
-	}
-	klog.Infof("prepare local disk storage to sync node(%s) for edge working mode", nif.nodeName)
-
-	nodeKey, err := s.KeyFunc(storage.KeyBuildInfo{
-		Component: "kubelet",
-		Name:      nif.nodeName,
-		Resources: "nodes",
-		Group:     "",
-		Version:   "v1",
-	})
-	if err != nil {
-		return fmt.Errorf("failed to get node key for %s, %v", nif.nodeName, err)
-	}
-	nif.nodeSynced = func() bool {
-		obj, err := s.Get(nodeKey)
-		if err != nil || obj == nil {
-			return false
-		}
-
-		if _, ok := obj.(*v1.Node); !ok {
-			return false
-		}
-
-		return true
-	}
-
-	nif.nodeGetter = func(name string) (*v1.Node, error) {
-		key, err := s.KeyFunc(storage.KeyBuildInfo{
-			Component: "kubelet",
-			Name:      name,
-			Resources: "nodes",
-			Group:     "",
-			Version:   "v1",
-		})
-		if err != nil {
-			return nil, fmt.Errorf("nodeGetter failed to get node key for %s, %v", name, err)
-		}
-		obj, err := s.Get(key)
-		if err != nil {
-			return nil, err
-		} else if obj == nil {
-			return nil, fmt.Errorf("node(%s) is not ready", name)
-		}
-
-		if node, ok := obj.(*v1.Node); ok {
-			return node, nil
-		}
-
-		return nil, fmt.Errorf("node(%s) is not found", name)
-	}
-
+func (nif *nodePortIsolationFilter) SetKubeClient(client kubernetes.Interface) error {
+	nif.client = client
 	return nil
 }
 
 func (nif *nodePortIsolationFilter) Filter(obj runtime.Object, stopCh <-chan struct{}) runtime.Object {
-	if ok := cache.WaitForCacheSync(stopCh, nif.nodeSynced); !ok {
-		return obj
-	}
-
 	switch v := obj.(type) {
 	case *v1.ServiceList:
 		var svcNew []v1.Service
@@ -179,16 +94,7 @@ func (nif *nodePortIsolationFilter) Filter(obj runtime.Object, stopCh <-chan str
 }
 
 func (nif *nodePortIsolationFilter) isolateNodePortService(svc *v1.Service) *v1.Service {
-	nodePoolName := nif.nodePoolName
-	if len(nodePoolName) == 0 {
-		node, err := nif.nodeGetter(nif.nodeName)
-		if err != nil {
-			klog.Warningf("skip isolateNodePortService filter, failed to get node(%s), %v", nif.nodeName, err)
-			return svc
-		}
-		nodePoolName = node.Labels[nodepoolv1alpha1.LabelCurrentNodePool]
-	}
-
+	nodePoolName := nif.resolveNodePoolName()
 	// node is not located in NodePool, keep the NodePort service the same as native K8s
 	if len(nodePoolName) == 0 {
 		return svc
@@ -201,13 +107,27 @@ func (nif *nodePortIsolationFilter) isolateNodePortService(svc *v1.Service) *v1.
 			if nodePoolConf.Len() != 0 && isNodePoolEnabled(nodePoolConf, nodePoolName) {
 				return svc
 			} else {
-				klog.V(2).Infof("nodePort service(%s) is disabled in nodePool(%s) by nodePortIsolationFilter", nsName, nodePoolName)
+				klog.V(2).Infof("service(%s) is disabled in nodePool(%s) by nodePortIsolationFilter", nsName, nodePoolName)
 				return nil
 			}
 		}
 	}
 
 	return svc
+}
+
+func (nif *nodePortIsolationFilter) resolveNodePoolName() string {
+	if len(nif.nodePoolName) != 0 {
+		return nif.nodePoolName
+	}
+
+	node, err := nif.client.CoreV1().Nodes().Get(context.Background(), nif.nodeName, metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("skip isolateNodePortService filter, failed to get node(%s), %v", nif.nodeName, err)
+		return nif.nodePoolName
+	}
+	nif.nodePoolName = node.Labels[apps.LabelDesiredNodePool]
+	return nif.nodePoolName
 }
 
 func getNodePoolConfiguration(v string) sets.String {

--- a/pkg/yurthub/filter/servicetopology/filter.go
+++ b/pkg/yurthub/filter/servicetopology/filter.go
@@ -17,23 +17,21 @@ limitations under the License.
 package servicetopology
 
 import (
-	"fmt"
+	"context"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	discoveryV1beta1 "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
-	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
-	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
-	"github.com/openyurtio/openyurt/pkg/yurthub/util"
 	nodepoolv1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/apis/apps/v1alpha1"
 	yurtinformers "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/informers/externalversions"
 	appslisters "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/listers/apps/v1alpha1"
@@ -58,9 +56,7 @@ func Register(filters *filter.Filters) {
 }
 
 func NewFilter() *serviceTopologyFilter {
-	return &serviceTopologyFilter{
-		workingMode: util.WorkingModeEdge,
-	}
+	return &serviceTopologyFilter{}
 }
 
 type serviceTopologyFilter struct {
@@ -68,10 +64,9 @@ type serviceTopologyFilter struct {
 	serviceSynced  cache.InformerSynced
 	nodePoolLister appslisters.NodePoolLister
 	nodePoolSynced cache.InformerSynced
-	nodeGetter     filter.NodeGetter
-	nodeSynced     cache.InformerSynced
+	nodePoolName   string
 	nodeName       string
-	workingMode    util.WorkingMode
+	client         kubernetes.Interface
 }
 
 func (stf *serviceTopologyFilter) Name() string {
@@ -85,20 +80,9 @@ func (stf *serviceTopologyFilter) SupportedResourceAndVerbs() map[string]sets.St
 	}
 }
 
-func (stf *serviceTopologyFilter) SetWorkingMode(mode util.WorkingMode) error {
-	stf.workingMode = mode
-	return nil
-}
-
 func (stf *serviceTopologyFilter) SetSharedInformerFactory(factory informers.SharedInformerFactory) error {
 	stf.serviceLister = factory.Core().V1().Services().Lister()
 	stf.serviceSynced = factory.Core().V1().Services().Informer().HasSynced
-
-	if stf.workingMode == util.WorkingModeCloud {
-		klog.Infof("prepare list/watch to sync node(%s) for cloud working mode", stf.nodeName)
-		stf.nodeSynced = factory.Core().V1().Nodes().Informer().HasSynced
-		stf.nodeGetter = factory.Core().V1().Nodes().Lister().Get
-	}
 
 	return nil
 }
@@ -116,76 +100,32 @@ func (stf *serviceTopologyFilter) SetNodeName(nodeName string) error {
 	return nil
 }
 
-// TODO: should use disk storage as parameter instead of StorageWrapper
-// we can internally construct a new StorageWrapper with passed-in disk storage
-func (stf *serviceTopologyFilter) SetStorageWrapper(s cachemanager.StorageWrapper) error {
-	if s.Name() != disk.StorageName {
-		return fmt.Errorf("serviceTopologyFilter can only support disk storage currently, cannot use %s", s.Name())
-	}
-
-	if len(stf.nodeName) == 0 {
-		return fmt.Errorf("node name for serviceTopologyFilter is not ready")
-	}
-
-	// hub agent will list/watch node from kube-apiserver when hub agent work as cloud mode
-	if stf.workingMode == util.WorkingModeCloud {
-		return nil
-	}
-	klog.Infof("prepare local disk storage to sync node(%s) for edge working mode", stf.nodeName)
-
-	nodeKey, err := s.KeyFunc(storage.KeyBuildInfo{
-		Component: "kubelet",
-		Name:      stf.nodeName,
-		Resources: "nodes",
-		Group:     "",
-		Version:   "v1",
-	})
-	if err != nil {
-		return fmt.Errorf("failed to get node key for %s, %v", stf.nodeName, err)
-	}
-	stf.nodeSynced = func() bool {
-		obj, err := s.Get(nodeKey)
-		if err != nil || obj == nil {
-			return false
-		}
-
-		if _, ok := obj.(*v1.Node); !ok {
-			return false
-		}
-
-		return true
-	}
-
-	stf.nodeGetter = func(name string) (*v1.Node, error) {
-		key, err := s.KeyFunc(storage.KeyBuildInfo{
-			Component: "kubelet",
-			Name:      name,
-			Resources: "nodes",
-			Group:     "",
-			Version:   "v1",
-		})
-		if err != nil {
-			return nil, fmt.Errorf("nodeGetter failed to get node key for %s, %v", name, err)
-		}
-		obj, err := s.Get(key)
-		if err != nil {
-			return nil, err
-		} else if obj == nil {
-			return nil, fmt.Errorf("node(%s) is not ready", name)
-		}
-
-		if node, ok := obj.(*v1.Node); ok {
-			return node, nil
-		}
-
-		return nil, fmt.Errorf("node(%s) is not found", name)
-	}
-
+func (stf *serviceTopologyFilter) SetNodePoolName(poolName string) error {
+	stf.nodePoolName = poolName
 	return nil
 }
 
+func (stf *serviceTopologyFilter) SetKubeClient(client kubernetes.Interface) error {
+	stf.client = client
+	return nil
+}
+
+func (stf *serviceTopologyFilter) resolveNodePoolName() string {
+	if len(stf.nodePoolName) != 0 {
+		return stf.nodePoolName
+	}
+
+	node, err := stf.client.CoreV1().Nodes().Get(context.Background(), stf.nodeName, metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("failed to get node(%s) in serviceTopologyFilter filter, %v", stf.nodeName, err)
+		return stf.nodePoolName
+	}
+	stf.nodePoolName = node.Labels[nodepoolv1alpha1.LabelDesiredNodePool]
+	return stf.nodePoolName
+}
+
 func (stf *serviceTopologyFilter) Filter(obj runtime.Object, stopCh <-chan struct{}) runtime.Object {
-	if ok := cache.WaitForCacheSync(stopCh, stf.nodeSynced, stf.serviceSynced, stf.nodePoolSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, stf.serviceSynced, stf.nodePoolSynced); !ok {
 		return obj
 	}
 
@@ -282,14 +222,8 @@ func (stf *serviceTopologyFilter) nodeTopologyHandler(obj runtime.Object) runtim
 }
 
 func (stf *serviceTopologyFilter) nodePoolTopologyHandler(obj runtime.Object) runtime.Object {
-	currentNode, err := stf.nodeGetter(stf.nodeName)
-	if err != nil {
-		klog.Warningf("skip serviceTopologyFilterHandler, failed to get current node %s, err: %v", stf.nodeName, err)
-		return obj
-	}
-
-	nodePoolName, ok := currentNode.Labels[nodepoolv1alpha1.LabelCurrentNodePool]
-	if !ok || len(nodePoolName) == 0 {
+	nodePoolName := stf.resolveNodePoolName()
+	if len(nodePoolName) == 0 {
 		klog.Infof("node(%s) is not added into node pool, so fall into node topology", stf.nodeName)
 		return stf.nodeTopologyHandler(obj)
 	}

--- a/pkg/yurthub/filter/servicetopology/filter_test.go
+++ b/pkg/yurthub/filter/servicetopology/filter_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package servicetopology
 
 import (
-	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -69,12 +68,15 @@ func TestFilter(t *testing.T) {
 	nodeName3 := "node3"
 
 	testcases := map[string]struct {
+		poolName       string
+		nodeName       string
 		responseObject runtime.Object
 		kubeClient     *k8sfake.Clientset
 		yurtClient     *yurtfake.Clientset
 		expectObject   runtime.Object
 	}{
 		"v1beta1.EndpointSliceList: topologyKeys is kubernetes.io/hostname": {
+			poolName: "hangzhou",
 			responseObject: &discoveryV1beta1.EndpointSliceList{
 				Items: []discoveryV1beta1.EndpointSlice{
 					{
@@ -127,7 +129,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -135,7 +137,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -143,7 +145,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -219,6 +221,7 @@ func TestFilter(t *testing.T) {
 			},
 		},
 		"v1beta1.EndpointSliceList: topologyKeys is openyurt.io/nodepool": {
+			poolName: "hangzhou",
 			responseObject: &discoveryV1beta1.EndpointSliceList{
 				Items: []discoveryV1beta1.EndpointSlice{
 					{
@@ -271,7 +274,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -279,7 +282,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -287,7 +290,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -423,7 +426,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -431,7 +434,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -439,7 +442,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -575,7 +578,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -583,7 +586,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -591,7 +594,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -739,7 +742,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -747,7 +750,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -874,7 +877,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -882,7 +885,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -890,7 +893,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1000,7 +1003,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1008,7 +1011,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1016,7 +1019,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1123,7 +1126,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1131,7 +1134,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1139,7 +1142,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1272,7 +1275,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1280,7 +1283,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1288,7 +1291,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1404,7 +1407,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1412,7 +1415,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1420,7 +1423,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1542,7 +1545,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1550,7 +1553,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1558,7 +1561,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1680,7 +1683,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1688,7 +1691,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1696,7 +1699,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1828,7 +1831,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1836,7 +1839,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1939,7 +1942,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -1947,7 +1950,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -1955,7 +1958,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2045,7 +2048,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2053,7 +2056,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2061,7 +2064,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2160,7 +2163,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2168,7 +2171,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2176,7 +2179,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2290,7 +2293,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2298,7 +2301,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2306,7 +2309,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2424,7 +2427,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2432,7 +2435,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2440,7 +2443,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2558,7 +2561,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2566,7 +2569,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2574,7 +2577,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2700,7 +2703,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2708,7 +2711,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2813,7 +2816,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2821,7 +2824,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2829,7 +2832,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2921,7 +2924,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -2929,7 +2932,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -2937,7 +2940,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -3029,7 +3032,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -3037,7 +3040,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -3045,7 +3048,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -3129,7 +3132,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "hangzhou",
+							nodepoolv1alpha1.LabelDesiredNodePool: "hangzhou",
 						},
 					},
 				},
@@ -3137,7 +3140,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -3145,7 +3148,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							nodepoolv1alpha1.LabelCurrentNodePool: "shanghai",
+							nodepoolv1alpha1.LabelDesiredNodePool: "shanghai",
 						},
 					},
 				},
@@ -3220,24 +3223,22 @@ func TestFilter(t *testing.T) {
 			yurtFactory.Start(stopper2)
 			yurtFactory.WaitForCacheSync(stopper2)
 
-			nodeGetter := func(name string) (*corev1.Node, error) {
-				return tt.kubeClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
-			}
-
-			nodeSynced := func() bool {
-				return true
-			}
-
 			stopCh := make(<-chan struct{})
 			stf := &serviceTopologyFilter{
 				nodeName:       currentNodeName,
 				serviceLister:  serviceLister,
 				nodePoolLister: nodePoolLister,
-				nodeGetter:     nodeGetter,
 				serviceSynced:  serviceSynced,
 				nodePoolSynced: nodePoolSynced,
-				nodeSynced:     nodeSynced,
+				client:         tt.kubeClient,
 			}
+
+			if len(tt.poolName) != 0 {
+				stf.nodePoolName = tt.poolName
+			} else {
+				stf.nodeName = currentNodeName
+			}
+
 			newObj := stf.Filter(tt.responseObject, stopCh)
 			if util.IsNil(newObj) {
 				t.Errorf("empty object is returned")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:
1. As described in pull request #1461 , filter servicetoplogy and nodeisolation have conflicts for getting node from local storage, and filter can not work well.

2. After diving into the code of these two filters, we found that node resource is used for resolving node pool, and as discussed in the issue: #1382 and pull request #1444 , node pool name for a node can not be changed after joining into the cluster.

3. at the same time, node pool name can be passed into yurthub by `yurtadm join` command, the detail info can be found in the pull request: #1402 , so we just use node pool name or get node from kube-apiserver only once when node pool name is not passed by `yurtadm join`.  then we can remove all the codes of getting node from local storage, and solve the conflicts problem. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
