### PR TITLE
fix: remove custom signal handler for concurrent reclaims

### DIFF
--- a/cmd/yurt-iot-dock/app/core.go
+++ b/cmd/yurt-iot-dock/app/core.go
@@ -186,7 +186,7 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 	}
 
 	setupLog.Info("[run controllers] Starting manager, acting on " + fmt.Sprintf("[NodePool: %s, Namespace: %s]", opts.Nodepool, opts.Namespace))
-	if err := mgr.Start(SetupSignalHandler(mgr.GetClient(), opts)); err != nil {
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "could not running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/sig iot 
/kind bug

#### What this PR does / why we need it:
Remove exit reclaim logic to avoid iot-dock actively delete resources on edgex due to extreme concurrency.

#### Which issue(s) this PR fixes:
Fixes #1887

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @LavenderQAQ @Rui-Gan

#### Does this PR introduce a user-facing change?
Users need to take the initiative to remove cr resources: device/deviceprofile/deviceservice.
```release-note
kubectl patch device hangzhou-random-boolean-device -p '{"metadata":{"finalizers":[]}}' --type=merge && kubectl delete device hangzhou-random-boolean-device
```
