### PR TITLE
Improved the rbac settings of yurt-manager component

### DIFF
--- a/pkg/yurtmanager/controller/platformadmin/platformadmin_controller.go
+++ b/pkg/yurtmanager/controller/platformadmin/platformadmin_controller.go
@@ -194,8 +194,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 // +kubebuilder:rbac:groups=iot.openyurt.io,resources=platformadmins/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps.openyurt.io,resources=yurtappsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.openyurt.io,resources=yurtappsets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=core,resources=configmaps;services,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=configmaps/status;services/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 
 // Reconcile reads that state of the cluster for a PlatformAdmin object and makes changes based on the state read
 // and what is in the PlatformAdmin.Spec


### PR DESCRIPTION
The RBAC settings have been refactored to split the resource configurations into individual lines for better readability and clarity. This change separates the RBAC rules for different resources, ensuring each resource and its corresponding verbs are clearly defined.
#1812 

