### PR TITLE
move list object handling from ObjectFilter into ResponseFilter

### DIFF
--- a/pkg/yurthub/filter/discardcloudservice/filter.go
+++ b/pkg/yurthub/filter/discardcloudservice/filter.go
@@ -70,16 +70,6 @@ func (sf *discardCloudServiceFilter) SupportedResourceAndVerbs() map[string]sets
 
 func (sf *discardCloudServiceFilter) Filter(obj runtime.Object, _ <-chan struct{}) runtime.Object {
 	switch v := obj.(type) {
-	case *v1.ServiceList:
-		var svcNew []v1.Service
-		for i := range v.Items {
-			svc := discardCloudService(&v.Items[i])
-			if svc != nil {
-				svcNew = append(svcNew, *svc)
-			}
-		}
-		v.Items = svcNew
-		return v
 	case *v1.Service:
 		return discardCloudService(v)
 	default:

--- a/pkg/yurthub/filter/discardcloudservice/filter_test.go
+++ b/pkg/yurthub/filter/discardcloudservice/filter_test.go
@@ -26,7 +26,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openyurtio/openyurt/pkg/util"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter/base"
 )
+
+func TestRegister(t *testing.T) {
+	filters := base.NewFilters([]string{})
+	Register(filters)
+	if !filters.Enabled(FilterName) {
+		t.Errorf("couldn't register %s filter", FilterName)
+	}
+}
 
 func TestName(t *testing.T) {
 	dcsf, _ := NewDiscardCloudServiceFilter()
@@ -58,175 +67,6 @@ func TestFilter(t *testing.T) {
 		responseObj runtime.Object
 		expectObj   runtime.Object
 	}{
-		"discard lb service for serviceList": {
-			responseObj: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-							Annotations: map[string]string{
-								DiscardServiceAnnotation: "true",
-							},
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.187",
-							Type:      corev1.ServiceTypeLoadBalancer,
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2",
-							Namespace: "default",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Type:      corev1.ServiceTypeClusterIP,
-						},
-					},
-				},
-			},
-			expectObj: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2",
-							Namespace: "default",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Type:      corev1.ServiceTypeClusterIP,
-						},
-					},
-				},
-			},
-		},
-		"discard cloud clusterIP service for serviceList": {
-			responseObj: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "x-tunnel-server-internal-svc",
-							Namespace: "kube-system",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.187",
-							Type:      corev1.ServiceTypeLoadBalancer,
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2",
-							Namespace: "default",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Type:      corev1.ServiceTypeClusterIP,
-						},
-					},
-				},
-			},
-			expectObj: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2",
-							Namespace: "default",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Type:      corev1.ServiceTypeClusterIP,
-						},
-					},
-				},
-			},
-		},
-		"doesn't discard service for serviceList": {
-			responseObj: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-							Annotations: map[string]string{
-								DiscardServiceAnnotation: "false",
-							},
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.187",
-							Type:      corev1.ServiceTypeLoadBalancer,
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2",
-							Namespace: "default",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Type:      corev1.ServiceTypeClusterIP,
-						},
-					},
-				},
-			},
-			expectObj: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-							Annotations: map[string]string{
-								DiscardServiceAnnotation: "false",
-							},
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.187",
-							Type:      corev1.ServiceTypeLoadBalancer,
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2",
-							Namespace: "default",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Type:      corev1.ServiceTypeClusterIP,
-						},
-					},
-				},
-			},
-		},
-		"discard all services for serviceList": {
-			responseObj: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-							Annotations: map[string]string{
-								DiscardServiceAnnotation: "true",
-							},
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.187",
-							Type:      corev1.ServiceTypeLoadBalancer,
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "x-tunnel-server-internal-svc",
-							Namespace: "kube-system",
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Type:      corev1.ServiceTypeClusterIP,
-						},
-					},
-				},
-			},
-			expectObj: &corev1.ServiceList{},
-		},
 		"discard lb service": {
 			responseObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/yurthub/filter/inclusterconfig/filter.go
+++ b/pkg/yurthub/filter/inclusterconfig/filter.go
@@ -65,15 +65,6 @@ func (iccf *inClusterConfigFilter) SupportedResourceAndVerbs() map[string]sets.S
 
 func (iccf *inClusterConfigFilter) Filter(obj runtime.Object, _ <-chan struct{}) runtime.Object {
 	switch v := obj.(type) {
-	case *v1.ConfigMapList:
-		for i := range v.Items {
-			newCM, mutated := mutateKubeProxyConfigMap(&v.Items[i])
-			if mutated {
-				v.Items[i] = *newCM
-				break
-			}
-		}
-		return v
 	case *v1.ConfigMap:
 		cm, _ := mutateKubeProxyConfigMap(v)
 		return cm

--- a/pkg/yurthub/filter/inclusterconfig/filter_test.go
+++ b/pkg/yurthub/filter/inclusterconfig/filter_test.go
@@ -26,7 +26,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openyurtio/openyurt/pkg/util"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter/base"
 )
+
+func TestRegister(t *testing.T) {
+	filters := base.NewFilters([]string{})
+	Register(filters)
+	if !filters.Enabled(FilterName) {
+		t.Errorf("couldn't register %s filter", FilterName)
+	}
+}
 
 func TestName(t *testing.T) {
 	iccf, _ := NewInClusterConfigFilter()
@@ -97,52 +106,6 @@ func TestRuntimeObjectFilter(t *testing.T) {
 				},
 				Data: map[string]string{
 					"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
-				},
-			},
-		},
-		"configmapList with kube-proxy configmap": {
-			responseObject: &v1.ConfigMapList{
-				Items: []v1.ConfigMap{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "foo",
-							Namespace: "default",
-						},
-						Data: map[string]string{
-							"foo": "bar",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      KubeProxyConfigMapName,
-							Namespace: KubeProxyConfigMapNamespace,
-						},
-						Data: map[string]string{
-							"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
-						},
-					},
-				},
-			},
-			expectObject: &v1.ConfigMapList{
-				Items: []v1.ConfigMap{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "foo",
-							Namespace: "default",
-						},
-						Data: map[string]string{
-							"foo": "bar",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      KubeProxyConfigMapName,
-							Namespace: KubeProxyConfigMapNamespace,
-						},
-						Data: map[string]string{
-							"config.conf": "    apiVersion: kubeproxy.config.k8s.io/v1alpha1\n    bindAddress: 0.0.0.0\n    bindAddressHardFail: false\n    clientConnection:\n      acceptContentTypes: \"\"\n      burst: 0\n      contentType: \"\"\n      #kubeconfig: /var/lib/kube-proxy/kubeconfig.conf\n      qps: 0\n    clusterCIDR: 10.244.0.0/16\n    configSyncPeriod: 0s",
-						},
-					},
 				},
 			},
 		},

