### PR TITLE
fix the cache leak in yurtappoverrider controller

### DIFF
--- a/pkg/yurtmanager/controller/yurtappoverrider/yurtappoverrider_controller.go
+++ b/pkg/yurtmanager/controller/yurtappoverrider/yurtappoverrider_controller.go
@@ -127,6 +127,7 @@ func (r *ReconcileYurtAppOverrider) Reconcile(_ context.Context, request reconci
 	err := r.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			delete(r.CacheOverriderMap, request.Namespace+"/"+request.Name)
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -163,9 +164,8 @@ func (r *ReconcileYurtAppOverrider) Reconcile(_ context.Context, request reconci
 		if reflect.DeepEqual(cacheOverrider.Entries, instance.Entries) {
 			return reconcile.Result{}, nil
 		}
-	} else {
-		r.CacheOverriderMap[instance.Namespace+"/"+instance.Name] = instance.DeepCopy()
 	}
+	r.CacheOverriderMap[instance.Namespace+"/"+instance.Name] = instance.DeepCopy()
 
 	deployments := v1.DeploymentList{}
 	if err := r.List(context.TODO(), &deployments); err != nil {


### PR DESCRIPTION
Add Cache Cleanup and Update on Deletion and Changes

When a `YurtAppOverrider` instance is deleted, the cache data in `CacheOverriderMap` should also be removed. This ensures that the cache stays synchronized with the actual instances.

Additionally, when entries of `YurtAppOverrider` are changed, the controller now updates the new instance into `CacheOverriderMap`. This guarantees that the cache reflects the latest changes in the `YurtAppOverrider` instances.
#1793 