### PR TITLE
fix: yad status should be updated according to the new created ControllerRevision (#1879)

### DIFF
--- a/pkg/yurtmanager/controller/yurtappdaemon/yurtappdaemon_controller.go
+++ b/pkg/yurtmanager/controller/yurtappdaemon/yurtappdaemon_controller.go
@@ -200,7 +200,7 @@ func (r *ReconcileYurtAppDaemon) Reconcile(_ context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	return r.updateStatus(instance, newStatus, oldStatus, currentRevision, collisionCount, templateType, currentNPToWorkload)
+	return r.updateStatus(instance, newStatus, oldStatus, expectedRevision, collisionCount, templateType, currentNPToWorkload)
 }
 
 func (r *ReconcileYurtAppDaemon) updateStatus(instance *unitv1alpha1.YurtAppDaemon, newStatus, oldStatus *unitv1alpha1.YurtAppDaemonStatus,

--- a/pkg/yurtmanager/controller/yurtappset/yurtappset_controller.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurtappset_controller.go
@@ -206,7 +206,7 @@ func (r *ReconcileYurtAppSet) Reconcile(_ context.Context, request reconcile.Req
 		r.recorder.Event(instance.DeepCopy(), corev1.EventTypeWarning, fmt.Sprintf("Failed%s", eventTypePoolsUpdate), err.Error())
 	}
 
-	return r.updateStatus(instance, newStatus, oldStatus, nameToPool, currentRevision, collisionCount, control)
+	return r.updateStatus(instance, newStatus, oldStatus, nameToPool, expectedRevision, collisionCount, control)
 }
 
 func (r *ReconcileYurtAppSet) getNameToPool(instance *unitv1alpha1.YurtAppSet, control ControlInterface) (map[string]*Pool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> /kind bug
> /kind good-first-issue

#### What this PR does / why we need it:
After editing yad's spec, there is a new created ControllerRevision. 

However, yad's status isn't updated because the function updateStatus use param `currentRevision`, instead of the updated value. We can see that in https://github.com/openyurtio/openyurt/blob/master/pkg/yurtmanager/controller/yurtappdaemon/yurtappdaemon_controller.go#L203


So, when invoking function updateStatus, we just need to replace `currentRevision` to `expectedRevision` to solve this problem.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1879 