### PR TITLE
return back watch.Deleted event to clients when watch object is removed in OjbectFilters

### DIFF
--- a/pkg/yurthub/filter/inclusterconfig/filter.go
+++ b/pkg/yurthub/filter/inclusterconfig/filter.go
@@ -66,17 +66,16 @@ func (iccf *inClusterConfigFilter) SupportedResourceAndVerbs() map[string]sets.S
 func (iccf *inClusterConfigFilter) Filter(obj runtime.Object, _ <-chan struct{}) runtime.Object {
 	switch v := obj.(type) {
 	case *v1.ConfigMap:
-		cm, _ := mutateKubeProxyConfigMap(v)
-		return cm
+		return mutateKubeProxyConfigMap(v)
 	default:
 		return v
 	}
 }
 
-func mutateKubeProxyConfigMap(cm *v1.ConfigMap) (*v1.ConfigMap, bool) {
-	mutated := false
+func mutateKubeProxyConfigMap(cm *v1.ConfigMap) *v1.ConfigMap {
 	if cm.Namespace == KubeProxyConfigMapNamespace && cm.Name == KubeProxyConfigMapName {
 		if cm.Data != nil && len(cm.Data[KubeProxyDataKey]) != 0 {
+			mutated := false
 			parts := make([]string, 0)
 			for _, line := range strings.Split(cm.Data[KubeProxyDataKey], "\n") {
 				items := strings.Split(strings.Trim(line, " "), ":")
@@ -94,5 +93,5 @@ func mutateKubeProxyConfigMap(cm *v1.ConfigMap) (*v1.ConfigMap, bool) {
 		}
 	}
 
-	return cm, mutated
+	return cm
 }

--- a/pkg/yurthub/filter/masterservice/filter.go
+++ b/pkg/yurthub/filter/masterservice/filter.go
@@ -89,10 +89,8 @@ func (msf *masterServiceFilter) Filter(obj runtime.Object, _ <-chan struct{}) ru
 	}
 }
 
-func (msf *masterServiceFilter) mutateMasterService(svc *v1.Service) bool {
-	mutated := false
+func (msf *masterServiceFilter) mutateMasterService(svc *v1.Service) {
 	if svc.Namespace == MasterServiceNamespace && svc.Name == MasterServiceName {
-		mutated = true
 		svc.Spec.ClusterIP = msf.host
 		for j := range svc.Spec.Ports {
 			if svc.Spec.Ports[j].Name == MasterServicePortName {
@@ -102,5 +100,4 @@ func (msf *masterServiceFilter) mutateMasterService(svc *v1.Service) bool {
 		}
 		klog.Infof("mutate master service with ClusterIP:Port=%s:%d", msf.host, msf.port)
 	}
-	return mutated
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind feature

#### What this PR does / why we need it:
ResponseFilter return `watch.Deleted` event back to clients when Standalone object is filtered to nil in ObjectFilters.

by the way, this feature will be helpful for all ObjectFilters, not only for `nodeportisolation` filter.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1994 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
