### PR TITLE
fix: yurtadm join can't work when kubernetes version large than v1.27.0

### DIFF
--- a/pkg/yurtadm/util/kubernetes/kubernetes.go
+++ b/pkg/yurtadm/util/kubernetes/kubernetes.go
@@ -405,11 +405,11 @@ func SetKubeadmJoinConfig(data joindata.YurtJoinData) error {
 	if nodeReg.CRISocket == constants.DefaultDockerCRISocket {
 		ctx["networkPlugin"] = "cni"
 	} else {
-		v127, err := version.NewVersion("v1.27.0")
+		v124alpha, err := version.NewVersion("1.24.0-alpha.0")
 		if err != nil {
 			return err
 		}
-		if v1.LessThan(v127) {
+		if v1.LessThan(v124alpha) {
 			ctx["containerRuntime"] = "remote"
 		}
 		ctx["containerRuntimeEndpoint"] = nodeReg.CRISocket

--- a/pkg/yurtadm/util/kubernetes/kubernetes.go
+++ b/pkg/yurtadm/util/kubernetes/kubernetes.go
@@ -396,17 +396,25 @@ func SetKubeadmJoinConfig(data joindata.YurtJoinData) error {
 		"criSocket":              nodeReg.CRISocket,
 		"name":                   nodeReg.Name,
 	}
-	if nodeReg.CRISocket == constants.DefaultDockerCRISocket {
-		ctx["networkPlugin"] = "cni"
-	} else {
-		ctx["containerRuntime"] = "remote"
-		ctx["containerRuntimeEndpoint"] = nodeReg.CRISocket
-	}
 
 	v1, err := version.NewVersion(data.KubernetesVersion())
 	if err != nil {
 		return err
 	}
+
+	if nodeReg.CRISocket == constants.DefaultDockerCRISocket {
+		ctx["networkPlugin"] = "cni"
+	} else {
+		v127, err := version.NewVersion("v1.27.0")
+		if err != nil {
+			return err
+		}
+		if v1.LessThan(v127) {
+			ctx["containerRuntime"] = "remote"
+		}
+		ctx["containerRuntimeEndpoint"] = nodeReg.CRISocket
+	}
+
 	v2, err := version.NewVersion("v1.22.0")
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

 /kind bug


#### What this PR does / why we need it:

fix: yurtadm join can't work when kubernetes version is large than v1.27.0


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1675

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
