### PR TITLE
use dynamicinformerfactory to get nodepool instead of yurt-app-manager-api repo

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -28,15 +28,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	componentbaseconfig "k8s.io/component-base/config"
@@ -47,18 +47,12 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/certificate"
 	certificatemgr "github.com/openyurtio/openyurt/pkg/yurthub/certificate/manager"
-	"github.com/openyurtio/openyurt/pkg/yurthub/filter"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/manager"
 	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
 	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
 	"github.com/openyurtio/openyurt/pkg/yurthub/network"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
 	"github.com/openyurtio/openyurt/pkg/yurthub/util"
-	yurtcorev1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/apis/apps/v1alpha1"
-	yurtclientset "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/clientset/versioned"
-	"github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/clientset/versioned/fake"
-	yurtinformers "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/informers/externalversions"
-	yurtv1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/informers/externalversions/apps/v1alpha1"
 )
 
 // YurtHubConfiguration represents configuration of yurthub
@@ -77,7 +71,7 @@ type YurtHubConfiguration struct {
 	SerializerManager               *serializer.SerializerManager
 	RESTMapperManager               *meta.RESTMapperManager
 	SharedFactory                   informers.SharedInformerFactory
-	YurtSharedFactory               yurtinformers.SharedInformerFactory
+	NodePoolInformerFactory         dynamicinformer.DynamicSharedInformerFactory
 	WorkingMode                     util.WorkingMode
 	KubeletHealthGracePeriod        time.Duration
 	FilterManager                   *manager.Manager
@@ -132,13 +126,13 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 	}
 
 	workingMode := util.WorkingMode(options.WorkingMode)
-	proxiedClient, sharedFactory, yurtSharedFactory, err := createClientAndSharedInformers(fmt.Sprintf("http://%s:%d", options.YurtHubProxyHost, options.YurtHubProxyPort), options.EnableNodePool)
+	proxiedClient, sharedFactory, dynamicSharedFactory, err := createClientAndSharedInformers(fmt.Sprintf("http://%s:%d", options.YurtHubProxyHost, options.YurtHubProxyPort), options.NodePoolName)
 	if err != nil {
 		return nil, err
 	}
 	tenantNs := util.ParseTenantNsFromOrgs(options.YurtHubCertOrganizations)
