### PR TITLE
fix panic: filter chain should be exited when object is nil

### DIFF
--- a/pkg/yurthub/filter/filter.go
+++ b/pkg/yurthub/filter/filter.go
@@ -293,6 +293,9 @@ func (chain filterChain) SupportedResourceAndVerbs() map[string]sets.String {
 func (chain filterChain) Filter(obj runtime.Object, stopCh <-chan struct{}) runtime.Object {
 	for i := range chain {
 		obj = chain[i].Filter(obj, stopCh)
+		if yurtutil.IsNil(obj) {
+			break
+		}
 	}
 
 	return obj


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:
when kube-proxy component list/watch LB service, filter `discardcloudservice` and `nodeportisolation` will be selected to create filter chain. if `discardcloudservice` filter returns a nil object, it will cause panic in `nodeportisolation` filter.

so we need to exit filter chain if object is nil.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
