### PR TITLE
fix(yurt-manager): add clusterrole for nodes/status subresources

### DIFF
--- a/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
+++ b/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
@@ -320,6 +320,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/pkg/yurtmanager/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/yurtmanager/controller/nodelifecycle/node_lifecycle_controller.go
@@ -285,6 +285,8 @@ type ReconcileNodeLifeCycle struct {
 	podUpdateQueue  workqueue.RateLimitingInterface
 }
 
+// +kubebuilder:rbac:groups=core,resources=nodes/status,verbs=get;list;watch;update;patch
+
 // Add creates a new CsrApprover Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, cfg *appconfig.CompletedConfig, mgr manager.Manager) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:
If role of nodes/status resource is missing, the operation of yurt-manager(nodelifecycle-controllerr) to update the node status is prohibited.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1882 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
