### PR TITLE
add rerun failed workflows script

### DIFF
--- a/.github/workflows/rerun-failed-workflows.yaml
+++ b/.github/workflows/rerun-failed-workflows.yaml
@@ -1,0 +1,67 @@
+name: Rerun Failed Workflows
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_failed_workflows:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check for Command and Access Level
+        id: check
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issue = context.issue;
+            const username = context.payload.comment.user.login;
+            const regex = /\/rerun/g;
+            const comment = await github.rest.issues.getComment({
+              owner: issue.owner,
+              repo: issue.repo,
+              comment_id: context.payload.comment.id,
+            });
+
+            if (regex.test(comment.data.body)) {
+              try {
+                await github.rest.repos.checkUserAccessLevel({
+                  owner: issue.owner,
+                  repo: issue.repo,
+                  username: username,
+                  permission: 'read'
+                });
+                return true;
+              } catch (error) {
+                console.log(`User ${username} does not have access to rerun failed workflows`);
+                return false;
+              }
+            } else {
+              return false;
+            }
+          result-encoding: string
+      - name: Fetch and rerun failed workflows
+        if: steps.check.outputs.result == 'true'
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issue = context.issue;
+            const pull = await github.rest.pulls.get({
+              owner: issue.owner,
+              repo: issue.repo,
+              pull_number: issue.number,
+            });
+            const workflows = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: issue.owner,
+              repo: issue.repo,
+              branch: pull.data.head.ref,
+              status: 'failure',
+            });
+            for (const run of workflows.data.workflow_runs) {
+              await github.rest.actions.reRunWorkflow({
+                owner: issue.owner,
+                repo: issue.repo,
+                run_id: run.id,
+              });
+            }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
reviewers or higher member can comment `/rerun` to trigger github actions that will rerun all failed workflows of the pull request.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
