### PR TITLE
print out all registered controllers

### DIFF
--- a/pkg/yurtmanager/controller/controller.go
+++ b/pkg/yurtmanager/controller/controller.go
@@ -115,6 +115,8 @@ func SetupWithManager(ctx context.Context, c *config.CompletedConfig, m manager.
 				continue
 			}
 			return err
+		} else {
+			klog.Infof("controller %s is added", controllerName)
 		}
 	}
 


### PR DESCRIPTION
it is easy to verify which controllers are registered if register log is printed out, so  improve the log print of controller register in the entry point instead of in each controller register function.
#1813 