-	registerInformers(options, sharedFactory, yurtSharedFactory, workingMode, tenantNs)
-	filterManager, err := manager.NewFilterManager(options, sharedFactory, yurtSharedFactory, proxiedClient, serializerManager, us[0].Host)
+	registerInformers(options, sharedFactory, workingMode, tenantNs)
+	filterManager, err := manager.NewFilterManager(options, sharedFactory, dynamicSharedFactory, proxiedClient, serializerManager, us[0].Host)
 	if err != nil {
 		klog.Errorf("could not create filter manager, %v", err)
 		return nil, err
@@ -160,7 +154,7 @@ func Complete(options *options.YurtHubOptions) (*YurtHubConfiguration, error) {
 		SerializerManager:         serializerManager,
 		RESTMapperManager:         restMapperManager,
 		SharedFactory:             sharedFactory,
-		YurtSharedFactory:         yurtSharedFactory,
+		NodePoolInformerFactory:   dynamicSharedFactory,
 		KubeletHealthGracePeriod:  options.KubeletHealthGracePeriod,
 		FilterManager:             filterManager,
 		MinRequestTimeout:         options.MinRequestTimeout,
@@ -241,9 +235,8 @@ func parseRemoteServers(serverAddr string) ([]*url.URL, error) {
 }
 
 // createClientAndSharedInformers create kubeclient and sharedInformers from the given proxyAddr.
-func createClientAndSharedInformers(proxyAddr string, enableNodePool bool) (kubernetes.Interface, informers.SharedInformerFactory, yurtinformers.SharedInformerFactory, error) {
+func createClientAndSharedInformers(proxyAddr string, nodePoolName string) (kubernetes.Interface, informers.SharedInformerFactory, dynamicinformer.DynamicSharedInformerFactory, error) {
 	var kubeConfig *rest.Config
-	var yurtClient yurtclientset.Interface
 	var err error
 	kubeConfig, err = clientcmd.BuildConfigFromFlags(proxyAddr, "")
 	if err != nil {
@@ -255,53 +248,27 @@ func createClientAndSharedInformers(proxyAddr string, enableNodePool bool) (kube
 		return nil, nil, nil, err
 	}
 
-	fakeYurtClient := &fake.Clientset{}
-	fakeWatch := watch.NewFake()
-	fakeYurtClient.AddWatchReactor("nodepools", core.DefaultWatchReactor(fakeWatch, nil))
-	// init yurtClient by fake client
-	yurtClient = fakeYurtClient
-	if enableNodePool {
-		yurtClient, err = yurtclientset.NewForConfig(kubeConfig)
-		if err != nil {
-			return nil, nil, nil, err
-		}
+	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
-	return client, informers.NewSharedInformerFactory(client, 24*time.Hour),
-		yurtinformers.NewSharedInformerFactory(yurtClient, 24*time.Hour), nil
+	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 24*time.Hour)
+	if len(nodePoolName) != 0 {
+		dynamicInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 24*time.Hour, metav1.NamespaceAll, func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.Set{"metadata.name": nodePoolName}.String()
+		})
+	}
+
+	return client, informers.NewSharedInformerFactory(client, 24*time.Hour), dynamicInformerFactory, nil
 }
 
-// registerInformers reconstruct node/nodePool/configmap informers
+// registerInformers reconstruct configmap/secret/pod informers
 func registerInformers(options *options.YurtHubOptions,
 	informerFactory informers.SharedInformerFactory,
-	yurtInformerFactory yurtinformers.SharedInformerFactory,
 	workingMode util.WorkingMode,
 	tenantNs string) {
-	// skip construct node/nodePool informers if service topology filter disabled
-	serviceTopologyFilterEnabled := isServiceTopologyFilterEnabled(options)
-	if serviceTopologyFilterEnabled {
-		if workingMode == util.WorkingModeCloud {
-			newNodeInformer := func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-				tweakListOptions := func(ops *metav1.ListOptions) {
-					ops.FieldSelector = fields.Set{"metadata.name": options.NodeName}.String()
-				}
-				return coreinformers.NewFilteredNodeInformer(client, resyncPeriod, nil, tweakListOptions)
-			}
-			informerFactory.InformerFor(&corev1.Node{}, newNodeInformer)
-		}
-
-		if len(options.NodePoolName) != 0 {
-			newNodePoolInformer := func(client yurtclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-				tweakListOptions := func(ops *metav1.ListOptions) {
-					ops.FieldSelector = fields.Set{"metadata.name": options.NodePoolName}.String()
-				}
-				return yurtv1alpha1.NewFilteredNodePoolInformer(client, resyncPeriod, nil, tweakListOptions)
-			}
-
-			yurtInformerFactory.InformerFor(&yurtcorev1alpha1.NodePool{}, newNodePoolInformer)
-		}
-	}
-
+	// configmap informer is used by Yurthub filter approver
 	newConfigmapInformer := func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 		tweakListOptions := func(options *metav1.ListOptions) {
 			options.FieldSelector = fields.Set{"metadata.name": util.YurthubConfigMapName}.String()
@@ -310,6 +277,7 @@ func registerInformers(options *options.YurtHubOptions,
 	}
 	informerFactory.InformerFor(&corev1.ConfigMap{}, newConfigmapInformer)
 
+	// secret informer is used by Tenant manager, this feature is not enabled in general.
 	if tenantNs != "" {
 		newSecretInformer := func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 			return coreinformers.NewFilteredSecretInformer(client, tenantNs, resyncPeriod, nil, nil)
@@ -317,6 +285,7 @@ func registerInformers(options *options.YurtHubOptions,
 		informerFactory.InformerFor(&corev1.Secret{}, newSecretInformer)
 	}
 
+	// pod informer is used by OTA updater on cloud working mode
 	if workingMode == util.WorkingModeCloud {
 		newPodInformer := func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 			listOptions := func(ops *metav1.ListOptions) {
@@ -326,29 +295,6 @@ func registerInformers(options *options.YurtHubOptions,
 		}
 		informerFactory.InformerFor(&corev1.Pod{}, newPodInformer)
 	}
-}
-
-// isServiceTopologyFilterEnabled is used to verify the service topology filter should be enabled or not.
-func isServiceTopologyFilterEnabled(options *options.YurtHubOptions) bool {
-	if !options.EnableResourceFilter {
-		return false
-	}
-
-	for _, filterName := range options.DisabledResourceFilters {
-		if filterName == filter.ServiceTopologyFilterName {
-			return false
-		}
-	}
-
-	if options.WorkingMode == string(util.WorkingModeCloud) {
-		for i := range filter.DisabledInCloudMode {
-			if filter.DisabledInCloudMode[i] == filter.ServiceTopologyFilterName {
-				return false
-			}
-		}
-	}
-
-	return true
 }
 
 func prepareServerServing(options *options.YurtHubOptions, certMgr certificate.YurtCertificateManager, cfg *YurtHubConfiguration) error {

--- a/cmd/yurthub/app/start.go
+++ b/cmd/yurthub/app/start.go
@@ -176,7 +176,7 @@ func Run(ctx context.Context, cfg *config.YurtHubConfiguration) error {
 
 	// Start the informer factory if all informers have been registered
 	cfg.SharedFactory.Start(ctx.Done())
-	cfg.YurtSharedFactory.Start(ctx.Done())
+	cfg.NodePoolInformerFactory.Start(ctx.Done())
 
 	klog.Infof("%d. new reverse proxy handler for remote servers", trace)
 	yurtProxyHandler, err := proxy.NewYurtReverseProxyHandler(

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/opencontainers/selinux v1.11.0
-	github.com/openyurtio/yurt-app-manager-api v0.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/projectcalico/api v0.0.0-20230222223746-44aa60c2201f

--- a/go.sum
+++ b/go.sum
@@ -232,7 +232,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.4.0 h1:uc1uML3hRYL9/ZZPdgHS/n8Nzo+eaYL/Efxkkamf7OM=
@@ -381,7 +380,6 @@ github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -524,7 +522,6 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
@@ -532,7 +529,6 @@ github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
@@ -557,8 +553,6 @@ github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:Ff
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/openyurtio/apiserver-network-proxy v0.1.0 h1:uJI6LeAHmkQL0zV1+NIbgRsx2ayzsPfMA2bd1gROypc=
 github.com/openyurtio/apiserver-network-proxy v0.1.0/go.mod h1:X5Au3jBNIgYL2uK0IHeNGnZqlUlVSCFQhi/npPgkKRg=
-github.com/openyurtio/yurt-app-manager-api v0.6.0 h1:GoayIUkdITBufJirU94dvyknFFG4On1T7XcDvsqCWaQ=
-github.com/openyurtio/yurt-app-manager-api v0.6.0/go.mod h1:Ql/n89HmezW7s0d2Cyq9P3hl2MEvvjjv3xxPkLVzz10=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
@@ -1188,7 +1182,6 @@ k8s.io/csi-translation-lib v0.22.3/go.mod h1:YkdI+scWhZJQeA26iNg9XrKO3LhLz6dAcRK
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-aggregator v0.22.3/go.mod h1:TIpLq1HvR/S4y75i3y+4q9ik3ZvgyaDz72CBfDS0A6E=
@@ -1208,7 +1201,6 @@ k8s.io/pod-security-admission v0.22.3/go.mod h1:xtkf/UhVWICokQLSDvD+8plfGkTQW4VT
 k8s.io/sample-apiserver v0.22.3/go.mod h1:HuEOdD/pT5R7gKNr2REb62uabZaJuFZyY3wUd86nFCA=
 k8s.io/system-validators v1.5.0/go.mod h1:bPldcLgkIUK22ALflnsXk8pvkTEndYdNuaHH6gRrl0Q=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20210527160623-6fdb442a123b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b h1:wxEMGetGMur3J1xuGLQY7GEQYg9bZxKn3tKo5k/eYcs=
@@ -1224,7 +1216,6 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22 h1:fmRfl9WJ4ApJn7LxNuED4m0t18qivVQOxP6aAYG9J6c=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
-sigs.k8s.io/controller-runtime v0.9.0/go.mod h1:TgkfvrhhEw3PlI0BRL/5xM+89y3/yc0ZDfdbTl84si8=
 sigs.k8s.io/controller-runtime v0.10.3 h1:s5Ttmw/B4AuIbwrXD3sfBkXwnPMMWrqpVj4WRt1dano=
 sigs.k8s.io/controller-runtime v0.10.3/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/kustomize/api v0.8.11 h1:LzQzlq6Z023b+mBtc6v72N2mSHYmN8x7ssgbf/hv0H8=

--- a/pkg/apis/apps/well_known_labels_annotations.go
+++ b/pkg/apis/apps/well_known_labels_annotations.go
@@ -40,6 +40,7 @@ const (
 	// LabelCurrentNodePool indicates which nodepool the node is currently
 	// belonging to
 	LabelCurrentNodePool = "apps.openyurt.io/nodepool"
+	NodePoolLabel        = "apps.openyurt.io/nodepool"
 
 	AnnotationPrevAttrs = "nodepool.openyurt.io/previous-attributes"
 

--- a/pkg/util/kubeconfig/kubeconfig.go
+++ b/pkg/util/kubeconfig/kubeconfig.go
@@ -24,8 +24,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	yurtclientset "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/client/clientset/versioned"
 )
 
 // CreateBasic creates a basic, general KubeConfig object that then can be extended
@@ -126,19 +124,4 @@ func GetAuthInfoFromKubeConfig(config *clientcmdapi.Config) *clientcmdapi.AuthIn
 		return config.AuthInfos[config.Contexts[config.CurrentContext].AuthInfo]
 	}
 	return nil
-}
-
-// ToYurtClientSet converts a KubeConfig object to a yurtClient
-func ToYurtClientSet(config *clientcmdapi.Config) (yurtclientset.Interface, error) {
-	overrides := clientcmd.ConfigOverrides{Timeout: "10s"}
-	clientConfig, err := clientcmd.NewDefaultClientConfig(*config, &overrides).ClientConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create yurt client configuration from kubeconfig")
-	}
-
-	client, err := yurtclientset.NewForConfig(clientConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create yurt client")
-	}
-	return client, nil
 }

--- a/pkg/util/kubeconfig/kubeconfig_test.go
+++ b/pkg/util/kubeconfig/kubeconfig_test.go
@@ -183,8 +183,6 @@ func TestWriteKubeconfigToDisk(t *testing.T) {
 					newFile,
 				)
 			}
-			client, err := ToYurtClientSet(c)
-			t.Log(client, err)
 		})
 	}
 }

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -30,6 +30,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
 
