### PR TITLE
feat: support yurt-manager work in specified namespace

### DIFF
--- a/pkg/yurtmanager/controller/controller.go
+++ b/pkg/yurtmanager/controller/controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/gatewayinternalservice"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/gatewaypickup"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/gatewaypublicservice"
+	ravenutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/util"
 	servicetopologyendpoints "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/servicetopology/endpoints"
 	servicetopologyendpointslice "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/servicetopology/endpointslice"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/yurtappdaemon"
@@ -139,6 +140,9 @@ func SetupWithManager(ctx context.Context, c *config.CompletedConfig, m manager.
 			return err
 		}
 	}
+
+	// set up raven working namespace
+	ravenutil.SetWorkingNamespace(c.ComponentConfig.Generic.WorkingNamespace)
 
 	return nil
 }

--- a/pkg/yurtmanager/controller/raven/util/constants.go
+++ b/pkg/yurtmanager/controller/raven/util/constants.go
@@ -18,7 +18,6 @@ package util
 
 const (
 	ConcurrentReconciles           = 1
-	WorkingNamespace               = "kube-system"
 	RavenGlobalConfig              = "raven-cfg"
 	RavenAgentConfig               = "raven-agent-config"
 	LabelCurrentGatewayEndpoints   = "raven.openyurt.io/endpoints-name"

--- a/pkg/yurtmanager/controller/raven/util/util.go
+++ b/pkg/yurtmanager/controller/raven/util/util.go
@@ -35,6 +35,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+var WorkingNamespace = "kube-system"
+
+func SetWorkingNamespace(ns string) {
+	WorkingNamespace = ns
+}
+
 // GetNodeInternalIP returns internal ip of the given `node`.
 func GetNodeInternalIP(node corev1.Node) string {
 	var ip string


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:

1. support gateway controllers work normally in specified namespace;
2. CRDs can be templated rather than hard code, so the namespace of conversion webhooks service can be configured in `gateways.raven.openyurt.io` and `nodepools.apps.openyurt.io`.

#### Which issue(s) this PR fixes:
Fixes #1845

#### Special notes for your reviewer:
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```