--- a/pkg/yurthub/filter/interfaces.go
+++ b/pkg/yurthub/filter/interfaces.go
@@ -47,8 +47,7 @@ type ResponseFilter interface {
 }
 
 // ObjectFilter is used for filtering runtime object.
-// runtime object includes List object(like ServiceList) that has multiple items and
-// Standalone object(like Service).
+// runtime object is only a standalone object(like Service).
 // Every Filter need to implement ObjectFilter interface.
 type ObjectFilter interface {
 	Name() string

--- a/pkg/yurthub/filter/masterservice/filter.go
+++ b/pkg/yurthub/filter/masterservice/filter.go
@@ -81,15 +81,6 @@ func (msf *masterServiceFilter) SetMasterServicePort(portStr string) error {
 
 func (msf *masterServiceFilter) Filter(obj runtime.Object, _ <-chan struct{}) runtime.Object {
 	switch v := obj.(type) {
-	case *v1.ServiceList:
-		for i := range v.Items {
-			mutated := msf.mutateMasterService(&v.Items[i])
-			if mutated {
-				// short-circuit break
-				break
-			}
-		}
-		return v
 	case *v1.Service:
 		msf.mutateMasterService(v)
 		return v
@@ -109,7 +100,7 @@ func (msf *masterServiceFilter) mutateMasterService(svc *v1.Service) bool {
 				break
 			}
 		}
-		klog.V(2).Infof("mutate master service with ClusterIP:Port=%s:%d", msf.host, msf.port)
+		klog.Infof("mutate master service with ClusterIP:Port=%s:%d", msf.host, msf.port)
 	}
 	return mutated
 }

--- a/pkg/yurthub/filter/masterservice/filter_test.go
+++ b/pkg/yurthub/filter/masterservice/filter_test.go
@@ -26,7 +26,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openyurtio/openyurt/pkg/util"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter/base"
 )
