### PR TITLE
fix: ensure local proxy can handle requests with the same path but with different selector

### DIFF
--- a/pkg/yurthub/cachemanager/cache_manager_test.go
+++ b/pkg/yurthub/cachemanager/cache_manager_test.go
@@ -3271,7 +3271,7 @@ func checkReqCanCache(m CacheManager, userAgent, verb, path string, header map[s
 	}
 	var reqCanCache bool
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		reqCanCache = m.CanCacheFor(req)
+		reqCanCache = m.CanCacheFor(req, CanCacheForRemote)
 
 	})
 

--- a/pkg/yurthub/proxy/local/local.go
+++ b/pkg/yurthub/proxy/local/local.go
@@ -214,7 +214,7 @@ func (lp *LocalProxy) localWatch(w http.ResponseWriter, req *http.Request) error
 
 // localReqCache handles Get/List/Update requests when remote servers are unhealthy
 func (lp *LocalProxy) localReqCache(w http.ResponseWriter, req *http.Request) error {
-	if !lp.cacheMgr.CanCacheFor(req) {
+	if !lp.cacheMgr.CanCacheFor(req, manager.CanCacheForLocal) {
 		klog.Errorf("can not cache for %s", hubutil.ReqString(req))
 		return apierrors.NewBadRequest(fmt.Sprintf("can not cache for %s", hubutil.ReqString(req)))
 	}

--- a/pkg/yurthub/proxy/pool/pool.go
+++ b/pkg/yurthub/proxy/pool/pool.go
@@ -262,7 +262,7 @@ func (pp *YurtCoordinatorProxy) modifyResponse(resp *http.Response) error {
 }
 
 func (pp *YurtCoordinatorProxy) cacheResponse(req *http.Request, resp *http.Response) {
-	if pp.localCacheMgr.CanCacheFor(req) {
+	if pp.localCacheMgr.CanCacheFor(req, cachemanager.CanCacheForLocal) {
 		ctx := req.Context()
 		req = req.WithContext(ctx)
 		wrapPrc, needUncompressed := hubutil.NewGZipReaderCloser(resp.Header, resp.Body, req, "cache-manager")

--- a/pkg/yurthub/proxy/remote/loadbalancer.go
+++ b/pkg/yurthub/proxy/remote/loadbalancer.go
@@ -238,7 +238,7 @@ func (lb *loadBalancer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 func (lb *loadBalancer) errorHandler(rw http.ResponseWriter, req *http.Request, err error) {
 	klog.Errorf("remote proxy error handler: %s, %v", hubutil.ReqString(req), err)
-	if lb.localCacheMgr == nil || !lb.localCacheMgr.CanCacheFor(req) {
+	if lb.localCacheMgr == nil || !lb.localCacheMgr.CanCacheFor(req, cachemanager.CanCacheForRemote) {
 		rw.WriteHeader(http.StatusBadGateway)
 		return
 	}
@@ -332,7 +332,7 @@ func (lb *loadBalancer) modifyResponse(resp *http.Response) error {
 }
 
 func (lb *loadBalancer) cacheResponse(req *http.Request, resp *http.Response) {
-	if lb.localCacheMgr.CanCacheFor(req) {
+	if lb.localCacheMgr.CanCacheFor(req, cachemanager.CanCacheForRemote) {
 		ctx := req.Context()
 		wrapPrc, needUncompressed := hubutil.NewGZipReaderCloser(resp.Header, resp.Body, req, "cache-manager")
 		// after gunzip in filter, the header content encoding should be removed.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
skip the check for the same path list requests, when the localproxy use the canCacheFor() method

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1963
