### PR TITLE
Feature: add name-length of dummy interface too long error

### DIFF
--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -167,6 +167,10 @@ func (options *YurtHubOptions) Validate() error {
 		return fmt.Errorf("dummy ip %s is not invalid, %w", options.HubAgentDummyIfIP, err)
 	}
 
+	if len(options.HubAgentDummyIfName) > 15 {
+		return fmt.Errorf("dummy name %s length should not be more than 15", options.HubAgentDummyIfName)
+	}
+
 	if len(options.CACertHashes) == 0 && !options.UnsafeSkipCAVerification {
 		return fmt.Errorf("set --discovery-token-unsafe-skip-ca-verification flag as true or pass CACertHashes to continue")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> /kind feature
<!--
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue

> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage
-->

#### What this PR does / why we need it:
Adds a new validation for dummy interface length not to exceed 15 chars. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1867 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
--> 
/@rambohe-ch

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->

