### PR TITLE
fix yurtappoverrider panic for handling normal deployments that has no ownerreferences

### DIFF
--- a/pkg/yurtmanager/controller/yurtappoverrider/yurtappoverrider_controller.go
+++ b/pkg/yurtmanager/controller/yurtappoverrider/yurtappoverrider_controller.go
@@ -173,13 +173,15 @@ func (r *ReconcileYurtAppOverrider) Reconcile(_ context.Context, request reconci
 	}
 
 	for _, deployment := range deployments.Items {
-		if deployment.OwnerReferences[0].Kind == instance.Subject.Kind && deployment.OwnerReferences[0].Name == instance.Subject.Name {
-			if deployment.Annotations == nil {
-				deployment.Annotations = make(map[string]string)
-			}
-			deployment.Annotations["LastOverrideTime"] = time.Now().String()
-			if err := r.Client.Update(context.TODO(), &deployment); err != nil {
-				return reconcile.Result{}, err
+		if len(deployment.OwnerReferences) != 0 {
+			if deployment.OwnerReferences[0].Kind == instance.Subject.Kind && deployment.OwnerReferences[0].Name == instance.Subject.Name {
+				if deployment.Annotations == nil {
+					deployment.Annotations = make(map[string]string)
+				}
+				deployment.Annotations["LastOverrideTime"] = time.Now().String()
+				if err := r.Client.Update(context.TODO(), &deployment); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:
panic will happen in yurtappoverrider when ordinary deployments without ownerreferences are handled.
so ownerreferences should be checked before yurtapporverrider deals with it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
