### PR TITLE
Fix: webhook overwrite deployment owned by yad/yas

### DIFF
--- a/pkg/yurtmanager/controller/yurtappdaemon/workloadcontroller/deployment_controller.go
+++ b/pkg/yurtmanager/controller/yurtappdaemon/workloadcontroller/deployment_controller.go
@@ -58,7 +58,7 @@ func (d *DeploymentControllor) DeleteWorkload(yda *v1alpha1.YurtAppDaemon, load 
 }
 
 // ApplyTemplate updates the object to the latest revision, depending on the YurtAppDaemon.
-func (d *DeploymentControllor) applyTemplate(scheme *runtime.Scheme, yad *v1alpha1.YurtAppDaemon, nodepool v1alpha1.NodePool, revision string, set *appsv1.Deployment) error {
+func (d *DeploymentControllor) ApplyTemplate(scheme *runtime.Scheme, yad *v1alpha1.YurtAppDaemon, nodepool v1alpha1.NodePool, revision string, set *appsv1.Deployment) error {
 
 	if set.Labels == nil {
 		set.Labels = map[string]string{}
@@ -129,7 +129,7 @@ func (d *DeploymentControllor) UpdateWorkload(load *Workload, yad *v1alpha1.Yurt
 			return getError
 		}
 
-		if err := d.applyTemplate(d.Scheme, yad, nodepool, revision, deploy); err != nil {
+		if err := d.ApplyTemplate(d.Scheme, yad, nodepool, revision, deploy); err != nil {
 			return err
 		}
 		updateError = d.Client.Update(context.TODO(), deploy)
@@ -145,7 +145,7 @@ func (d *DeploymentControllor) CreateWorkload(yad *v1alpha1.YurtAppDaemon, nodep
 	klog.Infof("YurtAppDaemon[%s/%s] prepare create new deployment by nodepool %s ", yad.GetNamespace(), yad.GetName(), nodepool.GetName())
 
 	deploy := appsv1.Deployment{}
-	if err := d.applyTemplate(d.Scheme, yad, nodepool, revision, &deploy); err != nil {
+	if err := d.ApplyTemplate(d.Scheme, yad, nodepool, revision, &deploy); err != nil {
 		klog.Errorf("YurtAppDaemon[%s/%s] could not apply template, when create deployment: %v", yad.GetNamespace(),
 			yad.GetName(), err)
 		return err

--- a/pkg/yurtmanager/controller/yurtappdaemon/workloadcontroller/deployment_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtappdaemon/workloadcontroller/deployment_controller_test.go
@@ -162,7 +162,7 @@ func TestApplyTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			get := dc.applyTemplate(tt.scheme, tt.yad, tt.nodepool, tt.revision, tt.set)
+			get := dc.ApplyTemplate(tt.scheme, tt.yad, tt.nodepool, tt.revision, tt.set)
 			t.Logf("expect: %v, get: %v", tt.expect, get)
 			if !reflect.DeepEqual(get, tt.expect) {
 				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)

--- a/pkg/yurtmanager/webhook/deploymentrender/v1alpha1/deploymentrender_webhook_test.go
+++ b/pkg/yurtmanager/webhook/deploymentrender/v1alpha1/deploymentrender_webhook_test.go
@@ -81,6 +81,13 @@ var defaultAppSet = &v1alpha1.YurtAppSet{
 	},
 }
 
+var defaultNodePool = &v1alpha1.NodePool{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "nodepool-test",
+	},
+	Spec: v1alpha1.NodePoolSpec{},
+}
+
 var defaultAppDaemon = &v1alpha1.YurtAppDaemon{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "yurtappdaemon",
@@ -312,7 +319,7 @@ func TestDeploymentRenderHandler_Default(t *testing.T) {
 	for _, tcase := range tcases {
 		t.Run("", func(t *testing.T) {
 			webhook := &DeploymentRenderHandler{
-				Client: fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(defaultAppSet, daemonDeployment, defaultDeployment, defaultAppDaemon, tcase.overrider).Build(),
+				Client: fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(defaultAppSet, daemonDeployment, defaultNodePool, defaultDeployment, defaultAppDaemon, tcase.overrider).Build(),
 				Scheme: scheme,
 			}
 			if err := webhook.Default(context.TODO(), defaultDeployment); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Currently,  deployment overrider webhook will override the deployment spec owned by a yad(yurtappdaemon) with the yad template. However, the `nodeselector` field in the deployment spec will be set to null because it's not set in the yad template but set by the yad controller. This leads to [issue](https://github.com/openyurtio/openyurt/issues/1841).

We need to use the `applyTemplate` in the yad controller to get the complete deployment spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/openyurtio/openyurt/issues/1841

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
@rambohe-ch  @vie-serendipity 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
