### PR TITLE
fix: deployment render should only mutate workloads created by yurtap…

### DIFF
--- a/pkg/yurtmanager/webhook/deploymentrender/v1alpha1/deploymentrender_default.go
+++ b/pkg/yurtmanager/webhook/deploymentrender/v1alpha1/deploymentrender_default.go
@@ -73,6 +73,9 @@ func (webhook *DeploymentRenderHandler) Default(ctx context.Context, obj runtime
 	var instance client.Object
 	switch app.Kind {
 	case "YurtAppSet":
+		if app.APIVersion != v1alpha1.SchemeGroupVersion.String() {
+			return nil
+		}
 		instance = &v1alpha1.YurtAppSet{}
 	case "YurtAppDaemon":
 		instance = &v1alpha1.YurtAppDaemon{}

--- a/pkg/yurtmanager/webhook/deploymentrender/v1alpha1/deploymentrender_webhook_test.go
+++ b/pkg/yurtmanager/webhook/deploymentrender/v1alpha1/deploymentrender_webhook_test.go
@@ -118,6 +118,45 @@ var defaultAppDaemon = &v1alpha1.YurtAppDaemon{
 	},
 }
 
+var deploymentByYasv1beta1 = &appsv1.Deployment{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test1",
+		Namespace: "default",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: "apps.openyurt.io/v1beta1",
+			Kind:       "YurtAppSet",
+			Name:       "yurtappset-patch",
+		}},
+		Labels: map[string]string{
+			"apps.openyurt.io/pool-name": "nodepool-test",
+		},
+	},
+	Status: appsv1.DeploymentStatus{},
+	Spec: appsv1.DeploymentSpec{
+		Replicas: &replica,
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "test",
+			},
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"app": "test",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx",
+					},
+				},
+			},
+		},
+	},
+}
+
 var defaultDeployment = &appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "test1",
@@ -326,6 +365,9 @@ func TestDeploymentRenderHandler_Default(t *testing.T) {
 				t.Fatal(err)
 			}
 			if err := webhook.Default(context.TODO(), daemonDeployment); err != nil {
+				t.Fatal(err)
+			}
+			if err := webhook.Default(context.TODO(), deploymentByYasv1beta1); err != nil {
 				t.Fatal(err)
 			}
 		})


### PR DESCRIPTION
…pset v1alpha1

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug
#### What this PR does / why we need it:
Yurtappset is updated to v1beta1. Now deployment render will mutate all workloads created by yurtappset. Actually, yurtappoverrider should only manage workloads created by yurtappset v1alpha1. Otherwise, it will cause unexpected errors. So we should add some restrictions to deployment webhook of yurtappoverrider.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
None
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
