### PR TITLE
check whether yurt manager's container is ready in e2e

### DIFF
--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -291,6 +291,7 @@ func (c *ClusterConverter) deployYurtManager() error {
 			for i := range podList.Items[0].Status.Conditions {
 				if podList.Items[0].Status.Conditions[i].Type == corev1.PodReady &&
 					podList.Items[0].Status.Conditions[i].Status == corev1.ConditionTrue {
+					klog.Info("yurt manager's container and pod are both ready")
 					return true, nil
 				}
 			}

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -284,6 +284,9 @@ func (c *ClusterConverter) deployYurtManager() error {
 		}
 
 		if podList.Items[0].Status.Phase == corev1.PodRunning {
+			if podList.Items[0].Status.ContainerStatuses[0].Ready == false {
+				return false, nil
+			}
 			for i := range podList.Items[0].Status.Conditions {
 				if podList.Items[0].Status.Conditions[i].Type == corev1.PodReady &&
 					podList.Items[0].Status.Conditions[i].Status == corev1.ConditionTrue {

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -285,6 +285,7 @@ func (c *ClusterConverter) deployYurtManager() error {
 
 		if podList.Items[0].Status.Phase == corev1.PodRunning {
 			if podList.Items[0].Status.ContainerStatuses[0].Ready == false {
+				klog.Info("yurt manager's container is not ready")
 				return false, nil
 			}
 			for i := range podList.Items[0].Status.Conditions {

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -284,20 +284,20 @@ func (c *ClusterConverter) deployYurtManager() error {
 		}
 
 		if podList.Items[0].Status.Phase == corev1.PodRunning {
-			if podList.Items[0].Status.ContainerStatuses[0].Ready == false {
-				klog.Info("yurt manager's container is not ready")
-				return false, nil
-			}
 			for i := range podList.Items[0].Status.Conditions {
 				if podList.Items[0].Status.Conditions[i].Type == corev1.PodReady &&
-					podList.Items[0].Status.Conditions[i].Status == corev1.ConditionTrue {
-					klog.Info("yurt manager's container and pod are both ready")
-					return true, nil
+					podList.Items[0].Status.Conditions[i].Status != corev1.ConditionTrue {
+					klog.Infof("pod(%s/%s): %#v", podList.Items[0].Namespace, podList.Items[0].Name, podList.Items[0])
+					return false, nil
+				}
+				if podList.Items[0].Status.Conditions[i].Type == corev1.ContainersReady &&
+					podList.Items[0].Status.Conditions[i].Status != corev1.ConditionTrue {
+					klog.Info("yurt manager's container is not ready")
+					return false, nil
 				}
 			}
 		}
-		klog.Infof("pod(%s/%s): %#v", podList.Items[0].Namespace, podList.Items[0].Name, podList.Items[0])
-		return false, nil
+		return true, nil
 	})
 }
 

--- a/test/e2e/cmd/init/init.go
+++ b/test/e2e/cmd/init/init.go
@@ -25,12 +25,11 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"

--- a/test/e2e/cmd/init/init.go
+++ b/test/e2e/cmd/init/init.go
@@ -382,7 +382,7 @@ func (ki *Initializer) configureAddons() error {
 		})
 		if err != nil {
 			klog.Errorf("failed to list yurt-manager pod, %v", err)
-			return false, nil
+			return false, err
 		}
 		for _, pod := range yurtManagerPods.Items {
 			if !pod.Status.ContainerStatuses[0].Ready {

--- a/test/e2e/cmd/init/init.go
+++ b/test/e2e/cmd/init/init.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/test/e2e/cmd/init/init.go
+++ b/test/e2e/cmd/init/init.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -375,26 +374,7 @@ func (ki *Initializer) prepareKindConfigFile(kindConfigPath string) error {
 }
 
 func (ki *Initializer) configureAddons() error {
-	err := wait.PollImmediate(10*time.Second, 4*time.Minute, func() (bool, error) {
-		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "yurt-manager"}}
-		yurtManagerPods, err := ki.kubeClient.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{
-			LabelSelector: metav1.FormatLabelSelector(&labelSelector),
-		})
-		if err != nil {
-			klog.Errorf("failed to list yurt-manager pod, %v", err)
-			return false, err
-		}
-		for _, pod := range yurtManagerPods.Items {
-			if !pod.Status.ContainerStatuses[0].Ready {
-				klog.Info("container is not ready in yurtmanager pod")
-				return false, nil
-			}
-		}
-		return true, nil
-	})
-	if err != nil {
-		return err
-	}
+
 	if err := ki.configureCoreDnsAddon(); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:
Add check about the yurt manager container's readiness in e2e, otherwise the deployment webhook won't be ready at update of coredns. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
