### PR TITLE
fix: yurt-iot-dock cannot be dynamically deployed in platformadmin

### DIFF
--- a/pkg/yurtmanager/controller/platformadmin/platformadmin_controller.go
+++ b/pkg/yurtmanager/controller/platformadmin/platformadmin_controller.go
@@ -777,12 +777,6 @@ func (r *ReconcilePlatformAdmin) initFramework(ctx context.Context, platformAdmi
 		r.calculateDesiredComponents(platformAdmin, platformAdminFramework, nil)
 	}
 
-	yurtIotDock, err := newYurtIoTDockComponent(platformAdmin, platformAdminFramework)
-	if err != nil {
-		return err
-	}
-	platformAdminFramework.Components = append(platformAdminFramework.Components, yurtIotDock)
-
 	// For better serialization, the serialization method of the Kubernetes runtime library is used
 	data, err := runtime.Encode(r.yamlSerializer, platformAdminFramework)
 	if err != nil {
@@ -860,6 +854,16 @@ func (r *ReconcilePlatformAdmin) calculateDesiredComponents(platformAdmin *iotv1
 				desiredComponents = append(desiredComponents, component)
 			}
 		}
+	}
+
+	// The yurt-iot-dock is maintained by openyurt and is not obtained through an auto-collector.
+	// Therefore, it needs to be handled separately
+	if addedComponentSet.Has(util.IotDockName) {
+		yurtIotDock, err := newYurtIoTDockComponent(platformAdmin, platformAdminFramework)
+		if err != nil {
+			klog.Errorf(Format("newYurtIoTDockComponent error %v", err))
+		}
+		desiredComponents = append(desiredComponents, yurtIotDock)
 	}
 
 	// TODO: In order to be compatible with v1alpha1, we need to add the component from annotation translation here


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug
/sig iot

#### What this PR does / why we need it:
Because the `yurt-iot-dock` is an internal component of `openyurt` and is not in the standard configuration collected by the `auto-collector`, a separate decision for the `yurt-iot-dock` is added when calculating the required components.

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