+
+func TestRegister(t *testing.T) {
+	filters := base.NewFilters([]string{})
+	Register(filters)
+	if !filters.Enabled(FilterName) {
+		t.Errorf("couldn't register %s filter", FilterName)
+	}
+}
 
 func TestName(t *testing.T) {
 	msf, _ := NewMasterServiceFilter()
@@ -63,112 +72,6 @@ func TestFilter(t *testing.T) {
 		responseObject runtime.Object
 		expectObject   runtime.Object
 	}{
-		"serviceList contains kubernetes service": {
-			responseObject: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      MasterServiceName,
-							Namespace: MasterServiceNamespace,
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.0.1",
-							Ports: []corev1.ServicePort{
-								{
-									Port: 443,
-									Name: MasterServicePortName,
-								},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: MasterServiceNamespace,
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Ports: []corev1.ServicePort{
-								{
-									Port: 80,
-								},
-							},
-						},
-					},
-				},
-			},
-			expectObject: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      MasterServiceName,
-							Namespace: MasterServiceNamespace,
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: masterServiceHost,
-							Ports: []corev1.ServicePort{
-								{
-									Port: masterServicePort,
-									Name: MasterServicePortName,
-								},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: MasterServiceNamespace,
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Ports: []corev1.ServicePort{
-								{
-									Port: 80,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"serviceList does not contain kubernetes service": {
-			responseObject: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: MasterServiceNamespace,
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Ports: []corev1.ServicePort{
-								{
-									Port: 80,
-								},
-							},
-						},
-					},
-				},
-			},
-			expectObject: &corev1.ServiceList{
-				Items: []corev1.Service{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: MasterServiceNamespace,
-						},
-						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
-							Ports: []corev1.ServicePort{
-								{
-									Port: 80,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 		"it's a kubernetes service": {
 			responseObject: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/yurthub/filter/nodeportisolation/filter.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter.go
@@ -85,16 +85,6 @@ func (nif *nodePortIsolationFilter) SetKubeClient(client kubernetes.Interface) e
 
 func (nif *nodePortIsolationFilter) Filter(obj runtime.Object, stopCh <-chan struct{}) runtime.Object {
 	switch v := obj.(type) {
-	case *v1.ServiceList:
-		var svcNew []v1.Service
-		for i := range v.Items {
-			svc := nif.isolateNodePortService(&v.Items[i])
-			if svc != nil {
-				svcNew = append(svcNew, *svc)
-			}
-		}
-		v.Items = svcNew
-		return v
 	case *v1.Service:
 		return nif.isolateNodePortService(v)
 	default:

--- a/pkg/yurthub/filter/servicetopology/filter.go
+++ b/pkg/yurthub/filter/servicetopology/filter.go
@@ -130,22 +130,6 @@ func (stf *serviceTopologyFilter) Filter(obj runtime.Object, stopCh <-chan struc
 	}
 
 	switch v := obj.(type) {
-	case *discoveryV1beta1.EndpointSliceList:
-		// filter endpointSlice before k8s 1.21
-		for i := range v.Items {
-			stf.serviceTopologyHandler(&v.Items[i])
-		}
-		return v
-	case *discovery.EndpointSliceList:
-		for i := range v.Items {
-			stf.serviceTopologyHandler(&v.Items[i])
-		}
-		return v
-	case *v1.EndpointsList:
-		for i := range v.Items {
-			stf.serviceTopologyHandler(&v.Items[i])
-		}
-		return v
 	case *v1.Endpoints, *discoveryV1beta1.EndpointSlice, *discovery.EndpointSlice:
 		return stf.serviceTopologyHandler(v)
 	default:

--- a/pkg/yurthub/filter/servicetopology/filter_test.go
+++ b/pkg/yurthub/filter/servicetopology/filter_test.go
@@ -38,12 +38,21 @@ import (
 	"github.com/openyurtio/openyurt/pkg/apis/apps/v1beta1"
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
 	"github.com/openyurtio/openyurt/pkg/util"
+	"github.com/openyurtio/openyurt/pkg/yurthub/filter/base"
 	"github.com/openyurtio/openyurt/pkg/yurthub/filter/initializer"
 )
 
 const (
 	LabelNodePoolName = "openyurt.io/pool-name"
 )
+
+func TestRegister(t *testing.T) {
+	filters := base.NewFilters([]string{})
+	Register(filters)
+	if !filters.Enabled(FilterName) {
+		t.Errorf("couldn't register %s filter", FilterName)
+	}
+}
 
 func TestName(t *testing.T) {
 	stf, _ := NewServiceTopologyFilter()
@@ -93,51 +102,47 @@ func TestFilter(t *testing.T) {
 		yurtClient                *fake.FakeDynamicClient
 		expectObject              runtime.Object
 	}{
-		"v1beta1.EndpointSliceList: topologyKeys is kubernetes.io/hostname": {
+		"v1beta1.EndpointSlice: topologyKeys is kubernetes.io/hostname": {
 			poolName: "hangzhou",
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
+			responseObject: &discoveryV1beta1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
+						Addresses: []string{
+							"10.244.1.2",
 						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
 						},
 					},
 				},
@@ -206,2963 +211,904 @@ func TestFilter(t *testing.T) {
 					},
 				},
 			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
+			expectObject: &discoveryV1beta1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
+						Addresses: []string{
+							"10.244.1.2",
 						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
 						},
 					},
 				},
 			},
 		},
-		"v1beta1.EndpointSliceList: topologyKeys is openyurt.io/nodepool": {
+		"v1beta1.EndpointSlice: topologyKeys is openyurt.io/nodepool": {
 			enableNodePool: true,
 			poolName:       "hangzhou",
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1beta1.EndpointSliceList: topologyKeys is kubernetes.io/zone": {
-			enableNodePool: true,
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueZone,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1beta1.EndpointSliceList: without openyurt.io/topologyKeys": {
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "svc1",
-						Namespace:   "default",
-						Annotations: map[string]string{},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1beta1.EndpointSliceList: currentNode is not in any nodepool": {
-			enableNodePool: true,
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   currentNodeName,
-						Labels: map[string]string{},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1beta1.EndpointSliceList: currentNode has no endpoints on node": {
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName2,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName3,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1beta1.EndpointSliceList: currentNode has no endpoints in nodepool": {
-			enableNodePool: true,
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName2,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName3,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1beta1.EndpointSliceList: no service info in endpointslice": {
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName2,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName3,
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName2,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: nodeName3,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointSliceList: topologyKeys is kubernetes.io/hostname": {
-			responseObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointSliceList: topologyKeys is openyurt.io/nodepool": {
-			enableNodePool: true,
-			responseObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointSliceList: topologyKeys is kubernetes.io/zone": {
-			enableNodePool: true,
-			responseObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueZone,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointSliceList: without openyurt.io/topologyKeys": {
-			responseObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "svc1",
-						Namespace:   "default",
-						Annotations: map[string]string{},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointSliceList: currentNode is not in any nodepool": {
-			enableNodePool: true,
-			responseObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   currentNodeName,
-						Labels: map[string]string{},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								NodeName: &currentNodeName,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								NodeName: &currentNodeName,
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointSliceList: currentNode has no endpoints on node": {
-			responseObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-							"node3",
-						},
-					},
-				},
-			),
-			expectObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointSliceList: currentNode has no endpoints in nodePool": {
-			enableNodePool: true,
-			responseObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								NodeName: &nodeName2,
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								NodeName: &nodeName3,
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-							"node3",
-						},
-					},
-				},
-			),
-			expectObject: &discovery.EndpointSliceList{
-				Items: []discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: topologyKeys is kubernetes.io/hostname": {
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: topologyKeys is openyurt.io/nodepool": {
-			enableNodePool: true,
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: topologyKeys is kubernetes.io/zone": {
-			enableNodePool: true,
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueZone,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: without openyurt.io/topologyKeys": {
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "svc1",
-						Namespace:   "default",
-						Annotations: map[string]string{},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: currentNode is not in any nodepool": {
-			enableNodePool: true,
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   currentNodeName,
-						Labels: map[string]string{},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node3",
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.2",
-										NodeName: &currentNodeName,
-									},
-									{
-										IP:       "10.244.1.4",
-										NodeName: &currentNodeName,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: currentNode has no endpoints on node": {
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-							"node3",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: currentNode has no endpoints in nodepool": {
-			enableNodePool: true,
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-							"node3",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-					},
-				},
-			},
-		},
-		"v1.EndpointsList: unknown openyurt.io/topologyKeys": {
-			responseObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: "unknown topology",
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							currentNodeName,
-						},
-					},
-				},
-				&v1beta1.NodePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-					},
-					Spec: v1beta1.NodePoolSpec{
-						Type: v1beta1.Edge,
-					},
-					Status: v1beta1.NodePoolStatus{
-						Nodes: []string{
-							"node2",
-							"node3",
-						},
-					},
-				},
-			),
-			expectObject: &corev1.EndpointsList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "EndpointsList",
-					APIVersion: "v1",
-				},
-				Items: []corev1.Endpoints{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1",
-							Namespace: "default",
-						},
-						Subsets: []corev1.EndpointSubset{
-							{
-								Addresses: []corev1.EndpointAddress{
-									{
-										IP:       "10.244.1.3",
-										NodeName: &nodeName2,
-									},
-									{
-										IP:       "10.244.1.5",
-										NodeName: &nodeName3,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"v1.Pod: un-recognized object for filter": {
-			responseObject: &corev1.Pod{
+			responseObject: &discoveryV1beta1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+		},
+		"v1beta1.EndpointSlice: topologyKeys is kubernetes.io/zone": {
+			enableNodePool: true,
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueZone,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+		},
+		"v1beta1.EndpointSlice: without openyurt.io/topologyKeys": {
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "svc1",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+		},
+		"v1beta1.EndpointSlice: currentNode is not in any nodepool": {
+			enableNodePool: true,
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   currentNodeName,
+						Labels: map[string]string{},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+				},
+			},
+		},
+		"v1beta1.EndpointSlice: currentNode has no endpoints on node": {
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName2,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName3,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+			},
+		},
+		"v1beta1.EndpointSlice: currentNode has no endpoints in nodepool": {
+			enableNodePool: true,
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName2,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName3,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+			},
+		},
+		"v1beta1.EndpointSlice: no service info in endpointslice": {
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
 					Namespace: "default",
 				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName2,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName3,
+						},
+					},
+				},
 			},
 			kubeClient: k8sfake.NewSimpleClientset(
 				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: currentNodeName,
 						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
+							projectinfo.GetNodePoolLabel(): "shanghai",
 						},
 					},
 				},
