### PR TITLE
feat: support message bus to sync metadata changes

### DIFF
--- a/cmd/yurt-iot-dock/app/core.go
+++ b/cmd/yurt-iot-dock/app/core.go
@@ -126,16 +126,16 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 		setupLog.Error(err, "unable to create controller", "controller", "DeviceProfile")
 		os.Exit(1)
 	}
-	dfs, err := controllers.NewDeviceProfileSyncer(mgr.GetClient(), opts, edgexdock)
-	if err != nil {
-		setupLog.Error(err, "unable to create syncer", "syncer", "DeviceProfile")
-		os.Exit(1)
-	}
-	err = mgr.Add(dfs.NewDeviceProfileSyncerRunnable())
-	if err != nil {
-		setupLog.Error(err, "unable to create syncer runnable", "syncer", "DeviceProfile")
-		os.Exit(1)
-	}
+	// dfs, err := controllers.NewDeviceProfileSyncer(mgr.GetClient(), opts, edgexdock)
+	// if err != nil {
+	// 	setupLog.Error(err, "unable to create syncer", "syncer", "DeviceProfile")
+	// 	os.Exit(1)
+	// }
+	// err = mgr.Add(dfs.NewDeviceProfileSyncerRunnable())
+	// if err != nil {
+	// 	setupLog.Error(err, "unable to create syncer runnable", "syncer", "DeviceProfile")
+	// 	os.Exit(1)
+	// }
 
 	// setup the Device Reconciler and Syncer
 	if err = (&controllers.DeviceReconciler{
@@ -156,6 +156,18 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 		os.Exit(1)
 	}
 
+	setupLog.Info("[NewPulsimeter] run the pulsimeter1205")
+	pm, err := controllers.NewPulsimeter(mgr.GetClient(), opts, edgexdock)
+	if err != nil {
+		setupLog.Error(err, "unable to create plusimeter", "controller", "Device")
+		os.Exit(1)
+	}
+	err = mgr.Add(pm.NewPulsimeterRunnable())
+	if err != nil {
+		setupLog.Error(err, "unable to create plusimeter runnable", "syncer", "Device")
+		os.Exit(1)
+	}
+
 	// setup the DeviceService Reconciler and Syncer
 	if err = (&controllers.DeviceServiceReconciler{
 		Client: mgr.GetClient(),
@@ -164,17 +176,17 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 		setupLog.Error(err, "unable to create controller", "controller", "DeviceService")
 		os.Exit(1)
 	}
-	dss, err := controllers.NewDeviceServiceSyncer(mgr.GetClient(), opts, edgexdock)
-	if err != nil {
-		setupLog.Error(err, "unable to create syncer", "syncer", "DeviceService")
-		os.Exit(1)
-	}
-	err = mgr.Add(dss.NewDeviceServiceSyncerRunnable())
-	if err != nil {
-		setupLog.Error(err, "unable to create syncer runnable", "syncer", "DeviceService")
-		os.Exit(1)
-	}
-	//+kubebuilder:scaffold:builder
+	// dss, err := controllers.NewDeviceServiceSyncer(mgr.GetClient(), opts, edgexdock)
+	// if err != nil {
+	// 	setupLog.Error(err, "unable to create syncer", "syncer", "DeviceService")
+	// 	os.Exit(1)
+	// }
+	// err = mgr.Add(dss.NewDeviceServiceSyncerRunnable())
+	// if err != nil {
+	// 	setupLog.Error(err, "unable to create syncer runnable", "syncer", "DeviceService")
+	// 	os.Exit(1)
+	// }
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/cmd/yurt-iot-dock/app/core.go
+++ b/cmd/yurt-iot-dock/app/core.go
@@ -126,16 +126,6 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 		setupLog.Error(err, "unable to create controller", "controller", "DeviceProfile")
 		os.Exit(1)
 	}
-	// dfs, err := controllers.NewDeviceProfileSyncer(mgr.GetClient(), opts, edgexdock)
-	// if err != nil {
-	// 	setupLog.Error(err, "unable to create syncer", "syncer", "DeviceProfile")
-	// 	os.Exit(1)
-	// }
-	// err = mgr.Add(dfs.NewDeviceProfileSyncerRunnable())
-	// if err != nil {
-	// 	setupLog.Error(err, "unable to create syncer runnable", "syncer", "DeviceProfile")
-	// 	os.Exit(1)
-	// }
 
 	// setup the Device Reconciler and Syncer
 	if err = (&controllers.DeviceReconciler{
@@ -143,28 +133,6 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr, opts, edgexdock); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Device")
-		os.Exit(1)
-	}
-	ds, err := controllers.NewDeviceSyncer(mgr.GetClient(), opts, edgexdock)
-	if err != nil {
-		setupLog.Error(err, "unable to create syncer", "controller", "Device")
-		os.Exit(1)
-	}
-	err = mgr.Add(ds.NewDeviceSyncerRunnable())
-	if err != nil {
-		setupLog.Error(err, "unable to create syncer runnable", "syncer", "Device")
-		os.Exit(1)
-	}
-
-	setupLog.Info("[NewPulsimeter] run the pulsimeter1205")
-	pm, err := controllers.NewPulsimeter(mgr.GetClient(), opts, edgexdock)
-	if err != nil {
-		setupLog.Error(err, "unable to create plusimeter", "controller", "Device")
-		os.Exit(1)
-	}
-	err = mgr.Add(pm.NewPulsimeterRunnable())
-	if err != nil {
-		setupLog.Error(err, "unable to create plusimeter runnable", "syncer", "Device")
 		os.Exit(1)
 	}
 
@@ -176,16 +144,19 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 		setupLog.Error(err, "unable to create controller", "controller", "DeviceService")
 		os.Exit(1)
 	}
-	// dss, err := controllers.NewDeviceServiceSyncer(mgr.GetClient(), opts, edgexdock)
-	// if err != nil {
-	// 	setupLog.Error(err, "unable to create syncer", "syncer", "DeviceService")
-	// 	os.Exit(1)
-	// }
-	// err = mgr.Add(dss.NewDeviceServiceSyncerRunnable())
-	// if err != nil {
-	// 	setupLog.Error(err, "unable to create syncer runnable", "syncer", "DeviceService")
-	// 	os.Exit(1)
-	// }
+
+	setupLog.Info("[NewPulsimeter] run the pulsimeter controller")
+	pm, err := controllers.NewPulsimeter(mgr.GetClient(), opts, edgexdock)
+	if err != nil {
+		setupLog.Error(err, "unable to create plusimeter", "messagebus")
+		os.Exit(1)
+	}
+	err = mgr.Add(pm.NewPulsimeterRunnable())
+	if err != nil {
+		setupLog.Error(err, "unable to create plusimeter runnable", "messagebus")
+		os.Exit(1)
+	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {

--- a/cmd/yurt-iot-dock/app/options/options.go
+++ b/cmd/yurt-iot-dock/app/options/options.go
@@ -34,9 +34,22 @@ type YurtIoTDockOptions struct {
 	CoreDataAddr         string
 	CoreMetadataAddr     string
 	CoreCommandAddr      string
-	RedisAddr            string
-	RedisPort            uint
+	MessageBusOptions    MessageBusOptions
 	EdgeSyncPeriod       uint
+}
+
+type MessageBusOptions struct {
+	// Host is the hostname or IP address of the messaging broker, if applicable.
+	Host string
+	// Port defines the port on which to access the message queue.
+	Port int
+	// Protocol indicates the protocol to use when accessing the message queue.
+	Protocol string
+	// Type indicates the message queue platform being used. eg. "redis" for Redis Pub/Sub
+	Type              string
+	HeartbeatInterval int
+	// Name is the name of the message bus instance.
+	Name string
 }
 
 func NewYurtIoTDockOptions() *YurtIoTDockOptions {
@@ -50,9 +63,13 @@ func NewYurtIoTDockOptions() *YurtIoTDockOptions {
 		CoreDataAddr:         "edgex-core-data:59880",
 		CoreMetadataAddr:     "edgex-core-metadata:59881",
 		CoreCommandAddr:      "edgex-core-command:59882",
-		RedisAddr:            "edgex-redis",
-		RedisPort:            6379,
-		EdgeSyncPeriod:       5,
+		MessageBusOptions: MessageBusOptions{
+			Host:     "edgex-redis",
+			Port:     6379,
+			Protocol: "redis",
+			Type:     "redis",
+		},
+		EdgeSyncPeriod: 120,
 	}
 }
 
@@ -73,9 +90,13 @@ func (o *YurtIoTDockOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.CoreDataAddr, "core-data-address", "edgex-core-data:59880", "The address of edge core-data service.")
 	fs.StringVar(&o.CoreMetadataAddr, "core-metadata-address", "edgex-core-metadata:59881", "The address of edge core-metadata service.")
 	fs.StringVar(&o.CoreCommandAddr, "core-command-address", "edgex-core-command:59882", "The address of edge core-command service.")
-	fs.StringVar(&o.RedisAddr, "edgex-redis-address", "edgex-redis", "The address of edge database service.")
-	fs.UintVar(&o.RedisPort, "edgex-redis-port", 6379, "The port of the redis service.")
-	fs.UintVar(&o.EdgeSyncPeriod, "edge-sync-period", 5, "The period of the device management platform synchronizing the device status to the cloud.(in seconds,not less than 5 seconds)")
+	fs.StringVar(&o.MessageBusOptions.Host, "message-bus-host", "edgex-redis", "The hostname or IP address of the messaging broker, if applicable.")
+	fs.IntVar(&o.MessageBusOptions.Port, "message-bus-port", 6379, "The port on which to access the message queue.")
+	fs.StringVar(&o.MessageBusOptions.Protocol, "message-bus-protocol", "redis", "The protocol to use when accessing the message queue.")
+	fs.StringVar(&o.MessageBusOptions.Type, "message-bus-type", "redis", "The message queue platform being used. eg. \"redis\" for Redis Pub/Sub")
+	fs.IntVar(&o.MessageBusOptions.HeartbeatInterval, "message-bus-heartbeat-interval", 30, "The heartbeat interval for iot-dock to checker the connection with message bus.(in seconds,not less than 30 seconds)")
+	fs.StringVar(&o.MessageBusOptions.Name, "message-bus-name", "edgex-redis", "The name of the message bus instance.")
+	fs.UintVar(&o.EdgeSyncPeriod, "edge-sync-period", 2*60, "The period of the device management platform synchronizing the device status to the cloud.(in seconds,not less than 2 minutes)")
 }
 
 func ValidateEdgePlatformAddress(options *YurtIoTDockOptions) error {

--- a/cmd/yurt-iot-dock/app/options/options.go
+++ b/cmd/yurt-iot-dock/app/options/options.go
@@ -34,6 +34,8 @@ type YurtIoTDockOptions struct {
 	CoreDataAddr         string
 	CoreMetadataAddr     string
 	CoreCommandAddr      string
+	RedisAddr            string
+	RedisPort            uint
 	EdgeSyncPeriod       uint
 }
 
@@ -44,10 +46,12 @@ func NewYurtIoTDockOptions() *YurtIoTDockOptions {
 		EnableLeaderElection: false,
 		Nodepool:             "",
 		Namespace:            "default",
-		Version:              "",
+		Version:              "minnesota",
 		CoreDataAddr:         "edgex-core-data:59880",
 		CoreMetadataAddr:     "edgex-core-metadata:59881",
 		CoreCommandAddr:      "edgex-core-command:59882",
+		RedisAddr:            "edgex-redis",
+		RedisPort:            6379,
 		EdgeSyncPeriod:       5,
 	}
 }
@@ -65,10 +69,12 @@ func (o *YurtIoTDockOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. "+"Enabling this will ensure there is only one active controller manager.")
 	fs.StringVar(&o.Nodepool, "nodepool", "", "The nodePool deviceController is deployed in.(just for debugging)")
 	fs.StringVar(&o.Namespace, "namespace", "default", "The cluster namespace for edge resources synchronization.")
-	fs.StringVar(&o.Version, "version", "", "The version of edge resources deploymenet.")
+	fs.StringVar(&o.Version, "version", "minnesota", "The version of edge resources deploymenet.")
 	fs.StringVar(&o.CoreDataAddr, "core-data-address", "edgex-core-data:59880", "The address of edge core-data service.")
 	fs.StringVar(&o.CoreMetadataAddr, "core-metadata-address", "edgex-core-metadata:59881", "The address of edge core-metadata service.")
 	fs.StringVar(&o.CoreCommandAddr, "core-command-address", "edgex-core-command:59882", "The address of edge core-command service.")
+	fs.StringVar(&o.RedisAddr, "edgex-redis-address", "edgex-redis", "The address of edge database service.")
+	fs.UintVar(&o.RedisPort, "edgex-redis-port", 6379, "The port of the redis service.")
 	fs.UintVar(&o.EdgeSyncPeriod, "edge-sync-period", 5, "The period of the device management platform synchronizing the device status to the cloud.(in seconds,not less than 5 seconds)")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -57,14 +57,22 @@ require (
 
 require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
+	github.com/eclipse/paho.mqtt.golang v1.4.2 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-redis/redis/v7 v7.3.0 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/nats-io/nats.go v1.25.0 // indirect
+	github.com/nats-io/nkeys v0.4.4 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
@@ -81,6 +89,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -90,6 +99,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/auth0/go-jwt-middleware v1.0.1/go.mod h1:YSeUX3z6+TF2H+7padiEqNJ73Zy9vXW72U//IgN0BIM=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -176,8 +178,12 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
+github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0 h1:xjwCI34DLM31cSl1q9XmYgXS3JqXufQJMgohnLLLDx0=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0/go.mod h1:zzzWGWij6wAqm1go9TLs++TFMIsBqBb1eRnIj4mRxGw=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0 h1:nU37Uo4/kloTMrdqDN9SJuDoXb3FpHaMdwVbHtn9PPk=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0/go.mod h1:x2CueD9gn/CmtCvDNFgrgBnR+B1iWJMSrC5+gesfDJ0=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -256,6 +262,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.13.0 h1:cFRQdfaSMCOSfGCCLB20MHvuoHb/s5G8L5pu2ppK5AQ=
 github.com/go-playground/validator/v10 v10.13.0/go.mod h1:dwu7+CG8/CtBiJFZDz4e+5Upb6OLw04gtBYw0mcG/z4=
+github.com/go-redis/redis/v7 v7.3.0 h1:3oHqd0W7f/VLKBxeYTEpqdMUsmMectngjM9OtoRoIgg=
+github.com/go-redis/redis/v7 v7.3.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -365,11 +373,14 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -428,6 +439,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.16.4 h1:91KN02FnsOYhuunwU4ssRe8lc2JosWmizWa91B5v1PU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -472,6 +484,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfr
 github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
+github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -511,6 +524,14 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nats-io/jwt/v2 v2.4.1 h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
+github.com/nats-io/nats-server/v2 v2.9.16 h1:SuNe6AyCcVy0g5326wtyU8TdqYmcPqzTjhkHojAjprc=
+github.com/nats-io/nats.go v1.25.0 h1:t5/wCPGciR7X3Mu8QOi4jiJaXaWM8qtkLu4lzGZvYHE=
+github.com/nats-io/nats.go v1.25.0/go.mod h1:D2WALIhz7V8M0pH8Scx8JZXlg6Oqz5VG+nQkK8nJdvg=
+github.com/nats-io/nkeys v0.4.4 h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
+github.com/nats-io/nkeys v0.4.4/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -519,6 +540,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
@@ -527,6 +549,7 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
@@ -836,6 +859,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -844,6 +868,7 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -898,6 +923,7 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/yurtiotdock/clients/edgex-foundry/v3/util.go
+++ b/pkg/yurtiotdock/clients/edgex-foundry/v3/util.go
@@ -107,6 +107,10 @@ func toEdgeXProfileProperty(pp iotv1alpha1.ResourceProperties) dtos.ResourceProp
 	}
 }
 
+func ToKubeDeviceService(ds dtos.DeviceService, namespace string) iotv1alpha1.DeviceService {
+	return toKubeDeviceService(ds, namespace)
+}
+
 func toKubeDeviceService(ds dtos.DeviceService, namespace string) iotv1alpha1.DeviceService {
 	return iotv1alpha1.DeviceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -198,6 +202,9 @@ func toEdgeXOperatingState(os iotv1alpha1.OperatingState) models.OperatingState 
 	}
 	return models.Unknown
 }
