### PR TITLE
feat: remove watch nodepool in service topology controller

### DIFF
--- a/pkg/controller/servicetopology/adapter/adapter.go
+++ b/pkg/controller/servicetopology/adapter/adapter.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/servicetopology"
@@ -33,7 +32,6 @@ import (
 
 type Adapter interface {
 	GetEnqueueKeysBySvc(svc *corev1.Service) []string
-	GetEnqueueKeysByNodePool(svcTopologyTypes map[string]string, allNpNodes sets.String) []string
 	UpdateTriggerAnnotations(namespace, name string) error
 }
 

--- a/pkg/controller/servicetopology/adapter/endpoints_adapter.go
+++ b/pkg/controller/servicetopology/adapter/endpoints_adapter.go
@@ -22,11 +22,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,39 +42,6 @@ type endpoints struct {
 func (s *endpoints) GetEnqueueKeysBySvc(svc *corev1.Service) []string {
 	var keys []string
 	return appendKeys(keys, svc)
-}
-
-func (s *endpoints) GetEnqueueKeysByNodePool(svcTopologyTypes map[string]string, allNpNodes sets.String) []string {
-	var keys []string
-	endpointsList := &corev1.EndpointsList{}
-	if err := s.client.List(context.TODO(), endpointsList, &client.ListOptions{LabelSelector: labels.Everything()}); err != nil {
-		klog.V(4).Infof("Error listing endpoints sets: %v", err)
-		return keys
-	}
-
-	for _, ep := range endpointsList.Items {
-		if !isNodePoolTypeSvc(ep.Namespace, ep.Name, svcTopologyTypes) {
-			continue
-		}
-
-		if s.getNodesInEp(&ep).Intersection(allNpNodes).Len() == 0 {
-			continue
-		}
-		keys = appendKeys(keys, &ep)
-	}
-	return keys
-}
-
-func (s *endpoints) getNodesInEp(ep *corev1.Endpoints) sets.String {
-	nodes := sets.NewString()
-	for _, subset := range ep.Subsets {
-		for _, addr := range subset.Addresses {
-			if addr.NodeName != nil {
-				nodes.Insert(*addr.NodeName)
-			}
-		}
-	}
-	return nodes
 }
 
 func (s *endpoints) UpdateTriggerAnnotations(namespace, name string) error {

--- a/pkg/controller/servicetopology/adapter/endpointslicev1_adapter.go
+++ b/pkg/controller/servicetopology/adapter/endpointslicev1_adapter.go
@@ -23,9 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,39 +54,6 @@ func (s *endpointslicev1) GetEnqueueKeysBySvc(svc *corev1.Service) []string {
 		keys = appendKeys(keys, &epSlice)
 	}
 	return keys
-}
-
-func (s *endpointslicev1) GetEnqueueKeysByNodePool(svcTopologyTypes map[string]string, allNpNodes sets.String) []string {
-	var keys []string
-	epSliceList := &discoveryv1.EndpointSliceList{}
-	if err := s.client.List(context.TODO(), epSliceList, &client.ListOptions{LabelSelector: labels.Everything()}); err != nil {
-		klog.V(4).Infof("Error listing endpointslices sets: %v", err)
-		return keys
-	}
-
-	for _, epSlice := range epSliceList.Items {
-		svcNamespace := epSlice.Namespace
-		svcName := epSlice.Labels[discoveryv1.LabelServiceName]
-		if !isNodePoolTypeSvc(svcNamespace, svcName, svcTopologyTypes) {
-			continue
-		}
-		if s.getNodesInEpSlice(&epSlice).Intersection(allNpNodes).Len() == 0 {
-			continue
-		}
-		keys = appendKeys(keys, &epSlice)
-	}
-
-	return keys
-}
-
-func (s *endpointslicev1) getNodesInEpSlice(epSlice *discoveryv1.EndpointSlice) sets.String {
-	nodes := sets.NewString()
-	for _, ep := range epSlice.Endpoints {
-		if ep.NodeName != nil {
-			nodes.Insert(*ep.NodeName)
-		}
-	}
-	return nodes
 }
 
 func (s *endpointslicev1) UpdateTriggerAnnotations(namespace, name string) error {

--- a/pkg/controller/servicetopology/adapter/endpointslicev1_adapter_test.go
+++ b/pkg/controller/servicetopology/adapter/endpointslicev1_adapter_test.go
@@ -26,77 +26,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-func TestEndpointSliceAdapterGetEnqueueKeysByNodePool(t *testing.T) {
-	svcName := "svc1"
-	svcNamespace := "default"
-	svcKey := fmt.Sprintf("%s/%s", svcNamespace, svcName)
-	nodeName1 := "node1"
-	nodeName2 := "node2"
-	tcases := map[string]struct {
-		kubeClient       kubernetes.Interface
-		client           client.Client
-		nodepoolNodes    sets.String
-		svcTopologyTypes map[string]string
-		expectResult     []string
-	}{
-		"service topology type: kubernetes.io/hostname": {
-			kubeClient: fake.NewSimpleClientset(
-				getEndpointSlice(svcNamespace, svcName, nodeName1),
-			),
-			client:        fakeclient.NewClientBuilder().WithObjects(getEndpointSlice(svcNamespace, svcName, nodeName1)).Build(),
-			nodepoolNodes: sets.NewString(nodeName1),
-			svcTopologyTypes: map[string]string{
-				svcKey: "kubernetes.io/hostname",
-			},
-			expectResult: nil,
-		},
-		"service topology type: kubernetes.io/zone, don't contain nodepool nodes": {
-			kubeClient: fake.NewSimpleClientset(
-				getEndpointSlice(svcNamespace, svcName, nodeName1),
-			),
-			client:        fakeclient.NewClientBuilder().WithObjects(getEndpointSlice(svcNamespace, svcName, nodeName1)).Build(),
-			nodepoolNodes: sets.NewString(nodeName2),
-			svcTopologyTypes: map[string]string{
-				svcKey: "kubernetes.io/zone",
-			},
-			expectResult: nil,
-		},
-		"service topology type: kubernetes.io/zone, contain nodepool nodes": {
-			kubeClient: fake.NewSimpleClientset(
-				getEndpointSlice(svcNamespace, svcName, nodeName1),
-			),
-			client:        fakeclient.NewClientBuilder().WithObjects(getEndpointSlice(svcNamespace, svcName, nodeName1)).Build(),
-			nodepoolNodes: sets.NewString(nodeName1),
-			svcTopologyTypes: map[string]string{
-				svcKey: "kubernetes.io/zone",
-			},
-			expectResult: []string{
-				getCacheKey(getEndpointSlice(svcNamespace, svcName, nodeName1)),
-			},
-		},
-	}
-
-	for k, tt := range tcases {
-		t.Logf("current test case is %s", k)
-
-		stopper := make(chan struct{})
-		defer close(stopper)
-
-		adapter := NewEndpointsV1Adapter(tt.kubeClient, tt.client)
-		keys := adapter.GetEnqueueKeysByNodePool(tt.svcTopologyTypes, tt.nodepoolNodes)
-		if !reflect.DeepEqual(keys, tt.expectResult) {
-			t.Errorf("expect enqueue keys %v, but got %v", tt.expectResult, keys)
-		}
-
-	}
-}
 
 func TestEndpointSliceV1AdapterUpdateTriggerAnnotations(t *testing.T) {
 	svcName := "svc1"

--- a/pkg/controller/servicetopology/adapter/endpointslicev1beta1_adapter_test.go
+++ b/pkg/controller/servicetopology/adapter/endpointslicev1beta1_adapter_test.go
@@ -22,86 +22,13 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-func TestEndpointSliceV1Beta1AdapterGetEnqueueKeysByNodePool(t *testing.T) {
-	svcName := "svc1"
-	svcNamespace := "default"
-	svcKey := fmt.Sprintf("%s/%s", svcNamespace, svcName)
-	nodeName1 := "node1"
-	nodeName2 := "node2"
-	tcases := map[string]struct {
-		kubeClient       kubernetes.Interface
-		client           client.Client
-		nodepoolNodes    sets.String
-		svcTopologyTypes map[string]string
-		expectResult     []string
-	}{
-		"service topology type: kubernetes.io/hostname": {
-			kubeClient: fake.NewSimpleClientset(
-				getV1Beta1EndpointSlice(svcNamespace, svcName, nodeName1),
-			),
-			client:        fakeclient.NewClientBuilder().WithObjects(getV1Beta1EndpointSlice(svcNamespace, svcName, nodeName1)).Build(),
-			nodepoolNodes: sets.NewString(nodeName1),
-			svcTopologyTypes: map[string]string{
-				svcKey: "kubernetes.io/hostname",
-			},
-			expectResult: nil,
-		},
-		"service topology type: openyurt.io/nodepool, don't contain nodepool nodes": {
-			kubeClient: fake.NewSimpleClientset(
-				getV1Beta1EndpointSlice(svcNamespace, svcName, nodeName1),
-			),
-			client:        fakeclient.NewClientBuilder().WithObjects(getV1Beta1EndpointSlice(svcNamespace, svcName, nodeName1)).Build(),
-			nodepoolNodes: sets.NewString(nodeName2),
-			svcTopologyTypes: map[string]string{
-				svcKey: "openyurt.io/nodepool",
-			},
-			expectResult: nil,
-		},
-		"service topology type: kubernetes.io/zone, contain nodepool nodes": {
-			kubeClient: fake.NewSimpleClientset(
-				getV1Beta1EndpointSlice(svcNamespace, svcName, nodeName1),
-			),
-			client:        fakeclient.NewClientBuilder().WithObjects(getV1Beta1EndpointSlice(svcNamespace, svcName, nodeName1)).Build(),
-			nodepoolNodes: sets.NewString(nodeName1),
-			svcTopologyTypes: map[string]string{
-				svcKey: "kubernetes.io/zone",
-			},
-			expectResult: []string{
-				getCacheKey(getV1Beta1EndpointSlice(svcNamespace, svcName, nodeName1)),
-			},
-		},
-	}
-
-	for k, tt := range tcases {
-		t.Logf("current test case is %s", k)
-		factory := informers.NewSharedInformerFactory(tt.kubeClient, 24*time.Hour)
-
-		stopper := make(chan struct{})
-		defer close(stopper)
-		factory.Start(stopper)
-		factory.WaitForCacheSync(stopper)
-
-		adapter := NewEndpointsV1Beta1Adapter(tt.kubeClient, tt.client)
-		keys := adapter.GetEnqueueKeysByNodePool(tt.svcTopologyTypes, tt.nodepoolNodes)
-		if !reflect.DeepEqual(keys, tt.expectResult) {
-			t.Errorf("expect enqueue keys %v, but got %v", tt.expectResult, keys)
-		}
-
-	}
-}
 
 func TestEndpointSliceV1Beta1AdapterUpdateTriggerAnnotations(t *testing.T) {
 	svcName := "svc1"

--- a/pkg/controller/servicetopology/endpoints/endpoints_enqueue_handlers.go
+++ b/pkg/controller/servicetopology/endpoints/endpoints_enqueue_handlers.go
@@ -19,17 +19,14 @@ package endpoints
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openyurtio/openyurt/pkg/controller/servicetopology/adapter"
 	"github.com/openyurtio/openyurt/pkg/controller/servicetopology/util"
-	nodepoolv1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/apis/apps/v1alpha1"
 )
 
 type EnqueueEndpointsForService struct {
@@ -74,77 +71,6 @@ func (e *EnqueueEndpointsForService) Generic(evt event.GenericEvent,
 func (e *EnqueueEndpointsForService) enqueueEndpointsForSvc(newSvc *corev1.Service, q workqueue.RateLimitingInterface) {
 	keys := e.endpointsAdapter.GetEnqueueKeysBySvc(newSvc)
 	klog.Infof(Format("the topology configuration of svc %s/%s is changed, enqueue endpoints: %v", newSvc.Namespace, newSvc.Name, keys))
-	for _, key := range keys {
-		ns, name, err := cache.SplitMetaNamespaceKey(key)
-		if err != nil {
-			klog.Errorf("failed to split key %s, %v", key, err)
-			continue
-		}
-		q.AddRateLimited(reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
-		})
-	}
-}
-
-type EnqueueEndpointsForNodePool struct {
-	endpointsAdapter adapter.Adapter
-	client           client.Client
-}
-
-// Create implements EventHandler
-func (e *EnqueueEndpointsForNodePool) Create(evt event.CreateEvent,
-	q workqueue.RateLimitingInterface) {
-}
-
-// Update implements EventHandler
-func (e *EnqueueEndpointsForNodePool) Update(evt event.UpdateEvent,
-	q workqueue.RateLimitingInterface) {
-	oldNp, ok := evt.ObjectOld.(*nodepoolv1alpha1.NodePool)
-	if !ok {
-		klog.Errorf(Format("Fail to assert runtime Object(%s) to nodepoolv1alpha1.NodePool",
-			evt.ObjectOld.GetName()))
-		return
-	}
-	newNp, ok := evt.ObjectNew.(*nodepoolv1alpha1.NodePool)
-	if !ok {
-		klog.Errorf(Format("Fail to assert runtime Object(%s) to nodepoolv1alpha1.NodePool",
-			evt.ObjectNew.GetName()))
-		return
-	}
-	newNpNodes := sets.NewString(newNp.Status.Nodes...)
-	oldNpNodes := sets.NewString(oldNp.Status.Nodes...)
-	if newNpNodes.Equal(oldNpNodes) {
-		return
-	}
-	klog.Infof(Format("the nodes record of nodepool %s is changed from %v to %v.", newNp.Name, oldNp.Status.Nodes, newNp.Status.Nodes))
-	allNpNodes := newNpNodes.Union(oldNpNodes)
-	svcTopologyTypes := util.GetSvcTopologyTypes(e.client)
-	e.enqueueEndpointsForNodePool(svcTopologyTypes, allNpNodes, newNp, q)
-}
-
-// Delete implements EventHandler
-func (e *EnqueueEndpointsForNodePool) Delete(evt event.DeleteEvent,
-	q workqueue.RateLimitingInterface) {
-	nodePool, ok := evt.Object.(*nodepoolv1alpha1.NodePool)
-	if !ok {
-		klog.Errorf(Format("Fail to assert runtime Object(%s) to nodepoolv1alpha1.NodePool",
-			evt.Object.GetName()))
-		return
-	}
-	klog.Infof(Format("nodepool %s is deleted", nodePool.Name))
-	allNpNodes := sets.NewString(nodePool.Status.Nodes...)
-	svcTopologyTypes := util.GetSvcTopologyTypes(e.client)
-	e.enqueueEndpointsForNodePool(svcTopologyTypes, allNpNodes, nodePool, q)
-}
-
-// Generic implements EventHandler
-func (e *EnqueueEndpointsForNodePool) Generic(evt event.GenericEvent,
-	q workqueue.RateLimitingInterface) {
-}
-
-func (e *EnqueueEndpointsForNodePool) enqueueEndpointsForNodePool(svcTopologyTypes map[string]string, allNpNodes sets.String, np *nodepoolv1alpha1.NodePool, q workqueue.RateLimitingInterface) {
-	keys := e.endpointsAdapter.GetEnqueueKeysByNodePool(svcTopologyTypes, allNpNodes)
-	klog.Infof(Format("according to the change of the nodepool %s, enqueue endpoints: %v", np.Name, keys))
 	for _, key := range keys {
 		ns, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {

--- a/pkg/controller/servicetopology/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/servicetopology/endpointslice/endpointslice_controller.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	appconfig "github.com/openyurtio/openyurt/cmd/yurt-manager/app/config"
-	appsv1beta1 "github.com/openyurtio/openyurt/pkg/apis/apps/v1beta1"
 	common "github.com/openyurtio/openyurt/pkg/controller/servicetopology"
 	"github.com/openyurtio/openyurt/pkg/controller/servicetopology/adapter"
 )
@@ -73,14 +72,6 @@ func Add(_ *appconfig.CompletedConfig, mgr manager.Manager) error {
 	// Watch for changes to Service
 	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, &EnqueueEndpointsliceForService{
 		endpointsliceAdapter: r.endpointsliceAdapter,
-	}); err != nil {
-		return err
-	}
-
-	// Watch for changes to NodePool
-	if err := c.Watch(&source.Kind{Type: &appsv1beta1.NodePool{}}, &EnqueueEndpointsliceForNodePool{
-		endpointsliceAdapter: r.endpointsliceAdapter,
-		client:               r.Client,
 	}); err != nil {
 		return err
 	}

--- a/pkg/controller/servicetopology/endpointslice/endpointslice_enqueue_handlers.go
+++ b/pkg/controller/servicetopology/endpointslice/endpointslice_enqueue_handlers.go
@@ -19,17 +19,14 @@ package endpointslice
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openyurtio/openyurt/pkg/controller/servicetopology/adapter"
 	"github.com/openyurtio/openyurt/pkg/controller/servicetopology/util"
-	nodepoolv1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/apis/apps/v1alpha1"
 )
 
 type EnqueueEndpointsliceForService struct {
@@ -74,77 +71,6 @@ func (e *EnqueueEndpointsliceForService) Generic(evt event.GenericEvent,
 func (e *EnqueueEndpointsliceForService) enqueueEndpointsliceForSvc(newSvc *corev1.Service, q workqueue.RateLimitingInterface) {
 	keys := e.endpointsliceAdapter.GetEnqueueKeysBySvc(newSvc)
 	klog.Infof(Format("the topology configuration of svc %s/%s is changed, enqueue endpointslices: %v", newSvc.Namespace, newSvc.Name, keys))
-	for _, key := range keys {
-		ns, name, err := cache.SplitMetaNamespaceKey(key)
-		if err != nil {
-			klog.Errorf("failed to split key %s, %v", key, err)
-			continue
-		}
-		q.AddRateLimited(reconcile.Request{
-			NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
-		})
-	}
-}
-
-type EnqueueEndpointsliceForNodePool struct {
-	endpointsliceAdapter adapter.Adapter
-	client               client.Client
-}
-
-// Create implements EventHandler
-func (e *EnqueueEndpointsliceForNodePool) Create(evt event.CreateEvent,
-	q workqueue.RateLimitingInterface) {
-}
-
-// Update implements EventHandler
-func (e *EnqueueEndpointsliceForNodePool) Update(evt event.UpdateEvent,
-	q workqueue.RateLimitingInterface) {
-	oldNp, ok := evt.ObjectOld.(*nodepoolv1alpha1.NodePool)
-	if !ok {
-		klog.Errorf(Format("Fail to assert runtime Object(%s) to nodepoolv1alpha1.NodePool",
-			evt.ObjectOld.GetName()))
-		return
-	}
-	newNp, ok := evt.ObjectNew.(*nodepoolv1alpha1.NodePool)
-	if !ok {
-		klog.Errorf(Format("Fail to assert runtime Object(%s) to nodepoolv1alpha1.NodePool",
-			evt.ObjectNew.GetName()))
-		return
-	}
-	newNpNodes := sets.NewString(newNp.Status.Nodes...)
-	oldNpNodes := sets.NewString(oldNp.Status.Nodes...)
-	if newNpNodes.Equal(oldNpNodes) {
-		return
-	}
-	klog.Infof(Format("the nodes record of nodepool %s is changed from %v to %v.", newNp.Name, oldNp.Status.Nodes, newNp.Status.Nodes))
-	allNpNodes := newNpNodes.Union(oldNpNodes)
-	svcTopologyTypes := util.GetSvcTopologyTypes(e.client)
-	e.enqueueEndpointSliceForNodePool(svcTopologyTypes, allNpNodes, newNp, q)
-}
-
-// Delete implements EventHandler
-func (e *EnqueueEndpointsliceForNodePool) Delete(evt event.DeleteEvent,
-	q workqueue.RateLimitingInterface) {
-	nodePool, ok := evt.Object.(*nodepoolv1alpha1.NodePool)
-	if !ok {
-		klog.Errorf(Format("Fail to assert runtime Object(%s) to nodepoolv1alpha1.NodePool",
-			evt.Object.GetName()))
-		return
-	}
-	klog.Infof(Format("nodepool %s is deleted", nodePool.Name))
-	allNpNodes := sets.NewString(nodePool.Status.Nodes...)
-	svcTopologyTypes := util.GetSvcTopologyTypes(e.client)
-	e.enqueueEndpointSliceForNodePool(svcTopologyTypes, allNpNodes, nodePool, q)
-}
-
-// Generic implements EventHandler
-func (e *EnqueueEndpointsliceForNodePool) Generic(evt event.GenericEvent,
-	q workqueue.RateLimitingInterface) {
-}
-
-func (e *EnqueueEndpointsliceForNodePool) enqueueEndpointSliceForNodePool(svcTopologyTypes map[string]string, allNpNodes sets.String, np *nodepoolv1alpha1.NodePool, q workqueue.RateLimitingInterface) {
-	keys := e.endpointsliceAdapter.GetEnqueueKeysByNodePool(svcTopologyTypes, allNpNodes)
-	klog.Infof(Format("according to the change of the nodepool %s, enqueue endpointslice: %v", np.Name, keys))
 	for _, key := range keys {
 		ns, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {

--- a/pkg/controller/servicetopology/util/util.go
+++ b/pkg/controller/servicetopology/util/util.go
@@ -17,14 +17,7 @@ limitations under the License.
 package util
 
 import (
-	"context"
-
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/servicetopology"
 )
@@ -36,28 +29,4 @@ func ServiceTopologyTypeChanged(oldSvc, newSvc *corev1.Service) bool {
 		return false
 	}
 	return true
-}
-
-func GetSvcTopologyTypes(c client.Client) map[string]string {
-	svcTopologyTypes := make(map[string]string)
-	svcList := &corev1.ServiceList{}
-	if err := c.List(context.TODO(), svcList, &client.ListOptions{LabelSelector: labels.Everything()}); err != nil {
-		klog.V(4).Infof("failed to list service sets: %v", err)
-		return svcTopologyTypes
-	}
-
-	for _, svc := range svcList.Items {
-		topologyType, ok := svc.Annotations[servicetopology.AnnotationServiceTopologyKey]
-		if !ok {
-			continue
-		}
-
-		key, err := cache.MetaNamespaceKeyFunc(svc)
-		if err != nil {
-			runtime.HandleError(err)
-			continue
-		}
-		svcTopologyTypes[key] = topologyType
-	}
-	return svcTopologyTypes
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

 /kind feature

#### What this PR does / why we need it:
As discussed in #1553 , The efficiency of service topology feature can be improved if nodepool list/watch is removed.
moreover, nodepool list/watch is a dummy function for service topology controller. 

so i want to remove list/watch nodepool function in service topology controller.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1553 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