@@ -3170,7 +1116,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node2",
 						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
+							projectinfo.GetNodePoolLabel(): "hangzhou",
 						},
 					},
 				},
@@ -3178,7 +1124,7 @@ func TestFilter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node3",
 						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
+							projectinfo.GetNodePoolLabel(): "hangzhou",
 						},
 					},
 				},
@@ -3187,7 +1133,7 @@ func TestFilter(t *testing.T) {
 						Name:      "svc1",
 						Namespace: "default",
 						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: "unknown topology",
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
 						},
 					},
 				},
@@ -3202,7 +1148,8 @@ func TestFilter(t *testing.T) {
 					},
 					Status: v1beta1.NodePoolStatus{
 						Nodes: []string{
-							currentNodeName,
+							"node2",
+							"node3",
 						},
 					},
 				},
@@ -3215,336 +1162,48 @@ func TestFilter(t *testing.T) {
 					},
 					Status: v1beta1.NodePoolStatus{
 						Nodes: []string{
-							"node2",
-							"node3",
+							currentNodeName,
 						},
 					},
 				},
 			),
-			expectObject: &corev1.Pod{
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
+					Name:      "svc1-np7sf",
 					Namespace: "default",
 				},
-			},
-		},
-		"v1beta1.EndpointSliceList use node bucket: topologyKeys is openyurt.io/nodepool": {
-			enablePoolServiceTopology: true,
-			poolName:                  "hangzhou",
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
+				Endpoints: []discoveryV1beta1.Endpoint{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
+						Addresses: []string{
+							"10.244.1.2",
 						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
 						},
 					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, nodeBucketGVRToListKind,
-				&v1alpha1.NodeBucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou",
-						Labels: map[string]string{
-							LabelNodePoolName: "hangzhou",
-						},
-					},
-					Nodes: []v1alpha1.Node{
-						{
-							Name: currentNodeName,
-						},
-						{
-							Name: "node3",
-						},
-					},
-				},
-				&v1alpha1.NodeBucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-						Labels: map[string]string{
-							LabelNodePoolName: "shanghai",
-						},
-					},
-					Nodes: []v1alpha1.Node{
-						{
-							Name: "node2",
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
+						Addresses: []string{
+							"10.244.1.3",
 						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName2,
 						},
 					},
-				},
-			},
-		},
-		"v1beta1.EndpointSliceList use multiple node buckets: topologyKeys is openyurt.io/nodepool": {
-			enablePoolServiceTopology: true,
-			poolName:                  "hangzhou",
-			responseObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
+						Addresses: []string{
+							"10.244.1.4",
 						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.3",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node2",
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
 						},
 					},
