### PR TITLE
fix  pool scope crd resource etcd key path

### DIFF
--- a/pkg/yurthub/storage/etcd/key.go
+++ b/pkg/yurthub/storage/etcd/key.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	hubmeta "github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
 )
 
@@ -71,6 +72,12 @@ func (s *etcdStorage) KeyFunc(info storage.KeyBuildInfo) (storage.Key, error) {
 	}
 
 	path := filepath.Join(s.prefix, resource, info.Namespace, info.Name)
+
+	gvr := schema.GroupVersionResource{Group: info.Group, Version: info.Version, Resource: info.Resources}
+	if isSchema := hubmeta.IsSchemeResource(gvr); !isSchema {
+		group := info.Group
+		path = filepath.Join(s.prefix, group, resource, info.Namespace, info.Name)
+	}
 
 	return storageKey{
 		comp: info.Component,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
 /kind bug


#### What this PR does / why we need it:
when pool scope resources set to some crd resources by editing yurt-hub-cfg configmap,  the default etcd storage key is wrong, where resource group is not set in the key path

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1728

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
