### PR TITLE
inject rbac for coordinator to enable logs/exec

### DIFF
--- a/pkg/yurthub/yurtcoordinator/constants/constants.go
+++ b/pkg/yurthub/yurtcoordinator/constants/constants.go
@@ -17,6 +17,9 @@ limitations under the License.
 package constants
 
 import (
+	v1rbac "k8s.io/api/rbac/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
 )
 
@@ -24,6 +27,27 @@ var (
 	UploadResourcesKeyBuildInfo = map[storage.KeyBuildInfo]struct{}{
 		{Component: "kubelet", Resources: "pods", Group: "", Version: "v1"}:  {},
 		{Component: "kubelet", Resources: "nodes", Group: "", Version: "v1"}: {},
+	}
+	CoordinatorAPIServerClusterRoleBinding = v1rbac.ClusterRoleBinding{
+		TypeMeta: v1meta.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: v1meta.ObjectMeta{
+			Name: "openyurt:yurt-coordinator:apiserver",
+		},
+		Subjects: []v1rbac.Subject{
+			{
+				Kind:     "User",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     "openyurt:yurt-coordinator:apiserver",
+			},
+		},
+		RoleRef: v1rbac.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "system:kubelet-api-admin",
+		},
 	}
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:

Currently, kubectl logs to poolcoordinator cannot work because the apiserver in pool-coordinator is not authorized to access the kubelet server, in other words it cannot get sub-resources proxy/logs. This pr will inject relative rbac rule to enable the apiserver to access the kubelet server.

The proposal in origin PR #1384 was deprecated for problems in offline scenario.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1176 



#### other Note

The way we do the injection is that: the leader yurthub should try to create the relative rbac rules for `openyurt:yurt-coordinator:apiserver` after winning the election. It will start a goroutine to create the rbac rules which will retry on faile. This goroutine will exit only when the rbac is created successfully or the leader changes.