+func ToKubeDevice(ed dtos.Device, namespace string) iotv1alpha1.Device {
+	return toKubeDevice(ed, namespace)
+}
 
 // toKubeDevice serialize the EdgeX Device to the corresponding Kubernetes Device
 func toKubeDevice(ed dtos.Device, namespace string) iotv1alpha1.Device {
@@ -260,6 +267,9 @@ func toKubeProtocols(
 		ret[k] = iotv1alpha1.ProtocolProperties(propMap)
 	}
 	return ret
+}
+func ToKubeDeviceProfile(dp dtos.DeviceProfile, namespace string) iotv1alpha1.DeviceProfile {
+	return toKubeDeviceProfile(&dp, namespace)
 }
 
 // toKubeDeviceProfile create DeviceProfile in cloud according to devicProfile in edge

--- a/pkg/yurtiotdock/clients/edgex-foundry/v3/util.go
+++ b/pkg/yurtiotdock/clients/edgex-foundry/v3/util.go
@@ -107,10 +107,6 @@ func toEdgeXProfileProperty(pp iotv1alpha1.ResourceProperties) dtos.ResourceProp
 	}
 }
 
-func ToKubeDeviceService(ds dtos.DeviceService, namespace string) iotv1alpha1.DeviceService {
-	return toKubeDeviceService(ds, namespace)
-}
-
 func toKubeDeviceService(ds dtos.DeviceService, namespace string) iotv1alpha1.DeviceService {
 	return iotv1alpha1.DeviceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -202,9 +198,6 @@ func toEdgeXOperatingState(os iotv1alpha1.OperatingState) models.OperatingState 
 	}
 	return models.Unknown
 }
-func ToKubeDevice(ed dtos.Device, namespace string) iotv1alpha1.Device {
-	return toKubeDevice(ed, namespace)
-}
 
 // toKubeDevice serialize the EdgeX Device to the corresponding Kubernetes Device
 func toKubeDevice(ed dtos.Device, namespace string) iotv1alpha1.Device {
@@ -267,9 +260,6 @@ func toKubeProtocols(
 		ret[k] = iotv1alpha1.ProtocolProperties(propMap)
 	}
 	return ret
-}
-func ToKubeDeviceProfile(dp dtos.DeviceProfile, namespace string) iotv1alpha1.DeviceProfile {
-	return toKubeDeviceProfile(&dp, namespace)
 }
 
 // toKubeDeviceProfile create DeviceProfile in cloud according to devicProfile in edge

--- a/pkg/yurtiotdock/controllers/pulsimeter.go
+++ b/pkg/yurtiotdock/controllers/pulsimeter.go
@@ -23,22 +23,16 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
-	"github.com/edgexfoundry/go-mod-messaging/v3/messaging"
-	"github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
-	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
+	kubetypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/avast/retry-go"
+	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
-	devcli "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
-	iotcli "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
+	"github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
 	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
-	utilv3 "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry/v3"
 	util "github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kubetypes "k8s.io/apimachinery/pkg/types"
 )
 
 type Pulsimeter struct {
@@ -47,87 +41,70 @@ type Pulsimeter struct {
 	// which nodePool Plusimeter is deployed in
 	NodePool string
 	// which namespace Plusimeter is deployed in
-	Namespace string
+	Namespace         string
+	deviceSyncer      DeviceSyncer
+	deviceProfileSync DeviceProfileSyncer
+	deviceServiceSync DeviceServiceSyncer
 	// messageBus
-	MessgaeBus messaging.MessageClient
-	listHelper ListHelper
+	messageBus util.MessageBus
+	// messageBus health checker
+	msgHealthChecker util.MessageBusHealthChecker
 }
 
-type ListHelper struct {
-	deviceServiceList DeviceServiceList
-	deviceProfileList DeviceProfileList
-}
+func NewPulsimeter(client client.Client, opts *options.YurtIoTDockOptions,
+	edgexdock *edgexobj.EdgexDock) (Pulsimeter, error) {
+	deviceSyncer, err := NewDeviceSyncer(client, opts, edgexdock)
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to create device syncer")
+		return Pulsimeter{}, err
+	}
+	deviceServiceSync, err := NewDeviceServiceSyncer(client, opts, edgexdock)
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to create deviceservice syncer")
+		return Pulsimeter{}, err
+	}
 
-type DeviceServiceList struct {
-	// Kubernetes client
-	client.Client
-	deviceServiceCli iotcli.DeviceServiceInterface
-	NodePool         string
-	Namespace        string
-}
-
-type DeviceProfileList struct {
-	// edge platform client
-	edgeClient devcli.DeviceProfileInterface
-	// Kubernetes client
-	client.Client
-	NodePool  string
-	Namespace string
-}
-
-func NewPulsimeter(client client.Client, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) (Pulsimeter, error) {
+	deviceProfileSync, err := NewDeviceProfileSyncer(client, opts, edgexdock)
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to create deviceprofile syncer")
+		return Pulsimeter{}, err
+	}
 
 	// init messagebus
 	// TODO support other kind of messagebus
-	messagebus, err := messaging.NewMessageClient(types.MessageBusConfig{
-		Broker: types.HostInfo{
-			Host:     opts.RedisAddr,
-			Port:     int(opts.RedisPort),
-			Protocol: "redis",
-		},
-		Type: "redis"})
+	messageBus, err := util.NewMessageBus(opts)
 
 	if err != nil {
+		klog.V(3).ErrorS(err, "could not init messagebus where yurt-iot-dock run")
 		return Pulsimeter{}, err
-	}
-	deviceserviceclient, err := edgexdock.CreateDeviceServiceClient()
-	if err != nil {
-		return Pulsimeter{}, err
-	}
-	deviceServiceList := DeviceServiceList{
-		Client:           client,
-		NodePool:         opts.Nodepool,
-		Namespace:        opts.Namespace,
-		deviceServiceCli: deviceserviceclient,
-	}
-	edgeclient, err := edgexdock.CreateDeviceProfileClient()
-	if err != nil {
-		return Pulsimeter{}, err
-	}
-	deviceProfileList := DeviceProfileList{
-		edgeClient: edgeclient,
-		Client:     client,
-		NodePool:   opts.Nodepool,
-		Namespace:  opts.Namespace,
 	}
 