-				},
-			},
-			kubeClient: k8sfake.NewSimpleClientset(
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: currentNodeName,
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node2",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "shanghai",
-						},
-					},
-				},
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node3",
-						Labels: map[string]string{
-							projectinfo.GetNodePoolLabel(): "hangzhou",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "svc1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
-						},
-					},
-				},
-			),
-			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, nodeBucketGVRToListKind,
-				&v1alpha1.NodeBucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou-foo",
-						Labels: map[string]string{
-							LabelNodePoolName: "hangzhou",
-						},
-					},
-					Nodes: []v1alpha1.Node{
-						{
-							Name: currentNodeName,
-						},
-					},
-				},
-				&v1alpha1.NodeBucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "hangzhou-bar",
-						Labels: map[string]string{
-							LabelNodePoolName: "hangzhou",
-						},
-					},
-					Nodes: []v1alpha1.Node{
-						{
-							Name: "node3",
-						},
-					},
-				},
-				&v1alpha1.NodeBucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "shanghai",
-						Labels: map[string]string{
-							LabelNodePoolName: "shanghai",
-						},
-					},
-					Nodes: []v1alpha1.Node{
-						{
-							Name: "node2",
-						},
-					},
-				},
-			),
-			expectObject: &discoveryV1beta1.EndpointSliceList{
-				Items: []discoveryV1beta1.EndpointSlice{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-np7sf",
-							Namespace: "default",
-							Labels: map[string]string{
-								discoveryV1beta1.LabelServiceName: "svc1",
-							},
+						Addresses: []string{
+							"10.244.1.5",
 						},
-						Endpoints: []discoveryV1beta1.Endpoint{
-							{
-								Addresses: []string{
-									"10.244.1.2",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.4",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: currentNodeName,
-								},
-							},
-							{
-								Addresses: []string{
-									"10.244.1.5",
-								},
-								Topology: map[string]string{
-									corev1.LabelHostname: "node3",
-								},
-							},
+						Topology: map[string]string{
+							corev1.LabelHostname: nodeName3,
 						},
 					},
 				},
@@ -3651,6 +1310,7 @@ func TestFilter(t *testing.T) {
 				},
 			),
 			expectObject: &discovery.EndpointSlice{
+
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1-np7sf",
 					Namespace: "default",
@@ -3670,6 +1330,1999 @@ func TestFilter(t *testing.T) {
 							"10.244.1.4",
 						},
 						NodeName: &currentNodeName,
+					},
+				},
+			},
+		},
+		"v1.EndpointSlice: topologyKeys is openyurt.io/nodepool": {
+			enableNodePool: true,
+			responseObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+		},
+		"v1.EndpointSlice: topologyKeys is kubernetes.io/zone": {
+			enableNodePool: true,
+			responseObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueZone,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+		},
+		"v1.EndpointSlice: without openyurt.io/topologyKeys": {
+			responseObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "svc1",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+		},
+		"v1.EndpointSlice: currentNode is not in any nodepool": {
+			enableNodePool: true,
+			responseObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   currentNodeName,
+						Labels: map[string]string{},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						NodeName: &currentNodeName,
+					},
+				},
+			},
+		},
+		"v1.EndpointSlice: currentNode has no endpoints on node": {
+			responseObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+							"node3",
+						},
+					},
+				},
+			),
+			expectObject: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+			},
+		},
+		"v1.EndpointSlice: currentNode has no endpoints in nodePool": {
+			enableNodePool: true,
+			responseObject: &discovery.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+							"node3",
+						},
+					},
+				},
+			),
+			expectObject: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+			},
+		},
+		"v1.Endpoints: topologyKeys is kubernetes.io/hostname": {
+			responseObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+						},
+					},
+				},
+			},
+		},
+		"v1.Endpoints: topologyKeys is openyurt.io/nodepool": {
+			enableNodePool: true,
+			responseObject: &corev1.Endpoints{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+		},
+		"v1.Endpoints: topologyKeys is kubernetes.io/zone": {
+			enableNodePool: true,
+			responseObject: &corev1.Endpoints{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueZone,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+		},
+		"v1.Endpoints: without openyurt.io/topologyKeys": {
+			responseObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "svc1",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+		},
+		"v1.Endpoints: currentNode is not in any nodepool": {
+			enableNodePool: true,
+			responseObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   currentNodeName,
+						Labels: map[string]string{},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node3",
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.2",
+								NodeName: &currentNodeName,
+							},
+							{
+								IP:       "10.244.1.4",
+								NodeName: &currentNodeName,
+							},
+						},
+					},
+				},
+			},
+		},
+		"v1.Endpoints: currentNode has no endpoints on node": {
+			responseObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+							"node3",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+			},
+		},
+		"v1.Endpoints: currentNode has no endpoints in nodepool": {
+			enableNodePool: true,
+			responseObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+							"node3",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+			},
+		},
+		"v1.Endpoints: unknown openyurt.io/topologyKeys": {
+			responseObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: "unknown topology",
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+							"node3",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP:       "10.244.1.3",
+								NodeName: &nodeName2,
+							},
+							{
+								IP:       "10.244.1.5",
+								NodeName: &nodeName3,
+							},
+						},
+					},
+				},
+			},
+		},
+		"v1.Pod: un-recognized object for filter": {
+			responseObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: "unknown topology",
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+						},
+					},
+				},
+				&v1beta1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta1.NodePoolSpec{
+						Type: v1beta1.Edge,
+					},
+					Status: v1beta1.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+							"node3",
+						},
+					},
+				},
+			),
+			expectObject: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+			},
+		},
+		"v1beta1.EndpointSlice use node bucket: topologyKeys is openyurt.io/nodepool": {
+			enablePoolServiceTopology: true,
+			poolName:                  "hangzhou",
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, nodeBucketGVRToListKind,
+				&v1alpha1.NodeBucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+						Labels: map[string]string{
+							LabelNodePoolName: "hangzhou",
+						},
+					},
+					Nodes: []v1alpha1.Node{
+						{
+							Name: currentNodeName,
+						},
+						{
+							Name: "node3",
+						},
+					},
+				},
+				&v1alpha1.NodeBucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+						Labels: map[string]string{
+							LabelNodePoolName: "shanghai",
+						},
+					},
+					Nodes: []v1alpha1.Node{
+						{
+							Name: "node2",
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+		},
+		"v1beta1.EndpointSlice use multiple node buckets: topologyKeys is openyurt.io/nodepool": {
+			enablePoolServiceTopology: true,
+			poolName:                  "hangzhou",
+			responseObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node2",
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, nodeBucketGVRToListKind,
+				&v1alpha1.NodeBucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou-foo",
+						Labels: map[string]string{
+							LabelNodePoolName: "hangzhou",
+						},
+					},
+					Nodes: []v1alpha1.Node{
+						{
+							Name: currentNodeName,
+						},
+					},
+				},
+				&v1alpha1.NodeBucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou-bar",
+						Labels: map[string]string{
+							LabelNodePoolName: "hangzhou",
+						},
+					},
+					Nodes: []v1alpha1.Node{
+						{
+							Name: "node3",
+						},
+					},
+				},
+				&v1alpha1.NodeBucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+						Labels: map[string]string{
+							LabelNodePoolName: "shanghai",
+						},
+					},
+					Nodes: []v1alpha1.Node{
+						{
+							Name: "node2",
+						},
+					},
+				},
+			),
+			expectObject: &discoveryV1beta1.EndpointSlice{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discoveryV1beta1.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discoveryV1beta1.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.4",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: currentNodeName,
+						},
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						Topology: map[string]string{
+							corev1.LabelHostname: "node3",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind feature

#### What this PR does / why we need it:
Move list object handling in every ObjectFilter(like masterservice, servicetopology, etc.) into `ResponseFilter`, so each ObjectFilter only need to handle single object.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1990 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
