### PR TITLE
Fix work dir nested `yurthub/yurthub`

### DIFF
--- a/pkg/yurthub/certificate/manager/manager.go
+++ b/pkg/yurthub/certificate/manager/manager.go
@@ -46,7 +46,7 @@ var (
 	apiServerClientCertNotReadyError = errors.New("APIServer client certificate")
 	caCertIsNotReadyError            = errors.New("ca.crt file")
 
-	DefaultRootDir = "/var/lib"
+	DefaultWorkDir = filepath.Join("/var/lib", projectinfo.GetHubName())
 )
 
 type yurtHubCertManager struct {
@@ -58,10 +58,12 @@ type yurtHubCertManager struct {
 func NewYurtHubCertManager(options *options.YurtHubOptions, remoteServers []*url.URL) (hubCert.YurtCertificateManager, error) {
 	var clientCertManager hubCert.YurtClientCertificateManager
 	var err error
+	var workDir string
 
-	workDir := filepath.Join(options.RootDir, projectinfo.GetHubName())
 	if len(options.RootDir) == 0 {
-		workDir = filepath.Join(DefaultRootDir, projectinfo.GetHubName())
+		workDir = DefaultWorkDir
+	} else {
+		workDir = options.RootDir
 	}
 
 	if options.BootstrapMode == "kubeletcertificate" {

--- a/pkg/yurthub/certificate/manager/manager_test.go
+++ b/pkg/yurthub/certificate/manager/manager_test.go
@@ -45,7 +45,7 @@ func TestGetHubServerCertFile(t *testing.T) {
 		},
 		"define root dir": {
 			rootDir: "/tmp",
-			path:    filepath.Join("/tmp", projectinfo.GetHubName(), "pki", fmt.Sprintf("%s-server-current.pem", projectinfo.GetHubName())),
+			path:    filepath.Join("/tmp", "pki", fmt.Sprintf("%s-server-current.pem", projectinfo.GetHubName())),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:
We expect Yurthub's workdir to be `/var/lib/yurthub`. Currently, it is set to `/var/lib/yurthub/yurthub` because `options.RootDir=/var/lib/yurthub` by default, which is misleading for end users.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