-	helper := ListHelper{
-		deviceServiceList: deviceServiceList,
-		deviceProfileList: deviceProfileList,
+	msgHealthChecker, err := util.NewMessageBusHealthChecker(opts, messageBus)
+
+	if err != nil {
+		klog.V(3).ErrorS(err, "could not init messagebus checker where yurt-iot-dock run")
+		return Pulsimeter{}, err
 	}
 
 	return Pulsimeter{
-		Client:     client,
-		NodePool:   opts.Nodepool,
-		Namespace:  opts.Namespace,
-		MessgaeBus: messagebus,
-		listHelper: helper,
+		Client:            client,
+		NodePool:          opts.Nodepool,
+		Namespace:         opts.Namespace,
+		deviceSyncer:      deviceSyncer,
+		deviceProfileSync: deviceProfileSync,
+		deviceServiceSync: deviceServiceSync,
+		msgHealthChecker:  msgHealthChecker,
+		messageBus:        messageBus,
 	}, nil
 
 }
 
 func (pm *Pulsimeter) NewPulsimeterRunnable() ctrlmgr.RunnableFunc {
 	return func(ctx context.Context) error {
+		go pm.msgHealthChecker.Run(ctx.Done())
+		go pm.deviceSyncer.Run(ctx.Done())
+		go pm.deviceProfileSync.Run(ctx.Done())
+		go pm.deviceServiceSync.Run(ctx.Done())
 		pm.Run(ctx.Done())
 		return nil
 	}
@@ -135,41 +112,13 @@ func (pm *Pulsimeter) NewPulsimeterRunnable() ctrlmgr.RunnableFunc {
 
 func (pm *Pulsimeter) Run(stop <-chan struct{}) {
 	klog.V(1).Info("[Pulsimeter] Starting ...")
-
-	// list all the metadata information
-	pm.listHelper.list()
-	// prepare the topic and channel for subscribe
-	// topic is like edgex/system-events/core-metadata/#
-	topic := common.BuildTopic(common.DefaultBaseTopic, common.SystemEventPublishTopic, common.CoreMetaDataServiceKey, "#")
-	messages := make(chan types.MessageEnvelope, 1)
-	messageErrors := make(chan error, 1)
-	topics := []types.TopicChannel{
-		{
-			Topic:    topic,
-			Messages: messages,
-		},
-	}
-	// make sure the messagebus is builded
-	err := retry.Do(
-		func() error {
-			err := pm.MessgaeBus.Subscribe(topics, messageErrors)
-			if err != nil {
-				klog.V(3).ErrorS(err, "fail to subscribe the topic")
-			}
-			return err
-		},
-	)
-	if err != nil {
-		klog.V(3).ErrorS(err, "retry subscribing the topic error")
-	}
-
-	klog.V(1).Info("start waiting for messages")
 	go func() {
+		klog.V(1).Info("start waiting for messages")
 		for {
 			select {
-			case err = <-messageErrors:
+			case err := <-pm.messageBus.MessageErrors:
 				klog.V(3).ErrorS(err, "fail to get the message")
-			case msgEnvelope := <-messages:
+			case msgEnvelope := <-pm.messageBus.Messages:
 				var systemEvent dtos.SystemEvent
 				err := json.Unmarshal(msgEnvelope.Payload, &systemEvent)
 				if err != nil {
@@ -201,17 +150,16 @@ func (pm *Pulsimeter) Run(stop <-chan struct{}) {
 
 // dealWithDevice focus on the change of device and apply these change to OpenYurt
 func (pm *Pulsimeter) dealWithDevice(systemEvent dtos.SystemEvent) error {
-	dto := dtos.Device{}
-	err := systemEvent.DecodeDetails(&dto)
+	kubeDevice := iotv1alpha1.Device{}
+	edgeDev, err := pm.deviceSyncer.deviceCli.Convert(context.TODO(), systemEvent, clients.GetOptions{Namespace: pm.Namespace})
 	if err != nil {
-		klog.V(3).ErrorS(err, "fail to decode device system event details")
+		return err
 	}
 
 	switch systemEvent.Action {
 	case common.SystemEventActionAdd:
 		klog.V(2).Info("deal with AddAction")
-		dev := utilv3.ToKubeDevice(dto, pm.Namespace)
-		newDevice := pm.completeDeviceCreateContent(&dev)
+		newDevice := pm.deviceSyncer.completeCreateContent(edgeDev)
 		if err := pm.Client.Create(context.TODO(), newDevice); err != nil {
 			klog.V(3).ErrorS(err, "fail to create device on OpenYurt", "DeviceName", strings.ToLower(newDevice.Name))
 			return err
@@ -219,35 +167,29 @@ func (pm *Pulsimeter) dealWithDevice(systemEvent dtos.SystemEvent) error {
 
 	case common.SystemEventActionUpdate:
 		klog.V(2).Info("deal with UpdateAction")
-		dev := utilv3.ToKubeDevice(dto, pm.Namespace)
-
-		kubeDev := iotv1alpha1.Device{}
-		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		name := strings.Join([]string{pm.NodePool, edgeDev.Name}, "-")
 		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
-		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDev); err != nil {
-			klog.V(3).ErrorS(err, "fail to get device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDevice); err != nil {
+			klog.V(3).ErrorS(err, "fail to get device on OpenYurt", "DeviceName", strings.ToLower(edgeDev.Name))
 			return err
 		}
 
-		pm.updateDevice(&kubeDev, &dev)
-		if err := pm.Client.Update(context.TODO(), &kubeDev); err != nil {
-			klog.V(3).ErrorS(err, "fail to update device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+		pm.deviceSyncer.completeUpdateContent(&kubeDevice, edgeDev)
+		if err := pm.Client.Update(context.TODO(), &kubeDevice); err != nil {
+			klog.V(3).ErrorS(err, "fail to update device on OpenYurt", "DeviceName", strings.ToLower(edgeDev.Name))
 			return err
 		}
 
 	case common.SystemEventActionDelete:
 		klog.V(2).Info("deal with DeleteAction")
-		dev := utilv3.ToKubeDevice(dto, pm.Namespace)
-
-		kubeDev := iotv1alpha1.Device{}
-		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		name := strings.Join([]string{pm.NodePool, edgeDev.Name}, "-")
 		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
-		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDev); err != nil {
-			klog.V(3).ErrorS(err, "fail to get device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDevice); err != nil {
+			klog.V(3).ErrorS(err, "fail to get device on OpenYurt", "DeviceName", strings.ToLower(edgeDev.Name))
 			return err
 		}
-		if err := pm.Client.Delete(context.TODO(), &kubeDev); err != nil {
-			klog.V(3).ErrorS(err, "fail to delete device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+		if err := pm.Client.Delete(context.TODO(), &kubeDevice); err != nil {
+			klog.V(3).ErrorS(err, "fail to delete device on OpenYurt", "DeviceName", strings.ToLower(edgeDev.Name))
 			return err
 		}
 		patchData, _ := json.Marshal(map[string]interface{}{
@@ -256,83 +198,57 @@ func (pm *Pulsimeter) dealWithDevice(systemEvent dtos.SystemEvent) error {
 			},
 		})
 
-		if err = pm.Client.Patch(context.TODO(), &kubeDev, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
-			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceName", strings.ToLower(dev.Name))
+		if err = pm.Client.Patch(context.TODO(), &kubeDevice, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
+			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceName", strings.ToLower(edgeDev.Name))
 			return err
 		}
 	}
 
 	return nil
-}
-
-// completeDeviceCreateContent completes the content of the device which will be created on OpenYurt
-func (pm *Pulsimeter) completeDeviceCreateContent(edgeDevice *iotv1alpha1.Device) *iotv1alpha1.Device {
-	createDevice := edgeDevice.DeepCopy()
-	createDevice.Spec.NodePool = pm.NodePool
-	createDevice.Name = strings.Join([]string{pm.NodePool, createDevice.Name}, "-")
-	createDevice.Namespace = pm.Namespace
-	createDevice.Spec.Managed = false
-
-	return createDevice
-}
-
-// updateDevice completes the content of the device which will be updated on OpenYurt
-func (pm *Pulsimeter) updateDevice(kubeDev *iotv1alpha1.Device, newDev *iotv1alpha1.Device) {
-	updateDevice := pm.completeDeviceCreateContent(newDev)
-	kubeDev.Spec = updateDevice.Spec
-	kubeDev.Status.OperatingState = updateDevice.Spec.OperatingState
-	kubeDev.Status.AdminState = updateDevice.Spec.AdminState
 }
 
 // dealWithDeviceService focus on the change of deviceservice and apply these change to OpenYurt
 func (pm *Pulsimeter) dealWithDeviceService(systemEvent dtos.SystemEvent) error {
-	dto := dtos.DeviceService{}
-	err := systemEvent.DecodeDetails(&dto)
+	kubeDs := iotv1alpha1.DeviceService{}
+	edgeDs, err := pm.deviceServiceSync.deviceServiceCli.Convert(context.TODO(), systemEvent, clients.GetOptions{Namespace: pm.Namespace})
 	if err != nil {
-		klog.V(3).ErrorS(err, "fail to decode deviceservice systemEvent details")
+		return err
 	}
 
 	switch systemEvent.Action {
 	case common.SystemEventActionAdd:
-		klog.V(2).Info("deal with AddAction")
-		dev := utilv3.ToKubeDeviceService(dto, pm.Namespace)
-		newDS := pm.completeDeviceServiceCreateContent(&dev)
-		if err := pm.Client.Create(context.TODO(), newDS); err != nil {
-			klog.V(3).ErrorS(err, "fail to create deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+		klog.V(2).Info("[Pulsimeter]: deal with the AddAction of DeviceService")
+		newDs := pm.deviceServiceSync.completeCreateContent(edgeDs)
+		if err := pm.Client.Create(context.TODO(), newDs); err != nil {
+			klog.V(3).ErrorS(err, "fail to create deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(edgeDs.Name))
 			return err
 		}
 
 	case common.SystemEventActionUpdate:
-		klog.V(2).Info("deal with UpdateAction")
-		dev := utilv3.ToKubeDeviceService(dto, pm.Namespace)
-
-		kubeDS := iotv1alpha1.DeviceService{}
-		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		klog.V(2).Info("[Pulsimeter]: deal with UpdateAction of DeviceService")
+		name := strings.Join([]string{pm.NodePool, edgeDs.Name}, "-")
 		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
-		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDS); err != nil {
-			klog.V(3).ErrorS(err, "fail to get deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDs); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(edgeDs.Name))
 			return err
 		}
 
-		pm.updateDeviceService(&kubeDS, &dev)
-		if err := pm.Client.Update(context.TODO(), &kubeDS); err != nil {
-			klog.V(3).ErrorS(err, "fail to update deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+		pm.deviceServiceSync.completeUpdateContent(&kubeDs, edgeDs)
+		if err := pm.Client.Update(context.TODO(), &kubeDs); err != nil {
+			klog.V(3).ErrorS(err, "fail to update deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(edgeDs.Name))
 			return err
 		}
 
 	case common.SystemEventActionDelete:
-		klog.V(2).Info("deal with DeleteAction")
-		dev := utilv3.ToKubeDeviceService(dto, pm.Namespace)
-
-		kubeDS := iotv1alpha1.DeviceService{}
-		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		klog.V(2).Info("[Pulsimeter]: deal with DeleteAction of DeviceService")
+		name := strings.Join([]string{pm.NodePool, edgeDs.Name}, "-")
 		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
-		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDS); err != nil {
-			klog.V(3).ErrorS(err, "fail to get deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDs); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(edgeDs.Name))
 			return err
 		}
-		if err := pm.Client.Delete(context.TODO(), &kubeDS); err != nil {
-			klog.V(3).ErrorS(err, "fail to delete deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+		if err := pm.Client.Delete(context.TODO(), &kubeDs); err != nil {
+			klog.V(3).ErrorS(err, "fail to delete deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(edgeDs.Name))
 			return err
 		}
 		patchData, _ := json.Marshal(map[string]interface{}{
@@ -341,81 +257,57 @@ func (pm *Pulsimeter) dealWithDeviceService(systemEvent dtos.SystemEvent) error 
 			},
 		})
 
-		if err = pm.Client.Patch(context.TODO(), &kubeDS, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
-			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceServiceName", strings.ToLower(dev.Name))
+		if err = pm.Client.Patch(context.TODO(), &kubeDs, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
+			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceServiceName", strings.ToLower(edgeDs.Name))
 			return err
 		}
 	}
 
 	return nil
-}
-
-// completeDeviceServiceCreateContent completes the content of the device which will be created on OpenYurt
-func (pm *Pulsimeter) completeDeviceServiceCreateContent(edgeDS *iotv1alpha1.DeviceService) *iotv1alpha1.DeviceService {
-	createDS := edgeDS.DeepCopy()
-	createDS.Spec.NodePool = pm.NodePool
-	createDS.Namespace = pm.Namespace
-	createDS.Name = strings.Join([]string{pm.NodePool, edgeDS.Name}, "-")
-	createDS.Spec.Managed = false
-	return createDS
-}
-
-// updateDeviceService completes the content of the device which will be updated on OpenYurt
-func (pm *Pulsimeter) updateDeviceService(kubeDS *iotv1alpha1.DeviceService, newDS *iotv1alpha1.DeviceService) {
-	updateDS := pm.completeDeviceServiceCreateContent(newDS)
-	kubeDS.Spec = updateDS.Spec
-	kubeDS.Status.AdminState = updateDS.Spec.AdminState
 }
 
 // dealWithDeviceProfile focus on the change of deviceprofile and apply these change to OpenYurt
 func (pm *Pulsimeter) dealWithDeviceProfile(systemEvent dtos.SystemEvent) error {
-	dto := dtos.DeviceProfile{}
-	err := systemEvent.DecodeDetails(&dto)
+	kubeDprofile := iotv1alpha1.DeviceProfile{}
+	edgeDprofile, err := pm.deviceProfileSync.edgeClient.Convert(context.TODO(), systemEvent, clients.GetOptions{Namespace: pm.Namespace})
 	if err != nil {
-		klog.V(3).ErrorS(err, "fail to decode deviceprofile systemEvent details")
+		return err
 	}
 
 	switch systemEvent.Action {
 	case common.SystemEventActionAdd:
 		klog.V(2).Info("deal with AddAction")
-		dev := utilv3.ToKubeDeviceProfile(dto, pm.Namespace)
-		newDP := pm.completeDeviceProfileCreateContent(&dev)
-		if err := pm.Client.Create(context.TODO(), newDP); err != nil {
-			klog.V(3).ErrorS(err, "fail to create deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+		newDp := pm.deviceProfileSync.completeCreateContent(edgeDprofile)
+		if err := pm.Client.Create(context.TODO(), newDp); err != nil {
+			klog.V(3).ErrorS(err, "fail to create deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(edgeDprofile.Name))
 			return err
 		}
 
 	case common.SystemEventActionUpdate:
 		klog.V(2).Info("deal with UpdateAction")
-		dev := utilv3.ToKubeDeviceProfile(dto, pm.Namespace)
-
-		kubeDP := iotv1alpha1.DeviceProfile{}
-		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		name := strings.Join([]string{pm.NodePool, edgeDprofile.Name}, "-")
 		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
-		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDP); err != nil {
-			klog.V(3).ErrorS(err, "fail to get deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDprofile); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(edgeDprofile.Name))
 			return err
 		}
 
-		pm.updateDeviceProfile(&kubeDP, &dev)
-		if err := pm.Client.Update(context.TODO(), &kubeDP); err != nil {
-			klog.V(3).ErrorS(err, "fail to update deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+		pm.deviceProfileSync.completeUpdateContent(&kubeDprofile, edgeDprofile)
+		if err := pm.Client.Update(context.TODO(), &kubeDprofile); err != nil {
+			klog.V(3).ErrorS(err, "fail to update deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(edgeDprofile.Name))
 			return err
 		}
 
 	case common.SystemEventActionDelete:
 		klog.V(2).Info("deal with DeleteAction")
-		dev := utilv3.ToKubeDeviceProfile(dto, pm.Namespace)
-
-		kubeDP := iotv1alpha1.DeviceProfile{}
-		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		name := strings.Join([]string{pm.NodePool, edgeDprofile.Name}, "-")
 		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
-		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDP); err != nil {
-			klog.V(3).ErrorS(err, "fail to get deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDprofile); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(edgeDprofile.Name))
 			return err
 		}
-		if err := pm.Client.Delete(context.TODO(), &kubeDP); err != nil {
-			klog.V(3).ErrorS(err, "fail to delete deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+		if err := pm.Client.Delete(context.TODO(), &kubeDprofile); err != nil {
+			klog.V(3).ErrorS(err, "fail to delete deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(edgeDprofile.Name))
 			return err
 		}
 		patchData, _ := json.Marshal(map[string]interface{}{
@@ -424,341 +316,11 @@ func (pm *Pulsimeter) dealWithDeviceProfile(systemEvent dtos.SystemEvent) error 
 			},
 		})
 
-		if err = pm.Client.Patch(context.TODO(), &kubeDP, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
-			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceProfileName", strings.ToLower(dev.Name))
+		if err = pm.Client.Patch(context.TODO(), &kubeDprofile, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
+			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceProfileName", strings.ToLower(edgeDprofile.Name))
 			return err
 		}
 	}
 
 	return nil
-}
-
-// completeCreateContent completes the content of the deviceProfile which will be created on OpenYurt
-func (pm *Pulsimeter) completeDeviceProfileCreateContent(edgeDps *iotv1alpha1.DeviceProfile) *iotv1alpha1.DeviceProfile {
-	createDeviceProfile := edgeDps.DeepCopy()
-	createDeviceProfile.Namespace = pm.Namespace
-	createDeviceProfile.Name = strings.Join([]string{pm.NodePool, createDeviceProfile.Name}, "-")
-	createDeviceProfile.Spec.NodePool = pm.NodePool
-	return createDeviceProfile
-}
-
-// updateDeviceProfile completes the content of the deviceProfile which will be updated on OpenYurt
-func (pm *Pulsimeter) updateDeviceProfile(kubeDP *iotv1alpha1.DeviceProfile, newDP *iotv1alpha1.DeviceProfile) {
-	updateDS := pm.completeDeviceProfileCreateContent(newDP)
-	kubeDP.Spec = updateDS.Spec
-}
-
-// DeviceServiceList
-func (ds *DeviceServiceList) ServiceList() {
-
-	// 1. get deviceServices on edge platform and OpenYurt
-	edgeDeviceServices, kubeDeviceServices, err := ds.getAllDeviceServices()
-	if err != nil {
-		klog.V(3).ErrorS(err, "fail to list the deviceServices")
-	}
-
-	// 2. find the deviceServices that need to be synchronized
-	redundantEdgeDeviceServices, redundantKubeDeviceServices, syncedDeviceServices :=
-		ds.findDiffDeviceServices(edgeDeviceServices, kubeDeviceServices)
-	klog.V(2).Infof("[DeviceService] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
-		"Edge deviceServices should be added to OpenYurt", len(redundantEdgeDeviceServices),
-		"OpenYurt deviceServices that should be deleted", len(redundantKubeDeviceServices),
-		"DeviceServices that should be synchronized", len(syncedDeviceServices))
-
-	// 3. create deviceServices on OpenYurt which are exists in edge platform but not in OpenYurt
-	if err := ds.syncEdgeToKube(redundantEdgeDeviceServices); err != nil {
-		klog.V(3).ErrorS(err, "fail to create deviceServices on OpenYurt")
-	}
-
-	// 4. delete redundant deviceServices on OpenYurt
-	if err := ds.deleteDeviceServices(redundantKubeDeviceServices); err != nil {
-		klog.V(3).ErrorS(err, "fail to delete redundant deviceServices on OpenYurt")
-	}
-
-	// 5. update deviceService status on OpenYurt
-	if err := ds.updateDeviceServices(syncedDeviceServices); err != nil {
-		klog.V(3).ErrorS(err, "fail to update deviceServices")
-	}
-	klog.V(2).Info("[DeviceService] synchronization is complete")
-
-}
-
-// Get the existing DeviceService on the Edge platform, as well as OpenYurt existing DeviceService
-// edgeDeviceServices：map[actualName]DeviceService
-// kubeDeviceServices：map[actualName]DeviceService
-func (ds *DeviceServiceList) getAllDeviceServices() (
-	map[string]iotv1alpha1.DeviceService, map[string]iotv1alpha1.DeviceService, error) {
-
-	edgeDeviceServices := map[string]iotv1alpha1.DeviceService{}
-	kubeDeviceServices := map[string]iotv1alpha1.DeviceService{}
-
-	// 1. list deviceServices on edge platform
-	eDevSs, err := ds.deviceServiceCli.List(context.TODO(), iotcli.ListOptions{Namespace: ds.Namespace})
-	if err != nil {
-		klog.V(4).ErrorS(err, "fail to list the deviceServices object on the edge platform")
-		return edgeDeviceServices, kubeDeviceServices, err
-	}
-	// 2. list deviceServices on OpenYurt (filter objects belonging to edgeServer)
-	var kDevSs iotv1alpha1.DeviceServiceList
-	listOptions := client.MatchingFields{util.IndexerPathForNodepool: ds.NodePool}
-	if err = ds.List(context.TODO(), &kDevSs, listOptions, client.InNamespace(ds.Namespace)); err != nil {
-		klog.V(4).ErrorS(err, "fail to list the deviceServices object on the Kubernetes")
-		return edgeDeviceServices, kubeDeviceServices, err
-	}
-	for i := range eDevSs {
-		deviceServicesName := util.GetEdgeDeviceServiceName(&eDevSs[i], EdgeXObjectName)
-		edgeDeviceServices[deviceServicesName] = eDevSs[i]
-	}
-
-	for i := range kDevSs.Items {
-		deviceServicesName := util.GetEdgeDeviceServiceName(&kDevSs.Items[i], EdgeXObjectName)
-		kubeDeviceServices[deviceServicesName] = kDevSs.Items[i]
-	}
-	return edgeDeviceServices, kubeDeviceServices, nil
-}
-
-// Get the list of deviceServices that need to be added, deleted and updated
-func (ds *DeviceServiceList) findDiffDeviceServices(
-	edgeDeviceService map[string]iotv1alpha1.DeviceService, kubeDeviceService map[string]iotv1alpha1.DeviceService) (
-	redundantEdgeDeviceServices map[string]*iotv1alpha1.DeviceService, redundantKubeDeviceServices map[string]*iotv1alpha1.DeviceService, syncedDeviceServices map[string]*iotv1alpha1.DeviceService) {
-
-	redundantEdgeDeviceServices = map[string]*iotv1alpha1.DeviceService{}
-	redundantKubeDeviceServices = map[string]*iotv1alpha1.DeviceService{}
-	syncedDeviceServices = map[string]*iotv1alpha1.DeviceService{}
-
-	for i := range edgeDeviceService {
-		eds := edgeDeviceService[i]
-		edName := util.GetEdgeDeviceServiceName(&eds, EdgeXObjectName)
-		if _, exists := kubeDeviceService[edName]; !exists {
-			redundantEdgeDeviceServices[edName] = ds.completeCreateContent(&eds)
-		} else {
-			kd := kubeDeviceService[edName]
-			syncedDeviceServices[edName] = ds.completeUpdateContent(&kd, &eds)
-		}
-	}
-
-	for i := range kubeDeviceService {
-		kds := kubeDeviceService[i]
-		if !kds.Status.Synced {
-			continue
-		}
-		kdName := util.GetEdgeDeviceServiceName(&kds, EdgeXObjectName)
-		if _, exists := edgeDeviceService[kdName]; !exists {
-			redundantKubeDeviceServices[kdName] = &kds
-		}
-	}
-	return
-}
-
-// syncEdgeToKube creates deviceServices on OpenYurt which are exists in edge platform but not in OpenYurt
-func (ds *DeviceServiceList) syncEdgeToKube(edgeDevs map[string]*iotv1alpha1.DeviceService) error {
-	for _, ed := range edgeDevs {
-		if err := ds.Client.Create(context.TODO(), ed); err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				klog.V(5).InfoS("DeviceService already exist on Kubernetes",
-					"DeviceService", strings.ToLower(ed.Name))
-				continue
-			}
-			klog.InfoS("created deviceService failed:", "DeviceService", strings.ToLower(ed.Name))
-			return err
-		}
-	}
-	return nil
-}
-
-// deleteDeviceServices deletes redundant deviceServices on OpenYurt
-func (ds *DeviceServiceList) deleteDeviceServices(redundantKubeDeviceServices map[string]*iotv1alpha1.DeviceService) error {
-	for _, kds := range redundantKubeDeviceServices {
-		if err := ds.Client.Delete(context.TODO(), kds); err != nil {
-			klog.V(5).ErrorS(err, "fail to delete the DeviceService on Kubernetes",
-				"DeviceService", kds.Name)
-			return err
-		}
-	}
-	return nil
-}
-
-// updateDeviceServices updates deviceServices status on OpenYurt
-func (ds *DeviceServiceList) updateDeviceServices(syncedDeviceServices map[string]*iotv1alpha1.DeviceService) error {
-	for _, sd := range syncedDeviceServices {
-		if sd.ObjectMeta.ResourceVersion == "" {
-			continue
-		}
-		if err := ds.Client.Status().Update(context.TODO(), sd); err != nil {
-			if apierrors.IsConflict(err) {
-				klog.V(5).InfoS("update Conflicts", "DeviceService", sd.Name)
-				continue
-			}
-			klog.V(5).ErrorS(err, "fail to update the DeviceService on Kubernetes",
-				"DeviceService", sd.Name)
-			return err
-		}
-	}
-	return nil
-}
-
-// completeCreateContent completes the content of the deviceService which will be created on OpenYurt
-func (ds *DeviceServiceList) completeCreateContent(edgeDS *iotv1alpha1.DeviceService) *iotv1alpha1.DeviceService {
-	createDevice := edgeDS.DeepCopy()
-	createDevice.Spec.NodePool = ds.NodePool
-	createDevice.Namespace = ds.Namespace
-	createDevice.Name = strings.Join([]string{ds.NodePool, edgeDS.Name}, "-")
-	createDevice.Spec.Managed = false
-	return createDevice
-}
-
-// completeUpdateContent completes the content of the deviceService which will be updated on OpenYurt
-func (ds *DeviceServiceList) completeUpdateContent(kubeDS *iotv1alpha1.DeviceService, edgeDS *iotv1alpha1.DeviceService) *iotv1alpha1.DeviceService {
-	updatedDS := kubeDS.DeepCopy()
-	// update device status
-	updatedDS.Status.LastConnected = edgeDS.Status.LastConnected
-	updatedDS.Status.LastReported = edgeDS.Status.LastReported
-	updatedDS.Status.AdminState = edgeDS.Status.AdminState
-	return updatedDS
-}
-
-// DeviceProfileList
-func (dps *DeviceProfileList) ProfileList() {
-
-	// 1. get deviceProfiles on edge platform and OpenYurt
-	edgeDeviceProfiles, kubeDeviceProfiles, err := dps.getAllDeviceProfiles()
-	if err != nil {
-		klog.V(3).ErrorS(err, "fail to list the deviceProfiles")
-	}
-
-	// 2. find the deviceProfiles that need to be synchronized
-	redundantEdgeDeviceProfiles, redundantKubeDeviceProfiles, syncedDeviceProfiles :=
-		dps.findDiffDeviceProfiles(edgeDeviceProfiles, kubeDeviceProfiles)
-	klog.V(2).Infof("[DeviceProfile] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
-		"Edge deviceProfiles should be added to OpenYurt", len(redundantEdgeDeviceProfiles),
-		"OpenYurt deviceProfiles that should be deleted", len(redundantKubeDeviceProfiles),
-		"DeviceProfiles that should be synchronized", len(syncedDeviceProfiles))
-
-	// 3. create deviceProfiles on OpenYurt which are exists in edge platform but not in OpenYurt
-	if err := dps.syncEdgeToKube(redundantEdgeDeviceProfiles); err != nil {
-		klog.V(3).ErrorS(err, "fail to create deviceProfiles on OpenYurt")
-	}
-
-	// 4. delete redundant deviceProfiles on OpenYurt
-	if err := dps.deleteDeviceProfiles(redundantKubeDeviceProfiles); err != nil {
-		klog.V(3).ErrorS(err, "fail to delete redundant deviceProfiles on OpenYurt")
-	}
-
-	// 5. update deviceProfiles on OpenYurt
-	// TODO
-
-}
-
-// Get the existing DeviceProfile on the Edge platform, as well as OpenYurt existing DeviceProfile
-// edgeDeviceProfiles：map[actualName]DeviceProfile
-// kubeDeviceProfiles：map[actualName]DeviceProfile
-func (dps *DeviceProfileList) getAllDeviceProfiles() (
-	map[string]iotv1alpha1.DeviceProfile, map[string]iotv1alpha1.DeviceProfile, error) {
-
-	edgeDeviceProfiles := map[string]iotv1alpha1.DeviceProfile{}
-	kubeDeviceProfiles := map[string]iotv1alpha1.DeviceProfile{}
-
-	// 1. list deviceProfiles on edge platform
-	eDps, err := dps.edgeClient.List(context.TODO(), devcli.ListOptions{Namespace: dps.Namespace})
-	if err != nil {
-		klog.V(4).ErrorS(err, "fail to list the deviceProfiles on the edge platform")
-		return edgeDeviceProfiles, kubeDeviceProfiles, err
-	}
-	// 2. list deviceProfiles on OpenYurt (filter objects belonging to edgeServer)
-	var kDps iotv1alpha1.DeviceProfileList
-	listOptions := client.MatchingFields{util.IndexerPathForNodepool: dps.NodePool}
-	if err = dps.List(context.TODO(), &kDps, listOptions, client.InNamespace(dps.Namespace)); err != nil {
-		klog.V(4).ErrorS(err, "fail to list the deviceProfiles on the Kubernetes")
-		return edgeDeviceProfiles, kubeDeviceProfiles, err
-	}
-	for i := range eDps {
-		deviceProfilesName := util.GetEdgeDeviceProfileName(&eDps[i], EdgeXObjectName)
-		edgeDeviceProfiles[deviceProfilesName] = eDps[i]
-	}
-
-	for i := range kDps.Items {
-		deviceProfilesName := util.GetEdgeDeviceProfileName(&kDps.Items[i], EdgeXObjectName)
-		kubeDeviceProfiles[deviceProfilesName] = kDps.Items[i]
-	}
-	return edgeDeviceProfiles, kubeDeviceProfiles, nil
-}
-
-// Get the list of deviceProfiles that need to be added, deleted and updated
-func (dps *DeviceProfileList) findDiffDeviceProfiles(
-	edgeDeviceProfiles map[string]iotv1alpha1.DeviceProfile, kubeDeviceProfiles map[string]iotv1alpha1.DeviceProfile) (
-	redundantEdgeDeviceProfiles map[string]*iotv1alpha1.DeviceProfile, redundantKubeDeviceProfiles map[string]*iotv1alpha1.DeviceProfile, syncedDeviceProfiles map[string]*iotv1alpha1.DeviceProfile) {
-
-	redundantEdgeDeviceProfiles = map[string]*iotv1alpha1.DeviceProfile{}
-	redundantKubeDeviceProfiles = map[string]*iotv1alpha1.DeviceProfile{}
-	syncedDeviceProfiles = map[string]*iotv1alpha1.DeviceProfile{}
-
-	for i := range edgeDeviceProfiles {
-		edp := edgeDeviceProfiles[i]
-		edpName := util.GetEdgeDeviceProfileName(&edp, EdgeXObjectName)
-		if _, exists := kubeDeviceProfiles[edpName]; !exists {
-			redundantEdgeDeviceProfiles[edpName] = dps.completeCreateContent(&edp)
-		} else {
-			kdp := kubeDeviceProfiles[edpName]
-			syncedDeviceProfiles[edpName] = dps.completeUpdateContent(&kdp, &edp)
-		}
-	}
-
-	for i := range kubeDeviceProfiles {
-		kdp := kubeDeviceProfiles[i]
-		if !kdp.Status.Synced {
-			continue
-		}
-		kdpName := util.GetEdgeDeviceProfileName(&kdp, EdgeXObjectName)
-		if _, exists := edgeDeviceProfiles[kdpName]; !exists {
-			redundantKubeDeviceProfiles[kdpName] = &kdp
-		}
-	}
-	return
-}
-
-// completeCreateContent completes the content of the deviceProfile which will be created on OpenYurt
-func (dps *DeviceProfileList) completeCreateContent(edgeDps *iotv1alpha1.DeviceProfile) *iotv1alpha1.DeviceProfile {
-	createDeviceProfile := edgeDps.DeepCopy()
-	createDeviceProfile.Namespace = dps.Namespace
-	createDeviceProfile.Name = strings.Join([]string{dps.NodePool, createDeviceProfile.Name}, "-")
-	createDeviceProfile.Spec.NodePool = dps.NodePool
-	return createDeviceProfile
-}
-
-// completeUpdateContent completes the content of the deviceProfile which will be updated on OpenYurt
-// TODO
-func (dps *DeviceProfileList) completeUpdateContent(kubeDps *iotv1alpha1.DeviceProfile, edgeDS *iotv1alpha1.DeviceProfile) *iotv1alpha1.DeviceProfile {
-	return kubeDps
-}
-
-// syncEdgeToKube creates deviceProfiles on OpenYurt which are exists in edge platform but not in OpenYurt
-func (dps *DeviceProfileList) syncEdgeToKube(edgeDps map[string]*iotv1alpha1.DeviceProfile) error {
-	for _, edp := range edgeDps {
-		if err := dps.Client.Create(context.TODO(), edp); err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				klog.V(5).Infof("DeviceProfile already exist on Kubernetes: %s", strings.ToLower(edp.Name))
-				continue
-			}
-			klog.Infof("created deviceProfile failed: %s", strings.ToLower(edp.Name))
-			return err
-		}
-	}
-	return nil
-}
-
-// deleteDeviceProfiles deletes redundant deviceProfiles on OpenYurt
-func (dps *DeviceProfileList) deleteDeviceProfiles(redundantKubeDeviceProfiles map[string]*iotv1alpha1.DeviceProfile) error {
-	for _, kdp := range redundantKubeDeviceProfiles {
-		if err := dps.Client.Delete(context.TODO(), kdp); err != nil {
-			klog.V(5).ErrorS(err, "fail to delete the DeviceProfile on Kubernetes: %s ",
-				"DeviceProfile", kdp.Name)
-			return err
-		}
-	}
-	return nil
-}
-
-func (help *ListHelper) list() {
-	help.deviceServiceList.ServiceList()
-	help.deviceProfileList.ProfileList()
 }

--- a/pkg/yurtiotdock/controllers/pulsimeter.go
+++ b/pkg/yurtiotdock/controllers/pulsimeter.go
@@ -1,0 +1,764 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
+	"github.com/edgexfoundry/go-mod-messaging/v3/messaging"
+	"github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
+	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/avast/retry-go"
+	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
+	devcli "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
+	iotcli "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
+	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
+	utilv3 "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry/v3"
+	util "github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+)
+
+type Pulsimeter struct {
+	// kubernetes client
+	client.Client
+	// which nodePool Plusimeter is deployed in
+	NodePool string
+	// which namespace Plusimeter is deployed in
+	Namespace string
+	// messageBus
+	MessgaeBus messaging.MessageClient
+	listHelper ListHelper
+}
+
+type ListHelper struct {
+	deviceServiceList DeviceServiceList
+	deviceProfileList DeviceProfileList
+}
+
+type DeviceServiceList struct {
+	// Kubernetes client
+	client.Client
+	deviceServiceCli iotcli.DeviceServiceInterface
+	NodePool         string
+	Namespace        string
+}
+
+type DeviceProfileList struct {
+	// edge platform client
+	edgeClient devcli.DeviceProfileInterface
+	// Kubernetes client
+	client.Client
+	NodePool  string
+	Namespace string
+}
+
+func NewPulsimeter(client client.Client, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) (Pulsimeter, error) {
+
+	// init messagebus
+	// TODO support other kind of messagebus
+	messagebus, err := messaging.NewMessageClient(types.MessageBusConfig{
+		Broker: types.HostInfo{
+			Host:     opts.RedisAddr,
+			Port:     int(opts.RedisPort),
+			Protocol: "redis",
+		},
+		Type: "redis"})
+
+	if err != nil {
+		return Pulsimeter{}, err
+	}
+	deviceserviceclient, err := edgexdock.CreateDeviceServiceClient()
+	if err != nil {
+		return Pulsimeter{}, err
+	}
+	deviceServiceList := DeviceServiceList{
+		Client:           client,
+		NodePool:         opts.Nodepool,
+		Namespace:        opts.Namespace,
+		deviceServiceCli: deviceserviceclient,
+	}
+	edgeclient, err := edgexdock.CreateDeviceProfileClient()
+	if err != nil {
+		return Pulsimeter{}, err
+	}
+	deviceProfileList := DeviceProfileList{
+		edgeClient: edgeclient,
+		Client:     client,
+		NodePool:   opts.Nodepool,
+		Namespace:  opts.Namespace,
+	}
+
+	helper := ListHelper{
+		deviceServiceList: deviceServiceList,
+		deviceProfileList: deviceProfileList,
+	}
+
+	return Pulsimeter{
+		Client:     client,
+		NodePool:   opts.Nodepool,
+		Namespace:  opts.Namespace,
+		MessgaeBus: messagebus,
+		listHelper: helper,
+	}, nil
+
+}
+
+func (pm *Pulsimeter) NewPulsimeterRunnable() ctrlmgr.RunnableFunc {
+	return func(ctx context.Context) error {
+		pm.Run(ctx.Done())
+		return nil
+	}
+}
+
+func (pm *Pulsimeter) Run(stop <-chan struct{}) {
+	klog.V(1).Info("[Pulsimeter] Starting ...")
+
+	// list all the metadata information
+	pm.listHelper.list()
+	// prepare the topic and channel for subscribe
+	// topic is like edgex/system-events/core-metadata/#
+	topic := common.BuildTopic(common.DefaultBaseTopic, common.SystemEventPublishTopic, common.CoreMetaDataServiceKey, "#")
+	messages := make(chan types.MessageEnvelope, 1)
+	messageErrors := make(chan error, 1)
+	topics := []types.TopicChannel{
+		{
+			Topic:    topic,
+			Messages: messages,
+		},
+	}
+	// make sure the messagebus is builded
+	err := retry.Do(
+		func() error {
+			err := pm.MessgaeBus.Subscribe(topics, messageErrors)
+			if err != nil {
+				klog.V(3).ErrorS(err, "fail to subscribe the topic")
+			}
+			return err
+		},
+	)
+	if err != nil {
+		klog.V(3).ErrorS(err, "retry subscribing the topic error")
+	}
+
+	klog.V(1).Info("start waiting for messages")
+	go func() {
+		for {
+			select {
+			case err = <-messageErrors:
+				klog.V(3).ErrorS(err, "fail to get the message")
+			case msgEnvelope := <-messages:
+				var systemEvent dtos.SystemEvent
+				err := json.Unmarshal(msgEnvelope.Payload, &systemEvent)
+				if err != nil {
+					klog.V(3).ErrorS(err, "fail to JSON decoding system event")
+					continue
+				}
+				klog.V(1).Info("successful get the message")
+				switch systemEvent.Type {
+				case common.DeviceSystemEventType:
+					if err := pm.dealWithDevice(systemEvent); err != nil {
+						klog.V(3).ErrorS(err, "fail to deal with device systemEvent")
+					}
+				case common.DeviceServiceSystemEventType:
+					if err := pm.dealWithDeviceService(systemEvent); err != nil {
+						klog.V(3).ErrorS(err, "fail to deal with deviceservice systemEvent")
+					}
+				case common.DeviceProfileSystemEventType:
+					if err := pm.dealWithDeviceProfile(systemEvent); err != nil {
+						klog.V(3).ErrorS(err, "fail to deal with deviceprofile systemEvent")
+					}
+				}
+			}
+		}
+	}()
+
+	<-stop
+	klog.V(1).Info("[Pulsimeter] Stopping ...")
+}
+
+// dealWithDevice focus on the change of device and apply these change to OpenYurt
+func (pm *Pulsimeter) dealWithDevice(systemEvent dtos.SystemEvent) error {
+	dto := dtos.Device{}
+	err := systemEvent.DecodeDetails(&dto)
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to decode device system event details")
+	}
+
+	switch systemEvent.Action {
+	case common.SystemEventActionAdd:
+		klog.V(2).Info("deal with AddAction")
+		dev := utilv3.ToKubeDevice(dto, pm.Namespace)
+		newDevice := pm.completeDeviceCreateContent(&dev)
+		if err := pm.Client.Create(context.TODO(), newDevice); err != nil {
+			klog.V(3).ErrorS(err, "fail to create device on OpenYurt", "DeviceName", strings.ToLower(newDevice.Name))
+			return err
+		}
+
+	case common.SystemEventActionUpdate:
+		klog.V(2).Info("deal with UpdateAction")
+		dev := utilv3.ToKubeDevice(dto, pm.Namespace)
+
+		kubeDev := iotv1alpha1.Device{}
+		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDev); err != nil {
+			klog.V(3).ErrorS(err, "fail to get device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+			return err
+		}
+
+		pm.updateDevice(&kubeDev, &dev)
+		if err := pm.Client.Update(context.TODO(), &kubeDev); err != nil {
+			klog.V(3).ErrorS(err, "fail to update device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+			return err
+		}
+
+	case common.SystemEventActionDelete:
+		klog.V(2).Info("deal with DeleteAction")
+		dev := utilv3.ToKubeDevice(dto, pm.Namespace)
+
+		kubeDev := iotv1alpha1.Device{}
+		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDev); err != nil {
+			klog.V(3).ErrorS(err, "fail to get device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+			return err
+		}
+		if err := pm.Client.Delete(context.TODO(), &kubeDev); err != nil {
+			klog.V(3).ErrorS(err, "fail to delete device on OpenYurt", "DeviceName", strings.ToLower(dev.Name))
+			return err
+		}
+		patchData, _ := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"finalizers": []string{},
+			},
+		})
+
+		if err = pm.Client.Patch(context.TODO(), &kubeDev, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
+			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceName", strings.ToLower(dev.Name))
+			return err
+		}
+	}
+
+	return nil
+}
+
+// completeDeviceCreateContent completes the content of the device which will be created on OpenYurt
+func (pm *Pulsimeter) completeDeviceCreateContent(edgeDevice *iotv1alpha1.Device) *iotv1alpha1.Device {
+	createDevice := edgeDevice.DeepCopy()
+	createDevice.Spec.NodePool = pm.NodePool
+	createDevice.Name = strings.Join([]string{pm.NodePool, createDevice.Name}, "-")
+	createDevice.Namespace = pm.Namespace
+	createDevice.Spec.Managed = false
+
+	return createDevice
+}
+
+// updateDevice completes the content of the device which will be updated on OpenYurt
+func (pm *Pulsimeter) updateDevice(kubeDev *iotv1alpha1.Device, newDev *iotv1alpha1.Device) {
+	updateDevice := pm.completeDeviceCreateContent(newDev)
+	kubeDev.Spec = updateDevice.Spec
+	kubeDev.Status.OperatingState = updateDevice.Spec.OperatingState
+	kubeDev.Status.AdminState = updateDevice.Spec.AdminState
+}
+
+// dealWithDeviceService focus on the change of deviceservice and apply these change to OpenYurt
+func (pm *Pulsimeter) dealWithDeviceService(systemEvent dtos.SystemEvent) error {
+	dto := dtos.DeviceService{}
+	err := systemEvent.DecodeDetails(&dto)
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to decode deviceservice systemEvent details")
+	}
+
+	switch systemEvent.Action {
+	case common.SystemEventActionAdd:
+		klog.V(2).Info("deal with AddAction")
+		dev := utilv3.ToKubeDeviceService(dto, pm.Namespace)
+		newDS := pm.completeDeviceServiceCreateContent(&dev)
+		if err := pm.Client.Create(context.TODO(), newDS); err != nil {
+			klog.V(3).ErrorS(err, "fail to create deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+			return err
+		}
+
+	case common.SystemEventActionUpdate:
+		klog.V(2).Info("deal with UpdateAction")
+		dev := utilv3.ToKubeDeviceService(dto, pm.Namespace)
+
+		kubeDS := iotv1alpha1.DeviceService{}
+		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDS); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+			return err
+		}
+
+		pm.updateDeviceService(&kubeDS, &dev)
+		if err := pm.Client.Update(context.TODO(), &kubeDS); err != nil {
+			klog.V(3).ErrorS(err, "fail to update deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+			return err
+		}
+
+	case common.SystemEventActionDelete:
+		klog.V(2).Info("deal with DeleteAction")
+		dev := utilv3.ToKubeDeviceService(dto, pm.Namespace)
+
+		kubeDS := iotv1alpha1.DeviceService{}
+		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDS); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+			return err
+		}
+		if err := pm.Client.Delete(context.TODO(), &kubeDS); err != nil {
+			klog.V(3).ErrorS(err, "fail to delete deviceservice on OpenYurt", "DeviceServiceName", strings.ToLower(dev.Name))
+			return err
+		}
+		patchData, _ := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"finalizers": []string{},
+			},
+		})
+
+		if err = pm.Client.Patch(context.TODO(), &kubeDS, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
+			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceServiceName", strings.ToLower(dev.Name))
+			return err
+		}
+	}
+
+	return nil
+}
+
+// completeDeviceServiceCreateContent completes the content of the device which will be created on OpenYurt
+func (pm *Pulsimeter) completeDeviceServiceCreateContent(edgeDS *iotv1alpha1.DeviceService) *iotv1alpha1.DeviceService {
+	createDS := edgeDS.DeepCopy()
+	createDS.Spec.NodePool = pm.NodePool
+	createDS.Namespace = pm.Namespace
+	createDS.Name = strings.Join([]string{pm.NodePool, edgeDS.Name}, "-")
+	createDS.Spec.Managed = false
+	return createDS
+}
+
+// updateDeviceService completes the content of the device which will be updated on OpenYurt
+func (pm *Pulsimeter) updateDeviceService(kubeDS *iotv1alpha1.DeviceService, newDS *iotv1alpha1.DeviceService) {
+	updateDS := pm.completeDeviceServiceCreateContent(newDS)
+	kubeDS.Spec = updateDS.Spec
+	kubeDS.Status.AdminState = updateDS.Spec.AdminState
+}
+
+// dealWithDeviceProfile focus on the change of deviceprofile and apply these change to OpenYurt
+func (pm *Pulsimeter) dealWithDeviceProfile(systemEvent dtos.SystemEvent) error {
+	dto := dtos.DeviceProfile{}
+	err := systemEvent.DecodeDetails(&dto)
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to decode deviceprofile systemEvent details")
+	}
+
+	switch systemEvent.Action {
+	case common.SystemEventActionAdd:
+		klog.V(2).Info("deal with AddAction")
+		dev := utilv3.ToKubeDeviceProfile(dto, pm.Namespace)
+		newDP := pm.completeDeviceProfileCreateContent(&dev)
+		if err := pm.Client.Create(context.TODO(), newDP); err != nil {
+			klog.V(3).ErrorS(err, "fail to create deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+			return err
+		}
+
+	case common.SystemEventActionUpdate:
+		klog.V(2).Info("deal with UpdateAction")
+		dev := utilv3.ToKubeDeviceProfile(dto, pm.Namespace)
+
+		kubeDP := iotv1alpha1.DeviceProfile{}
+		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDP); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+			return err
+		}
+
+		pm.updateDeviceProfile(&kubeDP, &dev)
+		if err := pm.Client.Update(context.TODO(), &kubeDP); err != nil {
+			klog.V(3).ErrorS(err, "fail to update deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+			return err
+		}
+
+	case common.SystemEventActionDelete:
+		klog.V(2).Info("deal with DeleteAction")
+		dev := utilv3.ToKubeDeviceProfile(dto, pm.Namespace)
+
+		kubeDP := iotv1alpha1.DeviceProfile{}
+		name := strings.Join([]string{pm.NodePool, dev.Name}, "-")
+		objectKey := client.ObjectKey{Namespace: pm.Namespace, Name: name}
+		if err := pm.Client.Get(context.TODO(), objectKey, &kubeDP); err != nil {
+			klog.V(3).ErrorS(err, "fail to get deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+			return err
+		}
+		if err := pm.Client.Delete(context.TODO(), &kubeDP); err != nil {
+			klog.V(3).ErrorS(err, "fail to delete deviceprofile on OpenYurt", "DeviceProfileName", strings.ToLower(dev.Name))
+			return err
+		}
+		patchData, _ := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"finalizers": []string{},
+			},
+		})
+
+		if err = pm.Client.Patch(context.TODO(), &kubeDP, client.RawPatch(kubetypes.MergePatchType, patchData)); err != nil {
+			klog.V(3).ErrorS(err, "fail to remove the finalizer", "DeviceProfileName", strings.ToLower(dev.Name))
+			return err
+		}
+	}
+
+	return nil
+}
+
+// completeCreateContent completes the content of the deviceProfile which will be created on OpenYurt
+func (pm *Pulsimeter) completeDeviceProfileCreateContent(edgeDps *iotv1alpha1.DeviceProfile) *iotv1alpha1.DeviceProfile {
+	createDeviceProfile := edgeDps.DeepCopy()
+	createDeviceProfile.Namespace = pm.Namespace
+	createDeviceProfile.Name = strings.Join([]string{pm.NodePool, createDeviceProfile.Name}, "-")
+	createDeviceProfile.Spec.NodePool = pm.NodePool
+	return createDeviceProfile
+}
+
+// updateDeviceProfile completes the content of the deviceProfile which will be updated on OpenYurt
+func (pm *Pulsimeter) updateDeviceProfile(kubeDP *iotv1alpha1.DeviceProfile, newDP *iotv1alpha1.DeviceProfile) {
+	updateDS := pm.completeDeviceProfileCreateContent(newDP)
+	kubeDP.Spec = updateDS.Spec
+}
+
+// DeviceServiceList
+func (ds *DeviceServiceList) ServiceList() {
+
+	// 1. get deviceServices on edge platform and OpenYurt
+	edgeDeviceServices, kubeDeviceServices, err := ds.getAllDeviceServices()
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to list the deviceServices")
+	}
+
+	// 2. find the deviceServices that need to be synchronized
+	redundantEdgeDeviceServices, redundantKubeDeviceServices, syncedDeviceServices :=
+		ds.findDiffDeviceServices(edgeDeviceServices, kubeDeviceServices)
+	klog.V(2).Infof("[DeviceService] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
+		"Edge deviceServices should be added to OpenYurt", len(redundantEdgeDeviceServices),
+		"OpenYurt deviceServices that should be deleted", len(redundantKubeDeviceServices),
+		"DeviceServices that should be synchronized", len(syncedDeviceServices))
+
+	// 3. create deviceServices on OpenYurt which are exists in edge platform but not in OpenYurt
+	if err := ds.syncEdgeToKube(redundantEdgeDeviceServices); err != nil {
+		klog.V(3).ErrorS(err, "fail to create deviceServices on OpenYurt")
+	}
+
+	// 4. delete redundant deviceServices on OpenYurt
+	if err := ds.deleteDeviceServices(redundantKubeDeviceServices); err != nil {
+		klog.V(3).ErrorS(err, "fail to delete redundant deviceServices on OpenYurt")
+	}
+
+	// 5. update deviceService status on OpenYurt
+	if err := ds.updateDeviceServices(syncedDeviceServices); err != nil {
+		klog.V(3).ErrorS(err, "fail to update deviceServices")
+	}
+	klog.V(2).Info("[DeviceService] synchronization is complete")
+
+}
+
+// Get the existing DeviceService on the Edge platform, as well as OpenYurt existing DeviceService
+// edgeDeviceServices：map[actualName]DeviceService
+// kubeDeviceServices：map[actualName]DeviceService
+func (ds *DeviceServiceList) getAllDeviceServices() (
+	map[string]iotv1alpha1.DeviceService, map[string]iotv1alpha1.DeviceService, error) {
+
+	edgeDeviceServices := map[string]iotv1alpha1.DeviceService{}
+	kubeDeviceServices := map[string]iotv1alpha1.DeviceService{}
+
+	// 1. list deviceServices on edge platform
+	eDevSs, err := ds.deviceServiceCli.List(context.TODO(), iotcli.ListOptions{Namespace: ds.Namespace})
+	if err != nil {
+		klog.V(4).ErrorS(err, "fail to list the deviceServices object on the edge platform")
+		return edgeDeviceServices, kubeDeviceServices, err
+	}
+	// 2. list deviceServices on OpenYurt (filter objects belonging to edgeServer)
+	var kDevSs iotv1alpha1.DeviceServiceList
+	listOptions := client.MatchingFields{util.IndexerPathForNodepool: ds.NodePool}
+	if err = ds.List(context.TODO(), &kDevSs, listOptions, client.InNamespace(ds.Namespace)); err != nil {
+		klog.V(4).ErrorS(err, "fail to list the deviceServices object on the Kubernetes")
+		return edgeDeviceServices, kubeDeviceServices, err
+	}
+	for i := range eDevSs {
+		deviceServicesName := util.GetEdgeDeviceServiceName(&eDevSs[i], EdgeXObjectName)
+		edgeDeviceServices[deviceServicesName] = eDevSs[i]
+	}
+
+	for i := range kDevSs.Items {
+		deviceServicesName := util.GetEdgeDeviceServiceName(&kDevSs.Items[i], EdgeXObjectName)
+		kubeDeviceServices[deviceServicesName] = kDevSs.Items[i]
+	}
+	return edgeDeviceServices, kubeDeviceServices, nil
+}
+
+// Get the list of deviceServices that need to be added, deleted and updated
+func (ds *DeviceServiceList) findDiffDeviceServices(
+	edgeDeviceService map[string]iotv1alpha1.DeviceService, kubeDeviceService map[string]iotv1alpha1.DeviceService) (
+	redundantEdgeDeviceServices map[string]*iotv1alpha1.DeviceService, redundantKubeDeviceServices map[string]*iotv1alpha1.DeviceService, syncedDeviceServices map[string]*iotv1alpha1.DeviceService) {
+
+	redundantEdgeDeviceServices = map[string]*iotv1alpha1.DeviceService{}
+	redundantKubeDeviceServices = map[string]*iotv1alpha1.DeviceService{}
+	syncedDeviceServices = map[string]*iotv1alpha1.DeviceService{}
+
+	for i := range edgeDeviceService {
+		eds := edgeDeviceService[i]
+		edName := util.GetEdgeDeviceServiceName(&eds, EdgeXObjectName)
+		if _, exists := kubeDeviceService[edName]; !exists {
+			redundantEdgeDeviceServices[edName] = ds.completeCreateContent(&eds)
+		} else {
+			kd := kubeDeviceService[edName]
+			syncedDeviceServices[edName] = ds.completeUpdateContent(&kd, &eds)
+		}
+	}
+
+	for i := range kubeDeviceService {
+		kds := kubeDeviceService[i]
+		if !kds.Status.Synced {
+			continue
+		}
+		kdName := util.GetEdgeDeviceServiceName(&kds, EdgeXObjectName)
+		if _, exists := edgeDeviceService[kdName]; !exists {
+			redundantKubeDeviceServices[kdName] = &kds
+		}
+	}
+	return
+}
+
+// syncEdgeToKube creates deviceServices on OpenYurt which are exists in edge platform but not in OpenYurt
+func (ds *DeviceServiceList) syncEdgeToKube(edgeDevs map[string]*iotv1alpha1.DeviceService) error {
+	for _, ed := range edgeDevs {
+		if err := ds.Client.Create(context.TODO(), ed); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				klog.V(5).InfoS("DeviceService already exist on Kubernetes",
+					"DeviceService", strings.ToLower(ed.Name))
+				continue
+			}
+			klog.InfoS("created deviceService failed:", "DeviceService", strings.ToLower(ed.Name))
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteDeviceServices deletes redundant deviceServices on OpenYurt
+func (ds *DeviceServiceList) deleteDeviceServices(redundantKubeDeviceServices map[string]*iotv1alpha1.DeviceService) error {
+	for _, kds := range redundantKubeDeviceServices {
+		if err := ds.Client.Delete(context.TODO(), kds); err != nil {
+			klog.V(5).ErrorS(err, "fail to delete the DeviceService on Kubernetes",
+				"DeviceService", kds.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// updateDeviceServices updates deviceServices status on OpenYurt
+func (ds *DeviceServiceList) updateDeviceServices(syncedDeviceServices map[string]*iotv1alpha1.DeviceService) error {
+	for _, sd := range syncedDeviceServices {
+		if sd.ObjectMeta.ResourceVersion == "" {
+			continue
+		}
+		if err := ds.Client.Status().Update(context.TODO(), sd); err != nil {
+			if apierrors.IsConflict(err) {
+				klog.V(5).InfoS("update Conflicts", "DeviceService", sd.Name)
+				continue
+			}
+			klog.V(5).ErrorS(err, "fail to update the DeviceService on Kubernetes",
+				"DeviceService", sd.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// completeCreateContent completes the content of the deviceService which will be created on OpenYurt
+func (ds *DeviceServiceList) completeCreateContent(edgeDS *iotv1alpha1.DeviceService) *iotv1alpha1.DeviceService {
+	createDevice := edgeDS.DeepCopy()
+	createDevice.Spec.NodePool = ds.NodePool
+	createDevice.Namespace = ds.Namespace
+	createDevice.Name = strings.Join([]string{ds.NodePool, edgeDS.Name}, "-")
+	createDevice.Spec.Managed = false
+	return createDevice
+}
+
+// completeUpdateContent completes the content of the deviceService which will be updated on OpenYurt
+func (ds *DeviceServiceList) completeUpdateContent(kubeDS *iotv1alpha1.DeviceService, edgeDS *iotv1alpha1.DeviceService) *iotv1alpha1.DeviceService {
+	updatedDS := kubeDS.DeepCopy()
+	// update device status
+	updatedDS.Status.LastConnected = edgeDS.Status.LastConnected
+	updatedDS.Status.LastReported = edgeDS.Status.LastReported
+	updatedDS.Status.AdminState = edgeDS.Status.AdminState
+	return updatedDS
+}
+
+// DeviceProfileList
+func (dps *DeviceProfileList) ProfileList() {
+
+	// 1. get deviceProfiles on edge platform and OpenYurt
+	edgeDeviceProfiles, kubeDeviceProfiles, err := dps.getAllDeviceProfiles()
+	if err != nil {
+		klog.V(3).ErrorS(err, "fail to list the deviceProfiles")
+	}
+
+	// 2. find the deviceProfiles that need to be synchronized
+	redundantEdgeDeviceProfiles, redundantKubeDeviceProfiles, syncedDeviceProfiles :=
+		dps.findDiffDeviceProfiles(edgeDeviceProfiles, kubeDeviceProfiles)
+	klog.V(2).Infof("[DeviceProfile] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
+		"Edge deviceProfiles should be added to OpenYurt", len(redundantEdgeDeviceProfiles),
+		"OpenYurt deviceProfiles that should be deleted", len(redundantKubeDeviceProfiles),
+		"DeviceProfiles that should be synchronized", len(syncedDeviceProfiles))
+
+	// 3. create deviceProfiles on OpenYurt which are exists in edge platform but not in OpenYurt
+	if err := dps.syncEdgeToKube(redundantEdgeDeviceProfiles); err != nil {
+		klog.V(3).ErrorS(err, "fail to create deviceProfiles on OpenYurt")
+	}
+
+	// 4. delete redundant deviceProfiles on OpenYurt
+	if err := dps.deleteDeviceProfiles(redundantKubeDeviceProfiles); err != nil {
+		klog.V(3).ErrorS(err, "fail to delete redundant deviceProfiles on OpenYurt")
+	}
+
+	// 5. update deviceProfiles on OpenYurt
+	// TODO
+
+}
+
+// Get the existing DeviceProfile on the Edge platform, as well as OpenYurt existing DeviceProfile
+// edgeDeviceProfiles：map[actualName]DeviceProfile
+// kubeDeviceProfiles：map[actualName]DeviceProfile
+func (dps *DeviceProfileList) getAllDeviceProfiles() (
+	map[string]iotv1alpha1.DeviceProfile, map[string]iotv1alpha1.DeviceProfile, error) {
+
+	edgeDeviceProfiles := map[string]iotv1alpha1.DeviceProfile{}
+	kubeDeviceProfiles := map[string]iotv1alpha1.DeviceProfile{}
+
+	// 1. list deviceProfiles on edge platform
+	eDps, err := dps.edgeClient.List(context.TODO(), devcli.ListOptions{Namespace: dps.Namespace})
+	if err != nil {
+		klog.V(4).ErrorS(err, "fail to list the deviceProfiles on the edge platform")
+		return edgeDeviceProfiles, kubeDeviceProfiles, err
+	}
+	// 2. list deviceProfiles on OpenYurt (filter objects belonging to edgeServer)
+	var kDps iotv1alpha1.DeviceProfileList
+	listOptions := client.MatchingFields{util.IndexerPathForNodepool: dps.NodePool}
+	if err = dps.List(context.TODO(), &kDps, listOptions, client.InNamespace(dps.Namespace)); err != nil {
+		klog.V(4).ErrorS(err, "fail to list the deviceProfiles on the Kubernetes")
+		return edgeDeviceProfiles, kubeDeviceProfiles, err
+	}
+	for i := range eDps {
+		deviceProfilesName := util.GetEdgeDeviceProfileName(&eDps[i], EdgeXObjectName)
+		edgeDeviceProfiles[deviceProfilesName] = eDps[i]
+	}
+
+	for i := range kDps.Items {
+		deviceProfilesName := util.GetEdgeDeviceProfileName(&kDps.Items[i], EdgeXObjectName)
+		kubeDeviceProfiles[deviceProfilesName] = kDps.Items[i]
+	}
+	return edgeDeviceProfiles, kubeDeviceProfiles, nil
+}
+
+// Get the list of deviceProfiles that need to be added, deleted and updated
+func (dps *DeviceProfileList) findDiffDeviceProfiles(
+	edgeDeviceProfiles map[string]iotv1alpha1.DeviceProfile, kubeDeviceProfiles map[string]iotv1alpha1.DeviceProfile) (
+	redundantEdgeDeviceProfiles map[string]*iotv1alpha1.DeviceProfile, redundantKubeDeviceProfiles map[string]*iotv1alpha1.DeviceProfile, syncedDeviceProfiles map[string]*iotv1alpha1.DeviceProfile) {
+
+	redundantEdgeDeviceProfiles = map[string]*iotv1alpha1.DeviceProfile{}
+	redundantKubeDeviceProfiles = map[string]*iotv1alpha1.DeviceProfile{}
+	syncedDeviceProfiles = map[string]*iotv1alpha1.DeviceProfile{}
+
+	for i := range edgeDeviceProfiles {
+		edp := edgeDeviceProfiles[i]
+		edpName := util.GetEdgeDeviceProfileName(&edp, EdgeXObjectName)
+		if _, exists := kubeDeviceProfiles[edpName]; !exists {
+			redundantEdgeDeviceProfiles[edpName] = dps.completeCreateContent(&edp)
+		} else {
+			kdp := kubeDeviceProfiles[edpName]
+			syncedDeviceProfiles[edpName] = dps.completeUpdateContent(&kdp, &edp)
+		}
+	}
+
+	for i := range kubeDeviceProfiles {
+		kdp := kubeDeviceProfiles[i]
+		if !kdp.Status.Synced {
+			continue
+		}
+		kdpName := util.GetEdgeDeviceProfileName(&kdp, EdgeXObjectName)
+		if _, exists := edgeDeviceProfiles[kdpName]; !exists {
+			redundantKubeDeviceProfiles[kdpName] = &kdp
+		}
+	}
+	return
+}
+
+// completeCreateContent completes the content of the deviceProfile which will be created on OpenYurt
+func (dps *DeviceProfileList) completeCreateContent(edgeDps *iotv1alpha1.DeviceProfile) *iotv1alpha1.DeviceProfile {
+	createDeviceProfile := edgeDps.DeepCopy()
+	createDeviceProfile.Namespace = dps.Namespace
+	createDeviceProfile.Name = strings.Join([]string{dps.NodePool, createDeviceProfile.Name}, "-")
+	createDeviceProfile.Spec.NodePool = dps.NodePool
+	return createDeviceProfile
+}
+
+// completeUpdateContent completes the content of the deviceProfile which will be updated on OpenYurt
+// TODO
+func (dps *DeviceProfileList) completeUpdateContent(kubeDps *iotv1alpha1.DeviceProfile, edgeDS *iotv1alpha1.DeviceProfile) *iotv1alpha1.DeviceProfile {
+	return kubeDps
+}
+
+// syncEdgeToKube creates deviceProfiles on OpenYurt which are exists in edge platform but not in OpenYurt
+func (dps *DeviceProfileList) syncEdgeToKube(edgeDps map[string]*iotv1alpha1.DeviceProfile) error {
+	for _, edp := range edgeDps {
+		if err := dps.Client.Create(context.TODO(), edp); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				klog.V(5).Infof("DeviceProfile already exist on Kubernetes: %s", strings.ToLower(edp.Name))
+				continue
+			}
+			klog.Infof("created deviceProfile failed: %s", strings.ToLower(edp.Name))
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteDeviceProfiles deletes redundant deviceProfiles on OpenYurt
+func (dps *DeviceProfileList) deleteDeviceProfiles(redundantKubeDeviceProfiles map[string]*iotv1alpha1.DeviceProfile) error {
+	for _, kdp := range redundantKubeDeviceProfiles {
+		if err := dps.Client.Delete(context.TODO(), kdp); err != nil {
+			klog.V(5).ErrorS(err, "fail to delete the DeviceProfile on Kubernetes: %s ",
+				"DeviceProfile", kdp.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+func (help *ListHelper) list() {
+	help.deviceServiceList.ServiceList()
+	help.deviceProfileList.ProfileList()
+}

--- a/pkg/yurtiotdock/controllers/util/health_checker.go
+++ b/pkg/yurtiotdock/controllers/util/health_checker.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
+)
+
+const (
+	Online  = iota // avalible
+	Offline        // async
+)
+
+type MessageBusHealthChecker struct {
+	messageBus        MessageBus
+	status            chan int32
+	heartbeatInterval int
+	NodePool          string
+	Namespace         string
+	Host              string
+	Name              string
+}
+
+func NewMessageBusHealthChecker(opts *options.YurtIoTDockOptions, msgBus MessageBus) (MessageBusHealthChecker, error) {
+
+	mbhc := MessageBusHealthChecker{
+		messageBus:        msgBus,
+		status:            make(chan int32, 1),
+		heartbeatInterval: opts.MessageBusOptions.HeartbeatInterval,
+		NodePool:          opts.Nodepool,
+		Namespace:         opts.Namespace,
+		Host:              opts.MessageBusOptions.Host,
+		Name:              opts.MessageBusOptions.Name,
+	}
+
+	return mbhc, nil
+}
+
+func (mbhc *MessageBusHealthChecker) Run(stopCh <-chan struct{}) {
+	intervalTicker := time.NewTicker(time.Duration(mbhc.heartbeatInterval) * time.Second)
+	defer intervalTicker.Stop()
+	defer close(mbhc.status)
+
+	for {
+		select {
+		case <-stopCh:
+			klog.V(2).Info("exit normally in health check loop.")
+			return
+		case <-intervalTicker.C:
+			if err := mbhc.messageBus.prepareMessageBus(); err != nil {
+				klog.V(3).ErrorS(err, "failed to prepare message bus")
+				mbhc.status <- Offline
+				return
+			}
+
+			mbhc.status <- Online
+		}
+	}
+}
+
+func (mbhc *MessageBusHealthChecker) StatusChan() chan int32 {
+	return mbhc.status
+}

--- a/pkg/yurtiotdock/controllers/util/messagebus.go
+++ b/pkg/yurtiotdock/controllers/util/messagebus.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/avast/retry-go"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	"github.com/edgexfoundry/go-mod-messaging/v3/messaging"
+	"github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
+)
+
+type MessageBus struct {
+	msgBusClient  messaging.MessageClient
+	Messages      chan types.MessageEnvelope
+	MessageErrors chan error
+}
+
+func NewMessageBus(opts *options.YurtIoTDockOptions) (MessageBus, error) {
+	msgClient, err := messaging.NewMessageClient(
+		types.MessageBusConfig{
+			Broker: types.HostInfo{
+				Host:     opts.MessageBusOptions.Host,
+				Port:     opts.MessageBusOptions.Port,
+				Protocol: opts.MessageBusOptions.Protocol,
+			},
+			Type: opts.MessageBusOptions.Type,
+		})
+
+	if err != nil {
+		klog.V(3).ErrorS(err, "failed to create messaging client")
+		return MessageBus{}, err
+	}
+
+	return MessageBus{
+		msgBusClient:  msgClient,
+		Messages:      make(chan types.MessageEnvelope, 1),
+		MessageErrors: make(chan error, 1),
+	}, nil
+}
+
+func (mb *MessageBus) prepareMessageBus() error {
+	// topic is like edgex/system-events/core-metadata/#
+	topics := []types.TopicChannel{
+		{
+			Topic:    common.BuildTopic(common.DefaultBaseTopic, common.SystemEventPublishTopic, common.CoreMetaDataServiceKey, "#"),
+			Messages: mb.Messages,
+		},
+	}
+
+	if err := mb.msgBusClient.Connect(); err != nil {
+		klog.V(3).ErrorS(err, "failed to connect to message bus")
+		return err
+	}
+
+	// make sure the messagebus is builded
+	err := retry.Do(
+		func() error {
+			err := mb.msgBusClient.Subscribe(topics, mb.MessageErrors)
+			if err != nil {
+				klog.V(3).ErrorS(err, "fail to subscribe the topic")
+			}
+			return err
+		},
+	)
+	return err
+}


### PR DESCRIPTION

#### What type of PR is this?
/sig iot
/kind feature

#### What this PR does / why we need it:
Since MessageBus is now the default inter-communication method for EdgeX, yurt-iot-dock should switch to MessageBus, and supports synchronization of message bus-driven metadata changes.

#### Which issue(s) this PR fixes:
Fixes #1799

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @LavenderQAQ
/assign @Rui-Gan

#### other Note
There are still the following issues to be resolved:
- Openyurt side supports CRUD based on message bus;
- Real-time asynchronous acquisition of device data;

```release-note
Example of Test
users:
# curl -X POST -H 'Content-Type: application/json'  \
http://edgex-core-metadata:59881/api/v3/device \
-d '[
         {
            "apiVersion": "v3",
            "device": {
               "name":"Camera",
               "serviceName": "device-rest",
               "profileName": "sample-numeric",
               "description": "My test camera",
               "adminState": "UNLOCKED",
               "operatingState": "UP",
               "protocols": {
                  "Onvif": {
                     "Address": "192.168.0.1",
                     "Port": "80",
                     "MACAddress": "xx:xx:xx:xx:xx:xx",
                     "FriendlyName":"Default Camera"
                  },
                  "CustomMetadata": {
                     "Location":"Front door"
                  }
               }
            }
         }
]'

openyurt:
# kubectl get device | grep camera
hangzhou-camera             hangzhou   true     5s

```