+	"github.com/openyurtio/openyurt/pkg/apis/apps"
 	"github.com/openyurtio/openyurt/pkg/controller/yurtstaticset/util"
 	kubeconfigutil "github.com/openyurtio/openyurt/pkg/util/kubeconfig"
 	"github.com/openyurtio/openyurt/pkg/util/kubernetes/kubeadm/app/util/apiclient"
@@ -39,7 +40,6 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/edgenode"
 	yurtadmutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/kubernetes"
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
-	nodepoolv1alpha1 "github.com/openyurtio/yurt-app-manager-api/pkg/yurtappmanager/apis/apps/v1alpha1"
 )
 
 type joinOptions struct {
@@ -345,19 +345,13 @@ func newJoinData(args []string, opt *joinOptions) (*joinData, error) {
 
 	// check whether specified nodePool exists
 	if len(opt.nodePoolName) != 0 {
-		yurtClient, err := kubeconfigutil.ToYurtClientSet(cfg)
-		if err != nil {
-			klog.Errorf("failed to create yurt client, %v", err)
-			return nil, err
-		}
-
-		np, err := apiclient.GetNodePoolInfoWithRetry(yurtClient, opt.nodePoolName)
+		np, err := apiclient.GetNodePoolInfoWithRetry(cfg, opt.nodePoolName)
 		if err != nil || np == nil {
 			// the specified nodePool not exist, return
 			return nil, errors.Errorf("when --nodepool-name is specified, the specified nodePool should be exist.")
 		}
 		// add nodePool label for node by kubelet
-		data.nodeLabels[nodepoolv1alpha1.LabelDesiredNodePool] = opt.nodePoolName
+		data.nodeLabels[apps.NodePoolLabel] = opt.nodePoolName
 	}
 
 	// check static pods has value and yurtstaticset is already exist

--- a/pkg/yurthub/filter/nodeportisolation/filter.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter.go
@@ -130,7 +130,7 @@ func (nif *nodePortIsolationFilter) resolveNodePoolName() string {
 		klog.Warningf("skip isolateNodePortService filter, failed to get node(%s), %v", nif.nodeName, err)
 		return nif.nodePoolName
 	}
-	nif.nodePoolName = node.Labels[apps.LabelDesiredNodePool]
+	nif.nodePoolName = node.Labels[apps.NodePoolLabel]
 	return nif.nodePoolName
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind feature

#### What this PR does / why we need it:
1. remove dependencies on yurt-app-manager-api repo and yurt client repo
2. use dynamic client and dynamicinformer to get NodePool resource
3. update imports of v1alpha1.NodePool to v1beta1.NodePool

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1010

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
