### PR TITLE
feat: improve service topology controller by using client.Client instead of kubernetes.Interface

### DIFF
--- a/pkg/controller/servicetopology/adapter/endpointslicev1beta1_adapter.go
+++ b/pkg/controller/servicetopology/adapter/endpointslicev1beta1_adapter.go
@@ -24,21 +24,18 @@ import (
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewEndpointsV1Beta1Adapter(kubeClient kubernetes.Interface, client client.Client) Adapter {
+func NewEndpointsV1Beta1Adapter(client client.Client) Adapter {
 	return &endpointslicev1beta1{
-		kubeClient: kubeClient,
-		client:     client,
+		client: client,
 	}
 }
 
 type endpointslicev1beta1 struct {
-	kubeClient kubernetes.Interface
-	client     client.Client
+	client client.Client
 }
 
 func (s *endpointslicev1beta1) GetEnqueueKeysBySvc(svc *corev1.Service) []string {
@@ -58,6 +55,15 @@ func (s *endpointslicev1beta1) GetEnqueueKeysBySvc(svc *corev1.Service) []string
 
 func (s *endpointslicev1beta1) UpdateTriggerAnnotations(namespace, name string) error {
 	patch := getUpdateTriggerPatch()
-	_, err := s.kubeClient.DiscoveryV1beta1().EndpointSlices(namespace).Patch(context.Background(), name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	err := s.client.Patch(
+		context.Background(),
+		&discoveryv1beta1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+			},
+		},
+		client.RawPatch(types.StrategicMergePatchType, patch), &client.PatchOptions{},
+	)
 	return err
 }

--- a/pkg/controller/servicetopology/adapter/endpointslicev1beta1_adapter_test.go
+++ b/pkg/controller/servicetopology/adapter/endpointslicev1beta1_adapter_test.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/types"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -35,17 +35,16 @@ func TestEndpointSliceV1Beta1AdapterUpdateTriggerAnnotations(t *testing.T) {
 	svcNamespace := "default"
 	epSlice := getV1Beta1EndpointSlice(svcNamespace, svcName, "node1")
 
-	kubeClient := fake.NewSimpleClientset(epSlice)
 	c := fakeclient.NewClientBuilder().WithObjects(epSlice).Build()
 	stopper := make(chan struct{})
 	defer close(stopper)
-	adapter := NewEndpointsV1Beta1Adapter(kubeClient, c)
+	adapter := NewEndpointsV1Beta1Adapter(c)
 	err := adapter.UpdateTriggerAnnotations(epSlice.Namespace, epSlice.Name)
 	if err != nil {
 		t.Errorf("update endpointsSlice trigger annotations failed")
 	}
-
-	newEpSlice, err := kubeClient.DiscoveryV1beta1().EndpointSlices(epSlice.Namespace).Get(context.TODO(), epSlice.Name, metav1.GetOptions{})
+	newEpSlice := &discoveryv1beta1.EndpointSlice{}
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: epSlice.Namespace, Name: epSlice.Name}, newEpSlice)
 	if err != nil || epSlice.Annotations["openyurt.io/update-trigger"] == newEpSlice.Annotations["openyurt.io/update-trigger"] {
 		t.Errorf("update endpoints trigger annotations failed")
 	}
@@ -65,9 +64,8 @@ func TestEndpointSliceV1Beta1AdapterGetEnqueueKeysBySvc(t *testing.T) {
 
 	stopper := make(chan struct{})
 	defer close(stopper)
-	kubeClient := fake.NewSimpleClientset(epSlice)
 	c := fakeclient.NewClientBuilder().WithObjects(epSlice).Build()
-	adapter := NewEndpointsV1Beta1Adapter(kubeClient, c)
+	adapter := NewEndpointsV1Beta1Adapter(c)
 
 	keys := adapter.GetEnqueueKeysBySvc(svc)
 	if !reflect.DeepEqual(keys, expectResult) {

--- a/pkg/controller/servicetopology/endpoints/endpoints_controller.go
+++ b/pkg/controller/servicetopology/endpoints/endpoints_controller.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -78,16 +76,7 @@ func newReconciler(_ *appconfig.CompletedConfig, mgr manager.Manager) reconcile.
 
 func (r *ReconcileServicetopologyEndpoints) InjectClient(c client.Client) error {
 	r.Client = c
-	return nil
-}
-
-func (r *ReconcileServicetopologyEndpoints) InjectConfig(cfg *rest.Config) error {
-	c, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		klog.Errorf(Format("failed to create kube client, %v", err))
-		return err
-	}
-	r.endpointsAdapter = adapter.NewEndpointsAdapter(c, r.Client)
+	r.endpointsAdapter = adapter.NewEndpointsAdapter(c)
 	return nil
 }
 

--- a/pkg/controller/servicetopology/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/servicetopology/endpointslice/endpointslice_controller.go
@@ -25,8 +25,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,9 +62,9 @@ func Add(_ *appconfig.CompletedConfig, mgr manager.Manager) error {
 	}
 
 	if r.isSupportEndpointslicev1 {
-		r.endpointsliceAdapter = adapter.NewEndpointsV1Adapter(r.kubeClient, r.Client)
+		r.endpointsliceAdapter = adapter.NewEndpointsV1Adapter(r.Client)
 	} else {
-		r.endpointsliceAdapter = adapter.NewEndpointsV1Beta1Adapter(r.kubeClient, r.Client)
+		r.endpointsliceAdapter = adapter.NewEndpointsV1Beta1Adapter(r.Client)
 	}
 
 	// Watch for changes to Service
@@ -85,19 +83,8 @@ var _ reconcile.Reconciler = &ReconcileServiceTopologyEndpointSlice{}
 // ReconcileServiceTopologyEndpointSlice reconciles a Example object
 type ReconcileServiceTopologyEndpointSlice struct {
 	client.Client
-	kubeClient               kubernetes.Interface
 	endpointsliceAdapter     adapter.Adapter
 	isSupportEndpointslicev1 bool
-}
-
-func (r *ReconcileServiceTopologyEndpointSlice) InjectConfig(cfg *rest.Config) error {
-	c, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		klog.Errorf(Format("failed to create kube client, %v", err))
-		return err
-	}
-	r.kubeClient = c
-	return nil
 }
 
 func (r *ReconcileServiceTopologyEndpointSlice) InjectMapper(mapper meta.RESTMapper) error {


### PR DESCRIPTION
feat: improve service topology controller by using client.Client instead of kubernetes.Interface

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue

/kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:
In service topology controller, kubernetes.Interface is used for updating annotations of [endpoints](https://github.com/openyurtio/openyurt/blob/master/pkg/controller/servicetopology/adapter/endpoints_adapter.go#L49), [v1.endpointslices](https://github.com/openyurtio/openyurt/blob/master/pkg/controller/servicetopology/adapter/endpointslicev1_adapter.go#L61), [v1beta1.endpointslices](https://github.com/openyurtio/openyurt/blob/master/pkg/controller/servicetopology/adapter/endpointslicev1beta1_adapter.go#L61).

and it is recommended to use client.Client instead of kubernetes.Interface to update K8s object in yurt-manager controller because controller-runtime is imported by yurt-manager.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1559 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
