### PR TITLE
fix: edgex component creation cause registration errors and core-command crash

### DIFF
--- a/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config-nosecty.json
+++ b/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config-nosecty.json
@@ -12,31 +12,31 @@
             ],
             "components": [
                 {
-                    "name": "edgex-support-scheduler",
+                    "name": "edgex-kuiper",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59861",
+                                "name": "tcp-59720",
                                 "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                                "port": 59720,
+                                "targetPort": 59720
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-scheduler"
+                            "app": "edgex-kuiper"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-kuiper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
+                                    "app": "edgex-kuiper"
                                 }
                             },
                             "spec": {
@@ -47,353 +47,32 @@
                                             "path": "/etc/localtime",
                                             "type": "DirectoryOrCreate"
                                         }
-                                    }
-                                ],
-                                "containers": [
+                                    },
                                     {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
                                     {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
+                                        "name": "kuiper-etc",
+                                        "emptyDir": {}
+                                    },
                                     {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "EXTERNALMQTT_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    },
                                     {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "openyurt/core-metadata:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
+                                        "name": "kuiper-plugins",
                                         "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:7.0.14-alpine",
+                                        "name": "edgex-kuiper",
+                                        "image": "openyurt/ekuiper:1.11.4-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -404,20 +83,87 @@
                                                 }
                                             }
                                         ],
+                                        "env": [
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-etc",
+                                                "mountPath": "/kuiper/etc"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            },
+                                            {
+                                                "name": "kuiper-plugins",
+                                                "mountPath": "/kuiper/plugins"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-redis"
+                                "hostname": "edgex-kuiper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -478,8 +224,194 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EXTERNALMQTT_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
                                             },
                                             {
                                                 "name": "EDGEX_SECURITY_SECRET_STORE",
@@ -496,10 +428,185 @@
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-notifications"
+                                "hostname": "edgex-core-command"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-common-config-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-common-config-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-common-config-bootstrapper",
+                                        "image": "openyurt/core-common-config-bootstrapper:3.1.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_REGISTRY_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -576,7 +683,190 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "openyurt/core-metadata:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -658,55 +948,57 @@
                                 "hostname": "edgex-device-rest"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-device-virtual",
+                    "name": "edgex-redis",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59900",
+                                "name": "tcp-6379",
                                 "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
+                                "port": 6379,
+                                "targetPort": 6379
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-virtual"
+                            "app": "edgex-redis"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-virtual"
+                                "app": "edgex-redis"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-virtual"
+                                    "app": "edgex-redis"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
+                                        "name": "db-data",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:3.1.0",
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:7.0.14-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -717,258 +1009,25 @@
                                                 }
                                             }
                                         ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
+                                                "name": "db-data",
+                                                "mountPath": "/data"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-virtual"
+                                "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-etc",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-plugins",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "openyurt/ekuiper:1.11.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-etc",
-                                                "mountPath": "/kuiper/etc"
-                                            },
-                                            {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
-                                            },
-                                            {
-                                                "name": "kuiper-plugins",
-                                                "mountPath": "/kuiper/plugins"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-common-config-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-common-config-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-common-config-bootstrapper",
-                                        "image": "openyurt/core-common-config-bootstrapper:3.1.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_REGISTRY_HOST",
-                                                "value": "edgex-core-consul"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -1050,854 +1109,12 @@
                                 "hostname": "edgex-ui-go"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "minnesota",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-core-common-config-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-common-config-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-common-config-bootstrapper",
-                                        "image": "openyurt/core-common-config-bootstrapper:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_REGISTRY_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-consul",
-                                        "image": "openyurt/consul:1.15.2",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXTERNALMQTT_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "openyurt/ekuiper:1.9.2-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "openyurt/core-metadata:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "openyurt/support-notifications:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:3.0.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "openyurt/edgex-ui:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-ui-go"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "openyurt/device-rest:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -1929,10 +1146,19 @@
                                 }
                             },
                             "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
                                 "containers": [
                                     {
                                         "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:3.0.0",
+                                        "image": "openyurt/device-virtual:3.1.0",
                                         "ports": [
                                             {
                                                 "name": "tcp-59900",
@@ -1958,19 +1184,60 @@
                                             }
                                         ],
                                         "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
                                 "hostname": "edgex-device-virtual"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
-                },
+                }
+            ]
+        },
+        {
+            "versionName": "kamakura",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "false",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "REGISTRY_HOST": "edgex-core-consul"
+                    }
+                }
+            ],
+            "components": [
                 {
                     "name": "edgex-core-data",
                     "service": {
                         "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
                             {
                                 "name": "tcp-59880",
                                 "protocol": "TCP",
@@ -1999,8 +1266,13 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:3.0.0",
+                                        "image": "openyurt/core-data:2.2.0",
                                         "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
                                             {
                                                 "name": "tcp-59880",
                                                 "containerPort": 59880,
@@ -2018,10 +1290,6 @@
                                             {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
                                             }
                                         ],
                                         "resources": {},
@@ -2031,232 +1299,12 @@
                                 "hostname": "edgex-core-data"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:7.0.11-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "kamakura",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "false",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "REGISTRY_HOST": "edgex-core-consul"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:6.2.6-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -2319,7 +1367,74 @@
                                 "hostname": "edgex-device-rest"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "openyurt/edgex-ui:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -2377,32 +1492,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
                                                 "name": "EDGEX__DEFAULT__TOPIC",
                                                 "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
                                             },
                                             {
                                                 "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
                                                 "value": "redis"
                                             },
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
                                             },
                                             {
                                                 "name": "KUIPER__BASIC__CONSOLELOG",
@@ -2413,7 +1512,23 @@
                                                 "value": "edgex-redis"
                                             },
                                             {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
                                                 "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
                                                 "value": "redis"
                                             },
                                             {
@@ -2434,7 +1549,308 @@
                                 "hostname": "edgex-kuiper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "openyurt/core-metadata:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -2511,212 +1927,12 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "openyurt/core-metadata:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -2779,57 +1995,51 @@
                                 "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-core-data",
+                    "name": "edgex-core-command",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-5563",
+                                "name": "tcp-59882",
                                 "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
+                                "port": 59882,
+                                "targetPort": 59882
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-data"
+                            "app": "edgex-core-command"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-data"
+                                "app": "edgex-core-command"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-core-command"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:2.2.0",
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:2.2.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -2843,17 +2053,22 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "value": "edgex-core-command"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-core-command"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -2905,16 +2120,16 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
                                                 "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
                                                 "name": "INTERVALACTIONS_SCRUBAGED_HOST",
                                                 "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
@@ -2924,46 +2139,57 @@
                                 "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-ui-go",
+                    "name": "edgex-redis",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-4000",
+                                "name": "tcp-6379",
                                 "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
+                                "port": 6379,
+                                "targetPort": 6379
                             }
                         ],
                         "selector": {
-                            "app": "edgex-ui-go"
+                            "app": "edgex-redis"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-ui-go"
+                                "app": "edgex-redis"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-ui-go"
+                                    "app": "edgex-redis"
                                 }
                             },
                             "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-ui-go",
-                                        "image": "openyurt/edgex-ui:2.2.0",
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:6.2.6-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -2975,84 +2201,24 @@
                                             }
                                         ],
                                         "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-ui-go"
+                                "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
                     }
                 }
             ]
@@ -3080,53 +2246,42 @@
             ],
             "components": [
                 {
-                    "name": "edgex-core-data",
+                    "name": "edgex-support-notifications",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-5563",
+                                "name": "tcp-59860",
                                 "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
+                                "port": 59860,
+                                "targetPort": 59860
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-data"
+                            "app": "edgex-support-notifications"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-data"
+                                "app": "edgex-support-notifications"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-support-notifications"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:2.1.1",
+                                        "name": "edgex-support-notifications",
+                                        "image": "openyurt/support-notifications:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3140,17 +2295,22 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -3208,48 +2368,48 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
                                                 "name": "EDGEX__DEFAULT__TYPE",
                                                 "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
                                             },
                                             {
                                                 "name": "KUIPER__BASIC__CONSOLELOG",
                                                 "value": "true"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
                                             },
                                             {
                                                 "name": "KUIPER__BASIC__RESTPORT",
                                                 "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
                                             }
                                         ],
                                         "resources": {},
@@ -3265,7 +2425,12 @@
                                 "hostname": "edgex-kuiper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -3336,7 +2501,292 @@
                                 "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "openyurt/device-rest:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -3413,196 +2863,12 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "openyurt/device-rest:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "openyurt/support-notifications:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -3654,11 +2920,11 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
+                                                "name": "NOTIFICATIONS_SENDER",
                                                 "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "NOTIFICATIONS_SENDER",
+                                                "name": "SERVICE_HOST",
                                                 "value": "edgex-core-metadata"
                                             }
                                         ],
@@ -3669,7 +2935,12 @@
                                 "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -3738,7 +3009,12 @@
                                 "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -3794,12 +3070,12 @@
                                                 "value": "edgex-redis"
                                             },
                                             {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
                                             },
                                             {
                                                 "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
@@ -3813,141 +3089,12 @@
                                 "hostname": "edgex-app-rules-engine"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -4004,33 +3151,14 @@
                                 "hostname": "edgex-ui-go"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
-                }
-            ]
-        },
-        {
-            "versionName": "levski",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "false",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "REGISTRY_HOST": "edgex-core-consul"
-                    }
-                }
-            ],
-            "components": [
+                },
                 {
                     "name": "edgex-core-data",
                     "service": {
@@ -4069,7 +3197,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:2.3.0",
+                                        "image": "openyurt/core-data:2.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-5563",
@@ -4102,7 +3230,252 @@
                                 "hostname": "edgex-core-data"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "levski",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "false",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "REGISTRY_HOST": "edgex-core-consul"
+                    }
+                }
+            ],
+            "components": [
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "openyurt/edgex-ui:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-ui-go"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:2.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -4160,27 +3533,27 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
                                             },
                                             {
                                                 "name": "EDGEX__DEFAULT__SERVER",
                                                 "value": "edgex-redis"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
                                             },
                                             {
                                                 "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
                                                 "value": "redis"
                                             },
                                             {
@@ -4188,20 +3561,20 @@
                                                 "value": "59720"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
                                             },
                                             {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
                                             },
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
                                             },
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -4217,224 +3590,12 @@
                                 "hostname": "edgex-kuiper"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:2.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            },
-                                            {
-                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -4501,46 +3662,51 @@
                                 "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-support-notifications",
+                    "name": "edgex-sys-mgmt-agent",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59860",
+                                "name": "tcp-58890",
                                 "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
+                                "port": 58890,
+                                "targetPort": 58890
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-notifications"
+                            "app": "edgex-sys-mgmt-agent"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-notifications"
+                                "app": "edgex-sys-mgmt-agent"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-notifications"
+                                    "app": "edgex-sys-mgmt-agent"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-support-notifications",
-                                        "image": "openyurt/support-notifications:2.3.0",
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.3.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -4553,144 +3719,31 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
+                                                "value": "edgex-sys-mgmt-agent"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-notifications"
+                                "hostname": "edgex-sys-mgmt-agent"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "openyurt/edgex-ui:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-ui-go"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -4767,7 +3820,227 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "openyurt/device-rest:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "openyurt/support-notifications:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -4836,167 +4109,14 @@
                                 "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "openyurt/device-rest:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "ireland",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "false",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "REGISTRY_HOST": "edgex-core-consul"
-                    }
-                }
-            ],
-            "components": [
                 {
                     "name": "edgex-support-scheduler",
                     "service": {
@@ -5029,7 +4149,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:2.0.0",
+                                        "image": "openyurt/support-scheduler:2.3.0",
                                         "ports": [
                                             {
                                                 "name": "tcp-59861",
@@ -5050,12 +4170,12 @@
                                                 "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
                                                 "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
                                                 "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
@@ -5065,9 +4185,103 @@
                                 "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "minnesota",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    }
+                }
+            ],
+            "components": [
                 {
                     "name": "edgex-core-consul",
                     "service": {
@@ -5110,7 +4324,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-consul",
-                                        "image": "openyurt/consul:1.9.5",
+                                        "image": "openyurt/consul:1.15.2",
                                         "ports": [
                                             {
                                                 "name": "tcp-8500",
@@ -5142,9 +4356,972 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "openyurt/ekuiper:1.9.2-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:3.0.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "openyurt/core-metadata:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:7.0.11-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "openyurt/support-notifications:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "EXTERNALMQTT_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-common-config-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-common-config-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-common-config-bootstrapper",
+                                        "image": "openyurt/core-common-config-bootstrapper:3.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_REGISTRY_HOST",
+                                                "value": "edgex-core-consul"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "openyurt/device-rest:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "openyurt/edgex-ui:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-ui-go"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "ireland",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "false",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "REGISTRY_HOST": "edgex-core-consul"
+                    }
+                }
+            ],
+            "components": [
                 {
                     "name": "edgex-core-metadata",
                     "service": {
@@ -5209,70 +5386,12 @@
                                 "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -5347,7 +5466,311 @@
                                 "hostname": "edgex-app-rules-engine"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -5410,7 +5833,12 @@
                                 "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -5473,210 +5901,12 @@
                                 "hostname": "edgex-device-rest"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:6.2.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -5775,57 +6005,125 @@
                                 "hostname": "edgex-kuiper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-core-data",
+                    "name": "edgex-redis",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-5563",
+                                "name": "tcp-6379",
                                 "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
+                                "port": 6379,
+                                "targetPort": 6379
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-data"
+                            "app": "edgex-redis"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-data"
+                                "app": "edgex-redis"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:6.2.4-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:2.0.0",
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -5839,17 +6137,104 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "value": "edgex-device-virtual"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-device-virtual"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "openyurt/consul:1.9.5",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 }
             ]
@@ -5880,6 +6265,150 @@
                 }
             ],
             "components": [
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48090",
+                                "protocol": "TCP",
+                                "port": 48090,
+                                "targetPort": 48090
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/docker-sys-mgmt-agent-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48090",
+                                                "containerPort": 48090,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-49990",
+                                "protocol": "TCP",
+                                "port": 49990,
+                                "targetPort": 49990
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/docker-device-virtual-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-49990",
+                                                "containerPort": 49990,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
                 {
                     "name": "edgex-core-metadata",
                     "service": {
@@ -5944,7 +6473,80 @@
                                 "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-49986",
+                                "protocol": "TCP",
+                                "port": 49986,
+                                "targetPort": 49986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "openyurt/docker-device-rest-go:1.2.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-49986",
+                                                "containerPort": 49986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -6007,7 +6609,12 @@
                                 "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -6059,24 +6666,24 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "BINDING_PUBLISHTOPIC",
-                                                "value": "events"
-                                            },
-                                            {
                                                 "name": "SERVICE_PORT",
                                                 "value": "48100"
                                             },
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-service-configurable-rules"
+                                                "name": "MESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "BINDING_PUBLISHTOPIC",
+                                                "value": "events"
                                             },
                                             {
                                                 "name": "EDGEX_PROFILE",
                                                 "value": "rules-engine"
                                             },
                                             {
-                                                "name": "MESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-service-configurable-rules"
                                             }
                                         ],
                                         "resources": {},
@@ -6086,7 +6693,80 @@
                                 "hostname": "edgex-app-service-configurable-rules"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48082",
+                                "protocol": "TCP",
+                                "port": 48082,
+                                "targetPort": 48082
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/docker-core-command-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48082",
+                                                "containerPort": 48082,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -6160,275 +6840,12 @@
                                 "hostname": "edgex-core-data"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-49990",
-                                "protocol": "TCP",
-                                "port": 49990,
-                                "targetPort": 49990
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/docker-device-virtual-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-49990",
-                                                "containerPort": 49990,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48082",
-                                "protocol": "TCP",
-                                "port": 48082,
-                                "targetPort": 48082
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/docker-core-command-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48082",
-                                                "containerPort": 48082,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48085",
-                                "protocol": "TCP",
-                                "port": 48085,
-                                "targetPort": 48085
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/docker-support-scheduler-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48085",
-                                                "containerPort": 48085,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48090",
-                                "protocol": "TCP",
-                                "port": 48090,
-                                "targetPort": 48090
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/docker-sys-mgmt-agent-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48090",
-                                                "containerPort": 48090,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -6497,7 +6914,12 @@
                                 "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -6592,46 +7014,51 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-device-rest",
+                    "name": "edgex-support-scheduler",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-49986",
+                                "name": "tcp-48085",
                                 "protocol": "TCP",
-                                "port": 49986,
-                                "targetPort": 49986
+                                "port": 48085,
+                                "targetPort": 48085
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-rest"
+                            "app": "edgex-support-scheduler"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-rest"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-rest"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-device-rest",
-                                        "image": "openyurt/docker-device-rest-go:1.2.1",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/docker-support-scheduler-go:1.3.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-49986",
-                                                "containerPort": 49986,
+                                                "name": "tcp-48085",
+                                                "containerPort": 48085,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -6644,18 +7071,31 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
+                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-rest"
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -6718,18 +7158,6 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "48075"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "5566"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "tcp"
-                                            },
-                                            {
                                                 "name": "EDGEX__DEFAULT__SERVER",
                                                 "value": "edgex-app-service-configurable-rules"
                                             },
@@ -6744,6 +7172,18 @@
                                             {
                                                 "name": "KUIPER__BASIC__CONSOLELOG",
                                                 "value": "true"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "48075"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "5566"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "tcp"
                                             }
                                         ],
                                         "resources": {},
@@ -6753,7 +7193,12 @@
                                 "hostname": "edgex-kuiper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 }
             ]

--- a/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config.json
+++ b/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config.json
@@ -30,67 +30,79 @@
             ],
             "components": [
                 {
-                    "name": "edgex-redis",
+                    "name": "edgex-kuiper",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-6379",
+                                "name": "tcp-59720",
                                 "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                                "port": 59720,
+                                "targetPort": 59720
                             }
                         ],
                         "selector": {
-                            "app": "edgex-redis"
+                            "app": "edgex-kuiper"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-kuiper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
+                                    "app": "edgex-kuiper"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "redis-config",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
+                                            "path": "/etc/localtime",
                                             "type": "DirectoryOrCreate"
                                         }
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-etc",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-plugins",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-redis",
-                                        "image": "redis:7.0.14-alpine",
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.11.4-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -103,108 +115,156 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
                                             },
                                             {
-                                                "name": "DATABASECONFIG_PATH",
-                                                "value": "/run/redis/conf"
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            },
-                                            {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "redis-config",
-                                                "mountPath": "/run/redis/conf"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
                                             },
                                             {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-etc",
+                                                "mountPath": "/kuiper/etc"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            },
+                                            {
+                                                "name": "kuiper-plugins",
+                                                "mountPath": "/kuiper/plugins"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-redis"
+                                "hostname": "edgex-kuiper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-core-consul",
+                    "name": "edgex-device-rest",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-8500",
+                                "name": "tcp-59986",
                                 "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
+                                "port": 59986,
+                                "targetPort": 59986
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-consul"
+                            "app": "edgex-device-rest"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-consul"
+                                "app": "edgex-device-rest"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-consul"
+                                    "app": "edgex-device-rest"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-rest",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-consul",
-                                        "image": "hashicorp/consul:1.16.2",
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:3.1.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -217,59 +277,139 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_REGISTRY_ACL_ROLES"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
                                             },
                                             {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-consul"
+                                "hostname": "edgex-device-rest"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/core-data:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -386,7 +526,12 @@
                                 "hostname": "edgex-nginx"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -458,16 +603,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
                                                 "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
                                                 "name": "INTERVALACTIONS_SCRUBAGED_HOST",
                                                 "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
@@ -491,201 +636,12 @@
                                 "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -782,823 +738,12 @@
                                 "hostname": "edgex-proxy-auth"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:3.1.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-etc",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-plugins",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.11.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-etc",
-                                                "mountPath": "/kuiper/etc"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
-                                            },
-                                            {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
-                                            },
-                                            {
-                                                "name": "kuiper-plugins",
-                                                "mountPath": "/kuiper/plugins"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-common-config-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-common-config-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-common-config-bootstrapper",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-common-config-bootstrapper",
-                                        "image": "edgexfoundry/core-common-config-bootstrapper:3.1.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_REGISTRY_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/core-common-config-bootstrapper"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-proxy-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-proxy-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-templates",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-tls",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:3.1.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            },
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_PROXY_ROUTE",
-                                                "value": "device-rest.http://edgex-device-rest:59986"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
-                                                "name": "nginx-templates",
-                                                "mountPath": "/etc/nginx/templates"
-                                            },
-                                            {
-                                                "name": "nginx-tls",
-                                                "mountPath": "/etc/ssl/nginx"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-ui-go"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -1668,35 +813,40 @@
                                 "hostname": "edgex-security-bootstrapper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-app-rules-engine",
+                    "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59701",
+                                "name": "tcp-59881",
                                 "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
+                                "port": 59881,
+                                "targetPort": 59881
                             }
                         ],
                         "selector": {
-                            "app": "edgex-app-rules-engine"
+                            "app": "edgex-core-metadata"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-app-rules-engine"
+                                "app": "edgex-core-metadata"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-app-rules-engine"
+                                    "app": "edgex-core-metadata"
                                 }
                             },
                             "spec": {
@@ -1715,19 +865,19 @@
                                     {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "path": "/tmp/edgex/secrets/core-metadata",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:3.1.0",
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:3.1.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -1741,11 +891,7 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
@@ -1760,16 +906,21 @@
                                             },
                                             {
                                                 "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-app-rules-engine"
+                                "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -1876,7 +1027,676 @@
                                 "hostname": "edgex-vault"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-secretstore-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-secretstore-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:3.1.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-ui-go"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-notifications",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "hashicorp/consul:1.16.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -1948,12 +1768,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
                                                 "name": "EXTERNALMQTT_URL",
                                                 "value": "tcp://edgex-mqtt-broker:1883"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
                                             }
                                         ],
                                         "resources": {},
@@ -1977,43 +1797,31 @@
                                 "hostname": "edgex-core-command"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
+                    "name": "edgex-security-proxy-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-data"
+                                "app": "edgex-security-proxy-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-security-proxy-setup"
                                 }
                             },
                             "spec": {
                                 "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
@@ -2022,24 +1830,37 @@
                                         }
                                     },
                                     {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-templates",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-tls",
+                                        "emptyDir": {}
+                                    },
+                                    {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
                                             "type": "DirectoryOrCreate"
                                         }
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:3.1.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -2049,316 +1870,89 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_DATA_HOST",
                                                 "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_PROXY_ROUTE",
+                                                "value": "device-rest.http://edgex-device-rest:59986"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
                                             {
                                                 "name": "anonymous-volume1",
                                                 "mountPath": "/etc/localtime"
                                             },
                                             {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "nginx-templates",
+                                                "mountPath": "/etc/nginx/templates"
+                                            },
+                                            {
+                                                "name": "nginx-tls",
+                                                "mountPath": "/etc/ssl/nginx"
+                                            },
+                                            {
                                                 "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-security-proxy-setup"
                             }
                         },
-                        "strategy": {}
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "minnesota",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "EDGEX_SECURITY_SECRET_STORE": "true",
-                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
-                        "SECRETSTORE_HOST": "edgex-vault",
-                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
-                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
-                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
-                        "STAGEGATE_DATABASE_PORT": "6379",
-                        "STAGEGATE_DATABASE_READYPORT": "6379",
-                        "STAGEGATE_READY_TORUNPORT": "54329",
-                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
-                        "STAGEGATE_REGISTRY_PORT": "8500",
-                        "STAGEGATE_REGISTRY_READYPORT": "54324",
-                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
-                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
-                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-common-config-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-common-config-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-common-config-bootstrapper",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-common-config-bootstrapper",
-                                        "image": "edgexfoundry/core-common-config-bootstrapper:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_REGISTRY_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-common-config-bootstrapper"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -2418,7 +2012,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-redis",
-                                        "image": "redis:7.0.11-alpine",
+                                        "image": "redis:7.0.14-alpine",
                                         "ports": [
                                             {
                                                 "name": "tcp-6379",
@@ -2472,182 +2066,27 @@
                                 "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
+                    "name": "edgex-core-common-config-bootstrapper",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-core-common-config-bootstrapper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.9.2-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
-                                            },
-                                            {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-core-common-config-bootstrapper"
                                 }
                             },
                             "spec": {
@@ -2659,22 +2098,22 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "path": "/etc/localtime",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-common-config-bootstrapper",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-core-common-config-bootstrapper",
+                                        "image": "edgexfoundry/core-common-config-bootstrapper:3.1.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -2684,8 +2123,24 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_REGISTRY_HOST",
+                                                "value": "edgex-core-consul"
                                             }
                                         ],
                                         "resources": {},
@@ -2696,188 +2151,111 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/core-common-config-bootstrapper"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-core-common-config-bootstrapper"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-nginx",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8443",
-                                "protocol": "TCP",
-                                "port": 8443,
-                                "targetPort": 8443
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-nginx"
                         }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "kamakura",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
                     },
+                    "data": {
+                        "API_GATEWAY_HOST": "edgex-kong",
+                        "API_GATEWAY_STATUS_PORT": "8100",
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "true",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
+                        "REGISTRY_HOST": "edgex-core-consul",
+                        "SECRETSTORE_HOST": "edgex-vault",
+                        "SECRETSTORE_PORT": "8200",
+                        "SPIFFE_ENDPOINTSOCKET": "/tmp/edgex/secrets/spiffe/public/api.sock",
+                        "SPIFFE_TRUSTBUNDLE_PATH": "/tmp/edgex/secrets/spiffe/trust/bundle",
+                        "SPIFFE_TRUSTDOMAIN": "edgexfoundry.org",
+                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
+                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
+                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
+                        "STAGEGATE_DATABASE_PORT": "6379",
+                        "STAGEGATE_DATABASE_READYPORT": "6379",
+                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
+                        "STAGEGATE_KONGDB_PORT": "5432",
+                        "STAGEGATE_KONGDB_READYPORT": "54325",
+                        "STAGEGATE_READY_TORUNPORT": "54329",
+                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
+                        "STAGEGATE_REGISTRY_PORT": "8500",
+                        "STAGEGATE_REGISTRY_READYPORT": "54324",
+                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
+                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
+                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
+                    }
+                }
+            ],
+            "components": [
+                {
+                    "name": "edgex-security-proxy-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-nginx"
+                                "app": "edgex-security-proxy-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-nginx"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume3",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume4",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-templates",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-tls",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-nginx",
-                                        "image": "nginx:1.24.0-alpine-slim",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8443",
-                                                "containerPort": 8443,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/etc/nginx/conf.d"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/var/cache/nginx"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume3",
-                                                "mountPath": "/var/log/nginx"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume4",
-                                                "mountPath": "/var/run"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "nginx-templates",
-                                                "mountPath": "/etc/nginx/templates"
-                                            },
-                                            {
-                                                "name": "nginx-tls",
-                                                "mountPath": "/etc/ssl/nginx"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-nginx"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
+                                    "app": "edgex-security-proxy-setup"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
                                         "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/core-command:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:2.2.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -2887,12 +2265,47 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ADD_PROXY_ROUTE"
+                                            },
+                                            {
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
                                                 "value": "edgex-core-command"
                                             },
                                             {
-                                                "name": "EXTERNALMQTT_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
@@ -2902,17 +2315,26 @@
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-command"
+                                "hostname": "edgex-security-proxy-setup"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -2960,7 +2382,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:3.0.1",
+                                        "image": "edgexfoundry/app-service-configurable:2.2.0",
                                         "ports": [
                                             {
                                                 "name": "tcp-59701",
@@ -2979,6 +2401,14 @@
                                             {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
                                             },
                                             {
                                                 "name": "EDGEX_PROFILE",
@@ -3002,187 +2432,12 @@
                                 "hostname": "edgex-app-rules-engine"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -3235,7 +2490,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-vault",
-                                        "image": "hashicorp/vault:1.13.2",
+                                        "image": "vault:1.8.9",
                                         "ports": [
                                             {
                                                 "name": "tcp-8200",
@@ -3252,16 +2507,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
                                             },
                                             {
                                                 "name": "VAULT_CONFIG_DIR",
                                                 "value": "/vault/config"
                                             },
                                             {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
+                                                "name": "VAULT_UI",
+                                                "value": "true"
                                             }
                                         ],
                                         "resources": {},
@@ -3289,46 +2544,64 @@
                                 "hostname": "edgex-vault"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-ui-go",
+                    "name": "edgex-support-scheduler",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-4000",
+                                "name": "tcp-59861",
                                 "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
+                                "port": 59861,
+                                "targetPort": 59861
                             }
                         ],
                         "selector": {
-                            "app": "edgex-ui-go"
+                            "app": "edgex-support-scheduler"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-ui-go"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-ui-go"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:3.0.0",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:2.2.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3341,323 +2614,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-ui-go"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-proxy-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-proxy-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-templates",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-tls",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_PROXY_ROUTE",
-                                                "value": "device-rest.http://edgex-device-rest:59986"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
@@ -3667,33 +2633,22 @@
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
-                                                "name": "nginx-templates",
-                                                "mountPath": "/etc/nginx/templates"
-                                            },
-                                            {
-                                                "name": "nginx-tls",
-                                                "mountPath": "/etc/ssl/nginx"
-                                            },
-                                            {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-security-proxy-setup"
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -3753,7 +2708,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-consul",
-                                        "image": "hashicorp/consul:1.15.2",
+                                        "image": "consul:1.10.10",
                                         "ports": [
                                             {
                                                 "name": "tcp-8500",
@@ -3770,27 +2725,23 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_ADD_REGISTRY_ACL_ROLES"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
                                             },
                                             {
                                                 "name": "EDGEX_GROUP",
                                                 "value": "2001"
                                             },
                                             {
-                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
-                                            },
-                                            {
                                                 "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
                                                 "value": "/consul/config/consul_acl_done"
                                             },
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            },
+                                            {
+                                                "name": "ADD_REGISTRY_ACL_ROLES"
                                             }
                                         ],
                                         "resources": {},
@@ -3822,118 +2773,76 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-proxy-auth",
+                    "name": "edgex-redis",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59842",
+                                "name": "tcp-6379",
                                 "protocol": "TCP",
-                                "port": 59842,
-                                "targetPort": 59842
+                                "port": 6379,
+                                "targetPort": 6379
                             }
                         ],
                         "selector": {
-                            "app": "edgex-proxy-auth"
+                            "app": "edgex-redis"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-proxy-auth"
+                                "app": "edgex-redis"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-proxy-auth"
+                                    "app": "edgex-redis"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
                                         "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "redis-config",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-auth",
+                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-proxy-auth",
-                                        "image": "edgexfoundry/security-proxy-auth:3.0.0",
+                                        "name": "edgex-redis",
+                                        "image": "redis:6.2.6-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-59842",
-                                                "containerPort": 59842,
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3946,8 +2855,119 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "DATABASECONFIG_PATH",
+                                                "value": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "redis-config",
+                                                "mountPath": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-proxy-auth"
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
@@ -3958,122 +2978,21 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-auth"
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-proxy-auth"
+                                "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "kamakura",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "API_GATEWAY_HOST": "edgex-kong",
-                        "API_GATEWAY_STATUS_PORT": "8100",
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "true",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
-                        "REGISTRY_HOST": "edgex-core-consul",
-                        "SECRETSTORE_HOST": "edgex-vault",
-                        "SECRETSTORE_PORT": "8200",
-                        "SPIFFE_ENDPOINTSOCKET": "/tmp/edgex/secrets/spiffe/public/api.sock",
-                        "SPIFFE_TRUSTBUNDLE_PATH": "/tmp/edgex/secrets/spiffe/trust/bundle",
-                        "SPIFFE_TRUSTDOMAIN": "edgexfoundry.org",
-                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
-                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
-                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
-                        "STAGEGATE_DATABASE_PORT": "6379",
-                        "STAGEGATE_DATABASE_READYPORT": "6379",
-                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
-                        "STAGEGATE_KONGDB_PORT": "5432",
-                        "STAGEGATE_KONGDB_READYPORT": "54325",
-                        "STAGEGATE_READY_TORUNPORT": "54329",
-                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
-                        "STAGEGATE_REGISTRY_PORT": "8500",
-                        "STAGEGATE_REGISTRY_READYPORT": "54324",
-                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
-                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
-                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:2.2.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "strategy": {}
+                        }
                     }
                 },
                 {
@@ -4159,7 +3078,284 @@
                                 "hostname": "edgex-core-command"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kong-db",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5432",
+                                "protocol": "TCP",
+                                "port": 5432,
+                                "targetPort": 5432
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kong-db"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kong-db"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kong-db"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume3",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "postgres-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "postgres-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kong-db",
+                                        "image": "postgres:13.5-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5432",
+                                                "containerPort": 5432,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "POSTGRES_DB",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "POSTGRES_USER",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "POSTGRES_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/var/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume3",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "postgres-config",
+                                                "mountPath": "/tmp/postgres-config"
+                                            },
+                                            {
+                                                "name": "postgres-data",
+                                                "mountPath": "/var/lib/postgresql/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kong-db"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.4.4-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -4245,35 +3441,102 @@
                                 "hostname": "edgex-device-rest"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-support-scheduler",
+                    "name": "edgex-ui-go",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59861",
+                                "name": "tcp-4000",
                                 "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                                "port": 4000,
+                                "targetPort": 4000
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-scheduler"
+                            "app": "edgex-ui-go"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-ui-go"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
                                 }
                             },
                             "spec": {
@@ -4285,19 +3548,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "path": "/tmp/edgex/secrets/support-notifications",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.2.0",
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:2.2.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -4311,15 +3574,7 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
@@ -4330,487 +3585,21 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-scheduler"
+                                "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kong-db",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5432",
-                                "protocol": "TCP",
-                                "port": 5432,
-                                "targetPort": 5432
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-kong-db"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kong-db"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kong-db"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume3",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "postgres-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "postgres-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kong-db",
-                                        "image": "postgres:13.5-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-5432",
-                                                "containerPort": 5432,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "POSTGRES_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
-                                            },
-                                            {
-                                                "name": "POSTGRES_USER",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "POSTGRES_DB",
-                                                "value": "kong"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/var/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume3",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "postgres-config",
-                                                "mountPath": "/tmp/postgres-config"
-                                            },
-                                            {
-                                                "name": "postgres-data",
-                                                "mountPath": "/var/lib/postgresql/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kong-db"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.2.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/tmp/kong"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "edgexfoundry/sys-mgmt-agent:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-consul",
-                                        "image": "consul:1.10.10",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
-                                            },
-                                            {
-                                                "name": "ADD_REGISTRY_ACL_ROLES"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -4913,28 +3702,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
                                                 "name": "KONG_STATUS_LISTEN",
                                                 "value": "0.0.0.0:8100"
                                             },
                                             {
-                                                "name": "KONG_ADMIN_LISTEN",
-                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "edgex-kong-db"
+                                                "name": "KONG_SSL_CIPHER_SUITE",
+                                                "value": "modern"
                                             },
                                             {
                                                 "name": "KONG_ADMIN_ACCESS_LOG",
@@ -4945,24 +3718,40 @@
                                                 "value": "1"
                                             },
                                             {
-                                                "name": "KONG_PROXY_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
+                                                "name": "KONG_PG_HOST",
+                                                "value": "edgex-kong-db"
                                             },
                                             {
                                                 "name": "KONG_DNS_VALID_TTL",
                                                 "value": "1"
                                             },
                                             {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
+                                            },
+                                            {
                                                 "name": "KONG_PG_PASSWORD_FILE",
                                                 "value": "/tmp/postgres-config/.pgpassword"
                                             },
                                             {
-                                                "name": "KONG_SSL_CIPHER_SUITE",
-                                                "value": "modern"
+                                                "name": "KONG_PROXY_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_LISTEN",
+                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
                                             }
                                         ],
                                         "resources": {},
@@ -4998,35 +3787,27 @@
                                 "hostname": "edgex-kong"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
+                    "name": "edgex-security-bootstrapper",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-security-bootstrapper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
+                                    "app": "edgex-security-bootstrapper"
                                 }
                             },
                             "spec": {
@@ -5034,31 +3815,12 @@
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.4.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:2.2.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -5068,48 +3830,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
                                             }
                                         ],
                                         "resources": {},
@@ -5117,499 +3843,20 @@
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kuiper"
+                                "hostname": "edgex-security-bootstrapper"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "redis-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "redis:6.2.6-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
-                                            },
-                                            {
-                                                "name": "DATABASECONFIG_PATH",
-                                                "value": "/run/redis/conf"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "redis-config",
-                                                "mountPath": "/run/redis/conf"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-proxy-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-proxy-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:2.2.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -5695,7 +3942,111 @@
                                 "hostname": "edgex-device-virtual"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "edgexfoundry/sys-mgmt-agent:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -5796,121 +4147,27 @@
                                 "hostname": "edgex-core-data"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
+                    "name": "edgex-security-secretstore-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-notifications"
+                                "app": "edgex-security-secretstore-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-vault",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8200",
-                                "protocol": "TCP",
-                                "port": 8200,
-                                "targetPort": 8200
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-vault"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-vault"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-vault"
+                                    "app": "edgex-security-secretstore-setup"
                                 }
                             },
                             "spec": {
@@ -5920,29 +4177,41 @@
                                         "emptyDir": {}
                                     },
                                     {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
                                         "name": "edgex-init",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "vault-file",
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kong",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "vault-logs",
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
                                         "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-vault",
-                                        "image": "vault:1.8.9",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8200",
-                                                "containerPort": 8200,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.2.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -5952,44 +4221,72 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
                                             },
                                             {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
+                                                "name": "ADD_SECRETSTORE_TOKENS"
                                             },
                                             {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
                                                 "name": "tmpfs-volume1",
-                                                "mountPath": "/vault/config"
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
                                             },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "vault-file",
-                                                "mountPath": "/vault/file"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
                                             },
                                             {
-                                                "name": "vault-logs",
-                                                "mountPath": "/vault/logs"
+                                                "name": "kong",
+                                                "mountPath": "/tmp/kong"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-vault"
+                                "hostname": "edgex-security-secretstore-setup"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 }
             ]
@@ -6136,12 +4433,28 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "KONG_PG_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            },
+                                            {
                                                 "name": "KONG_STATUS_LISTEN",
                                                 "value": "0.0.0.0:8100"
                                             },
                                             {
-                                                "name": "KONG_PG_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_VALID_TTL",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
                                             },
                                             {
                                                 "name": "KONG_PROXY_ACCESS_LOG",
@@ -6152,40 +4465,24 @@
                                                 "value": "modern"
                                             },
                                             {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
                                                 "name": "KONG_NGINX_WORKER_PROCESSES",
                                                 "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "edgex-kong-db"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
                                             },
                                             {
                                                 "name": "KONG_ADMIN_LISTEN",
                                                 "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
                                             },
                                             {
-                                                "name": "KONG_DNS_VALID_TTL",
-                                                "value": "1"
-                                            },
-                                            {
                                                 "name": "KONG_ADMIN_ACCESS_LOG",
                                                 "value": "/dev/stdout"
                                             },
                                             {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "edgex-kong-db"
                                             }
                                         ],
                                         "resources": {},
@@ -6221,449 +4518,12 @@
                                 "hostname": "edgex-kong"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-consul",
-                                        "image": "consul:1.10.3",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ADD_REGISTRY_ACL_ROLES"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.1.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "ADD_SECRETSTORE_TOKENS"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/tmp/kong"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.1.2",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -6728,16 +4588,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
                                             },
                                             {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-sys-mgmt-agent"
                                             },
                                             {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
                                             }
                                         ],
                                         "resources": {},
@@ -6757,203 +4617,12 @@
                                 "hostname": "edgex-sys-mgmt-agent"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:2.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.4.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -7039,22 +4708,40 @@
                                 "hostname": "edgex-core-command"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-security-proxy-setup",
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-security-proxy-setup"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
@@ -7064,21 +4751,24 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:2.1.1",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -7088,237 +4778,15 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "name": "SERVICE_HOST",
                                                 "value": "edgex-support-scheduler"
                                             },
                                             {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5563",
-                                "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-data",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
                                                 "value": "edgex-core-data"
                                             }
                                         ],
@@ -7330,265 +4798,49 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-redis",
+                    "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-6379",
+                                "name": "tcp-59701",
                                 "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                                "port": 59701,
+                                "targetPort": 59701
                             }
                         ],
                         "selector": {
-                            "app": "edgex-redis"
+                            "app": "edgex-app-rules-engine"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-app-rules-engine"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "redis-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "redis:6.2.6-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
-                                            },
-                                            {
-                                                "name": "DATABASECONFIG_PATH",
-                                                "value": "/run/redis/conf"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "redis-config",
-                                                "mountPath": "/run/redis/conf"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-vault",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8200",
-                                "protocol": "TCP",
-                                "port": 8200,
-                                "targetPort": 8200
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-vault"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-vault"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-vault"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-file",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-logs",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-vault",
-                                        "image": "vault:1.8.4",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8200",
-                                                "containerPort": 8200,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
-                                            },
-                                            {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "vault-file",
-                                                "mountPath": "/vault/file"
-                                            },
-                                            {
-                                                "name": "vault-logs",
-                                                "mountPath": "/vault/logs"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-vault"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
+                                    "app": "edgex-app-rules-engine"
                                 }
                             },
                             "spec": {
@@ -7600,19 +4852,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:2.1.1",
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:2.1.2",
                                         "ports": [
                                             {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -7626,7 +4878,19 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
                                             }
                                         ],
                                         "resources": {},
@@ -7637,161 +4901,21 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-rest"
+                                "hostname": "edgex-app-rules-engine"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:2.1.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -7914,176 +5038,40 @@
                                 "hostname": "edgex-kong-db"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-support-scheduler",
+                    "name": "edgex-redis",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59861",
+                                "name": "tcp-6379",
                                 "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                                "port": 6379,
+                                "targetPort": 6379
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-scheduler"
+                            "app": "edgex-redis"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-redis"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "levski",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "API_GATEWAY_HOST": "edgex-kong",
-                        "API_GATEWAY_STATUS_PORT": "8100",
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "true",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
-                        "REGISTRY_HOST": "edgex-core-consul",
-                        "SECRETSTORE_HOST": "edgex-vault",
-                        "SECRETSTORE_PORT": "8200",
-                        "SPIFFE_ENDPOINTSOCKET": "/tmp/edgex/secrets/spiffe/public/api.sock",
-                        "SPIFFE_TRUSTBUNDLE_PATH": "/tmp/edgex/secrets/spiffe/trust/bundle",
-                        "SPIFFE_TRUSTDOMAIN": "edgexfoundry.org",
-                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
-                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
-                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
-                        "STAGEGATE_DATABASE_PORT": "6379",
-                        "STAGEGATE_DATABASE_READYPORT": "6379",
-                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
-                        "STAGEGATE_KONGDB_PORT": "5432",
-                        "STAGEGATE_KONGDB_READYPORT": "54325",
-                        "STAGEGATE_READY_TORUNPORT": "54329",
-                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
-                        "STAGEGATE_REGISTRY_PORT": "8500",
-                        "STAGEGATE_REGISTRY_READYPORT": "54324",
-                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
-                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
-                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-vault",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8200",
-                                "protocol": "TCP",
-                                "port": 8200,
-                                "targetPort": 8200
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-vault"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-vault"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-vault"
+                                    "app": "edgex-redis"
                                 }
                             },
                             "spec": {
@@ -8093,26 +5081,33 @@
                                         "emptyDir": {}
                                     },
                                     {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
                                         "name": "edgex-init",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "vault-file",
+                                        "name": "redis-config",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "vault-logs",
-                                        "emptyDir": {}
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
+                                            "type": "DirectoryOrCreate"
+                                        }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-vault",
-                                        "image": "vault:1.11.4",
+                                        "name": "edgex-redis",
+                                        "image": "redis:6.2.6-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-8200",
-                                                "containerPort": 8200,
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -8125,349 +5120,49 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
                                             },
                                             {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
-                                            },
-                                            {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
+                                                "name": "DATABASECONFIG_PATH",
+                                                "value": "/run/redis/conf"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
                                                 "name": "tmpfs-volume1",
-                                                "mountPath": "/vault/config"
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
                                             },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "vault-file",
-                                                "mountPath": "/vault/file"
-                                            },
-                                            {
-                                                "name": "vault-logs",
-                                                "mountPath": "/vault/logs"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-vault"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-proxy-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-proxy-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:2.3.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                                "name": "redis-config",
+                                                "mountPath": "/run/redis/conf"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-security-proxy-setup"
+                                "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-command",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/core-command:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-command"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -8515,7 +5210,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:2.3.0",
+                                        "image": "edgexfoundry/device-virtual:2.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59900",
@@ -8553,72 +5248,64 @@
                                 "hostname": "edgex-device-virtual"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-kong-db",
+                    "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-5432",
+                                "name": "tcp-59881",
                                 "protocol": "TCP",
-                                "port": 5432,
-                                "targetPort": 5432
+                                "port": 59881,
+                                "targetPort": 59881
                             }
                         ],
                         "selector": {
-                            "app": "edgex-kong-db"
+                            "app": "edgex-core-metadata"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kong-db"
+                                "app": "edgex-core-metadata"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kong-db"
+                                    "app": "edgex-core-metadata"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume3",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "postgres-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "postgres-data",
-                                        "emptyDir": {}
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "DirectoryOrCreate"
+                                        }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-kong-db",
-                                        "image": "postgres:13.8-alpine",
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-5432",
-                                                "containerPort": 5432,
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -8631,52 +5318,37 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "POSTGRES_DB",
-                                                "value": "kong"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "POSTGRES_USER",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "POSTGRES_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/var/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume3",
-                                                "mountPath": "/run"
-                                            },
-                                            {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "postgres-config",
-                                                "mountPath": "/tmp/postgres-config"
-                                            },
-                                            {
-                                                "name": "postgres-data",
-                                                "mountPath": "/var/lib/postgresql/data"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kong-db"
+                                "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -8735,7 +5407,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.3.0",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.1.1",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -8745,7 +5417,15 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
+                                            },
+                                            {
                                                 "name": "ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
                                             },
                                             {
                                                 "name": "SECUREMESSAGEBUS_TYPE",
@@ -8754,14 +5434,6 @@
                                             {
                                                 "name": "EDGEX_USER",
                                                 "value": "2002"
-                                            },
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
                                             }
                                         ],
                                         "resources": {},
@@ -8805,46 +5477,208 @@
                                 "hostname": "edgex-security-secretstore-setup"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-ui-go",
+                    "name": "edgex-kuiper",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-4000",
+                                "name": "tcp-59720",
                                 "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
+                                "port": 59720,
+                                "targetPort": 59720
                             }
                         ],
                         "selector": {
-                            "app": "edgex-ui-go"
+                            "app": "edgex-kuiper"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-ui-go"
+                                "app": "edgex-kuiper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-ui-go"
+                                    "app": "edgex-kuiper"
                                 }
                             },
                             "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    }
+                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:2.3.0",
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.4.4-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -8858,17 +5692,32 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-ui-go"
+                                                "value": "edgex-device-rest"
                                             }
                                         ],
                                         "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                            }
+                                        ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-ui-go"
+                                "hostname": "edgex-device-rest"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -8928,7 +5777,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-consul",
-                                        "image": "consul:1.13.2",
+                                        "image": "consul:1.10.3",
                                         "ports": [
                                             {
                                                 "name": "tcp-8500",
@@ -8945,24 +5794,20 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
                                             },
                                             {
                                                 "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
                                                 "value": "/consul/config/consul_acl_done"
                                             },
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
                                             },
                                             {
-                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
                                             },
                                             {
                                                 "name": "ADD_REGISTRY_ACL_ROLES"
@@ -8997,146 +5842,12 @@
                                 "hostname": "edgex-core-consul"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.7.1-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -9184,7 +5895,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:2.3.0",
+                                        "image": "edgexfoundry/support-notifications:2.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59860",
@@ -9222,7 +5933,368 @@
                                 "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8200",
+                                "protocol": "TCP",
+                                "port": 8200,
+                                "targetPort": 8200
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-vault"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-file",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-logs",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault",
+                                        "image": "vault:1.8.4",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8200",
+                                                "containerPort": 8200,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            },
+                                            {
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
+                                            },
+                                            {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-file",
+                                                "mountPath": "/vault/file"
+                                            },
+                                            {
+                                                "name": "vault-logs",
+                                                "mountPath": "/vault/logs"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-proxy-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-proxy-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:2.1.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ADD_PROXY_ROUTE"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:2.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:2.1.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -9276,7 +6348,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:2.3.0",
+                                        "image": "edgexfoundry/core-data:2.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-5563",
@@ -9298,12 +6370,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
                                             }
                                         ],
                                         "resources": {},
@@ -9323,35 +6395,74 @@
                                 "hostname": "edgex-core-data"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
                         }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "levski",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
                     },
+                    "data": {
+                        "API_GATEWAY_HOST": "edgex-kong",
+                        "API_GATEWAY_STATUS_PORT": "8100",
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "true",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
+                        "REGISTRY_HOST": "edgex-core-consul",
+                        "SECRETSTORE_HOST": "edgex-vault",
+                        "SECRETSTORE_PORT": "8200",
+                        "SPIFFE_ENDPOINTSOCKET": "/tmp/edgex/secrets/spiffe/public/api.sock",
+                        "SPIFFE_TRUSTBUNDLE_PATH": "/tmp/edgex/secrets/spiffe/trust/bundle",
+                        "SPIFFE_TRUSTDOMAIN": "edgexfoundry.org",
+                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
+                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
+                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
+                        "STAGEGATE_DATABASE_PORT": "6379",
+                        "STAGEGATE_DATABASE_READYPORT": "6379",
+                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
+                        "STAGEGATE_KONGDB_PORT": "5432",
+                        "STAGEGATE_KONGDB_READYPORT": "54325",
+                        "STAGEGATE_READY_TORUNPORT": "54329",
+                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
+                        "STAGEGATE_REGISTRY_PORT": "8500",
+                        "STAGEGATE_REGISTRY_READYPORT": "54324",
+                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
+                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
+                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
+                    }
+                }
+            ],
+            "components": [
+                {
+                    "name": "edgex-security-proxy-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-security-proxy-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
+                                    "app": "edgex-security-proxy-setup"
                                 }
                             },
                             "spec": {
@@ -9361,24 +6472,21 @@
                                         "emptyDir": {}
                                     },
                                     {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:2.3.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -9388,16 +6496,47 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
                                                 "value": "edgex-support-scheduler"
                                             },
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
                                             },
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "ADD_PROXY_ROUTE"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
@@ -9407,17 +6546,26 @@
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-scheduler"
+                                "hostname": "edgex-security-proxy-setup"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -9476,289 +6624,12 @@
                                 "hostname": "edgex-security-bootstrapper"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kong",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8000",
-                                "protocol": "TCP",
-                                "port": 8000,
-                                "targetPort": 8000
-                            },
-                            {
-                                "name": "tcp-8100",
-                                "protocol": "TCP",
-                                "port": 8100,
-                                "targetPort": 8100
-                            },
-                            {
-                                "name": "tcp-8443",
-                                "protocol": "TCP",
-                                "port": 8443,
-                                "targetPort": 8443
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-kong"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kong"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kong"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "postgres-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kong",
-                                        "image": "kong:2.8.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8000",
-                                                "containerPort": 8000,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8100",
-                                                "containerPort": 8100,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8443",
-                                                "containerPort": 8443,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_NGINX_WORKER_PROCESSES",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
-                                            },
-                                            {
-                                                "name": "KONG_STATUS_LISTEN",
-                                                "value": "0.0.0.0:8100"
-                                            },
-                                            {
-                                                "name": "KONG_PG_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_VALID_TTL",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_SSL_CIPHER_SUITE",
-                                                "value": "modern"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "edgex-kong-db"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_LISTEN",
-                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            },
-                                            {
-                                                "name": "postgres-config",
-                                                "mountPath": "/tmp/postgres-config"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/usr/local/kong"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kong"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "edgexfoundry/sys-mgmt-agent:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -9872,7 +6743,896 @@
                                 "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/core-command:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "edgexfoundry/sys-mgmt-agent:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.7.1-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/core-data:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-secretstore-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-secretstore-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.3.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/tmp/kong"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8200",
+                                "protocol": "TCP",
+                                "port": 8200,
+                                "targetPort": 8200
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-vault"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-file",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-logs",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault",
+                                        "image": "vault:1.11.4",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8200",
+                                                "containerPort": 8200,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
+                                            },
+                                            {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-file",
+                                                "mountPath": "/vault/file"
+                                            },
+                                            {
+                                                "name": "vault-logs",
+                                                "mountPath": "/vault/logs"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -9962,35 +7722,40 @@
                                 "hostname": "edgex-core-metadata"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-device-rest",
+                    "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59986",
+                                "name": "tcp-59701",
                                 "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
+                                "port": 59701,
+                                "targetPort": 59701
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-rest"
+                            "app": "edgex-app-rules-engine"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-rest"
+                                "app": "edgex-app-rules-engine"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-rest"
+                                    "app": "edgex-app-rules-engine"
                                 }
                             },
                             "spec": {
@@ -10002,19 +7767,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:2.3.0",
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:2.3.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -10027,8 +7792,20 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -10039,92 +7816,73 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-rest"
+                                "hostname": "edgex-app-rules-engine"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
-                }
-            ]
-        },
-        {
-            "versionName": "ireland",
-            "configMaps": [
+                },
                 {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "API_GATEWAY_HOST": "edgex-kong",
-                        "API_GATEWAY_STATUS_PORT": "8100",
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "true",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
-                        "REGISTRY_HOST": "edgex-core-consul",
-                        "SECRETSTORE_HOST": "edgex-vault",
-                        "SECRETSTORE_PORT": "8200",
-                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
-                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
-                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
-                        "STAGEGATE_DATABASE_PORT": "6379",
-                        "STAGEGATE_DATABASE_READYPORT": "6379",
-                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
-                        "STAGEGATE_KONGDB_PORT": "5432",
-                        "STAGEGATE_KONGDB_READYPORT": "54325",
-                        "STAGEGATE_READY_TORUNPORT": "54329",
-                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
-                        "STAGEGATE_REGISTRY_PORT": "8500",
-                        "STAGEGATE_REGISTRY_READYPORT": "54324",
-                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
-                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
-                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-sys-mgmt-agent",
+                    "name": "edgex-kong",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-58890",
+                                "name": "tcp-8000",
                                 "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
+                                "port": 8000,
+                                "targetPort": 8000
+                            },
+                            {
+                                "name": "tcp-8100",
+                                "protocol": "TCP",
+                                "port": 8100,
+                                "targetPort": 8100
+                            },
+                            {
+                                "name": "tcp-8443",
+                                "protocol": "TCP",
+                                "port": 8443,
+                                "targetPort": 8443
                             }
                         ],
                         "selector": {
-                            "app": "edgex-sys-mgmt-agent"
+                            "app": "edgex-kong"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
+                                "app": "edgex-kong"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
+                                    "app": "edgex-kong"
                                 }
                             },
                             "spec": {
                                 "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -10132,19 +7890,37 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
                                             "type": "DirectoryOrCreate"
                                         }
+                                    },
+                                    {
+                                        "name": "postgres-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "edgexfoundry/sys-mgmt-agent:2.0.0",
+                                        "name": "edgex-kong",
+                                        "image": "kong:2.8.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
+                                                "name": "tcp-8000",
+                                                "containerPort": 8000,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8100",
+                                                "containerPort": 8100,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8443",
+                                                "containerPort": 8443,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -10157,95 +7933,97 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
                                             },
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
+                                                "name": "KONG_PROXY_ACCESS_LOG",
+                                                "value": "/dev/stdout"
                                             },
                                             {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
+                                                "name": "KONG_STATUS_LISTEN",
+                                                "value": "0.0.0.0:8100"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_LISTEN",
+                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
+                                            },
+                                            {
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_NGINX_WORKER_PROCESSES",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_VALID_TTL",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_PG_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "edgex-kong-db"
+                                            },
+                                            {
+                                                "name": "KONG_SSL_CIPHER_SUITE",
+                                                "value": "modern"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
+                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:2.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
                                             },
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
+                                                "name": "postgres-config",
+                                                "mountPath": "/tmp/postgres-config"
+                                            },
                                             {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
+                                                "name": "kong",
+                                                "mountPath": "/usr/local/kong"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-security-bootstrapper"
+                                "hostname": "edgex-kong"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -10306,7 +8084,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-kong-db",
-                                        "image": "postgres:12.3-alpine",
+                                        "image": "postgres:13.8-alpine",
                                         "ports": [
                                             {
                                                 "name": "tcp-5432",
@@ -10323,15 +8101,15 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "POSTGRES_USER",
+                                                "value": "kong"
+                                            },
+                                            {
                                                 "name": "POSTGRES_PASSWORD_FILE",
                                                 "value": "/tmp/postgres-config/.pgpassword"
                                             },
                                             {
                                                 "name": "POSTGRES_DB",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "POSTGRES_USER",
                                                 "value": "kong"
                                             }
                                         ],
@@ -10368,59 +8146,51 @@
                                 "hostname": "edgex-kong-db"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-core-metadata",
+                    "name": "edgex-ui-go",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59881",
+                                "name": "tcp-4000",
                                 "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
+                                "port": 4000,
+                                "targetPort": 4000
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-metadata"
+                            "app": "edgex-ui-go"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-metadata"
+                                "app": "edgex-ui-go"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-metadata"
+                                    "app": "edgex-ui-go"
                                 }
                             },
                             "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:2.0.0",
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:2.3.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -10434,58 +8204,54 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
+                                                "value": "edgex-ui-go"
                                             }
                                         ],
                                         "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-metadata"
+                                "hostname": "edgex-ui-go"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-security-secretstore-setup",
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
+                                "app": "edgex-support-notifications"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-security-secretstore-setup"
+                                    "app": "edgex-support-notifications"
                                 }
                             },
                             "spec": {
                                 "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -10493,27 +8259,22 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
+                                            "path": "/tmp/edgex/secrets/support-notifications",
                                             "type": "DirectoryOrCreate"
                                         }
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.0.0",
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -10523,63 +8284,167 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "ADD_SECRETSTORE_TOKENS"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/tmp/kong"
-                                            },
-                                            {
-                                                "name": "kuiper-config",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-security-secretstore-setup"
+                                "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "consul:1.13.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            },
+                                            {
+                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -10627,7 +8492,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:2.0.0",
+                                        "image": "edgexfoundry/device-virtual:2.3.0",
                                         "ports": [
                                             {
                                                 "name": "tcp-59900",
@@ -10665,7 +8530,951 @@
                                 "hostname": "edgex-device-virtual"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "minnesota",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "EDGEX_SECURITY_SECRET_STORE": "true",
+                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
+                        "SECRETSTORE_HOST": "edgex-vault",
+                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
+                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
+                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
+                        "STAGEGATE_DATABASE_PORT": "6379",
+                        "STAGEGATE_DATABASE_READYPORT": "6379",
+                        "STAGEGATE_READY_TORUNPORT": "54329",
+                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
+                        "STAGEGATE_REGISTRY_PORT": "8500",
+                        "STAGEGATE_REGISTRY_READYPORT": "54324",
+                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
+                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
+                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
+                    }
+                }
+            ],
+            "components": [
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.9.2-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "hashicorp/consul:1.15.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/core-data:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "redis-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "redis:7.0.11-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "DATABASECONFIG_PATH",
+                                                "value": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "redis-config",
+                                                "mountPath": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-ui-go"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:3.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -10690,7 +9499,15 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "consul-acl-token",
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-templates",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-tls",
                                         "emptyDir": {}
                                     },
                                     {
@@ -10699,12 +9516,16 @@
                                             "path": "/tmp/edgex/secrets/security-proxy-setup",
                                             "type": "DirectoryOrCreate"
                                         }
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:2.0.0",
+                                        "image": "edgexfoundry/security-proxy-setup:3.0.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -10714,43 +9535,40 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
+                                                "name": "EDGEX_ADD_PROXY_ROUTE",
+                                                "value": "device-rest.http://edgex-device-rest:59986"
                                             },
                                             {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
                                             },
                                             {
                                                 "name": "ROUTES_CORE_DATA_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
                                             },
                                             {
                                                 "name": "ROUTES_CORE_COMMAND_HOST",
                                                 "value": "edgex-core-command"
                                             },
                                             {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
                                             },
                                             {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
                                             },
                                             {
                                                 "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
@@ -10764,12 +9582,24 @@
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "nginx-templates",
+                                                "mountPath": "/etc/nginx/templates"
+                                            },
+                                            {
+                                                "name": "nginx-tls",
+                                                "mountPath": "/etc/ssl/nginx"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
                                                 "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
@@ -10778,7 +9608,1096 @@
                                 "hostname": "edgex-security-proxy-setup"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-notifications",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-common-config-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-common-config-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-common-config-bootstrapper",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-common-config-bootstrapper",
+                                        "image": "edgexfoundry/core-common-config-bootstrapper:3.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_REGISTRY_HOST",
+                                                "value": "edgex-core-consul"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-common-config-bootstrapper"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8200",
+                                "protocol": "TCP",
+                                "port": 8200,
+                                "targetPort": 8200
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-vault"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-file",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-logs",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault",
+                                        "image": "hashicorp/vault:1.13.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8200",
+                                                "containerPort": 8200,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            },
+                                            {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-file",
+                                                "mountPath": "/vault/file"
+                                            },
+                                            {
+                                                "name": "vault-logs",
+                                                "mountPath": "/vault/logs"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-nginx",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8443",
+                                "protocol": "TCP",
+                                "port": 8443,
+                                "targetPort": 8443
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-nginx"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-nginx"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-nginx"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume3",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume4",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-templates",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-tls",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-nginx",
+                                        "image": "nginx:1.24.0-alpine-slim",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8443",
+                                                "containerPort": 8443,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/etc/nginx/conf.d"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/var/cache/nginx"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume3",
+                                                "mountPath": "/var/log/nginx"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume4",
+                                                "mountPath": "/var/run"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "nginx-templates",
+                                                "mountPath": "/etc/nginx/templates"
+                                            },
+                                            {
+                                                "name": "nginx-tls",
+                                                "mountPath": "/etc/ssl/nginx"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-nginx"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/core-command:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "EXTERNALMQTT_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-proxy-auth",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59842",
+                                "protocol": "TCP",
+                                "port": 59842,
+                                "targetPort": 59842
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-proxy-auth"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-proxy-auth"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-proxy-auth"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-auth",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-proxy-auth",
+                                        "image": "edgexfoundry/security-proxy-auth:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59842",
+                                                "containerPort": 59842,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-proxy-auth"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-auth"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-proxy-auth"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-secretstore-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-secretstore-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:3.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:3.0.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "ireland",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "API_GATEWAY_HOST": "edgex-kong",
+                        "API_GATEWAY_STATUS_PORT": "8100",
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "true",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
+                        "REGISTRY_HOST": "edgex-core-consul",
+                        "SECRETSTORE_HOST": "edgex-vault",
+                        "SECRETSTORE_PORT": "8200",
+                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
+                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
+                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
+                        "STAGEGATE_DATABASE_PORT": "6379",
+                        "STAGEGATE_DATABASE_READYPORT": "6379",
+                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
+                        "STAGEGATE_KONGDB_PORT": "5432",
+                        "STAGEGATE_KONGDB_READYPORT": "54325",
+                        "STAGEGATE_READY_TORUNPORT": "54329",
+                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
+                        "STAGEGATE_REGISTRY_PORT": "8500",
+                        "STAGEGATE_REGISTRY_READYPORT": "54324",
+                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
+                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
+                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
+                    }
+                }
+            ],
+            "components": [
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "consul:1.9.5",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            },
+                                            {
+                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -10864,39 +10783,39 @@
                                 "hostname": "edgex-device-rest"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
+                    "name": "edgex-security-secretstore-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-security-secretstore-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
+                                    "app": "edgex-security-secretstore-setup"
                                 }
                             },
                             "spec": {
                                 "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -10904,22 +10823,27 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "path": "/tmp/edgex/secrets",
                                             "type": "DirectoryOrCreate"
                                         }
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.0.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -10929,64 +10853,83 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
+                                                "name": "ADD_SECRETSTORE_TOKENS"
                                             },
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
                                             },
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/tmp/kong"
+                                            },
+                                            {
+                                                "name": "kuiper-config",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-scheduler"
+                                "hostname": "edgex-security-secretstore-setup"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
+                    "name": "edgex-security-bootstrapper",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-security-bootstrapper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
+                                    "app": "edgex-security-bootstrapper"
                                 }
                             },
                             "spec": {
@@ -10994,27 +10937,12 @@
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-config",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.3.0-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:2.0.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -11024,32 +10952,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
                                             },
                                             {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
                                             }
                                         ],
                                         "resources": {},
@@ -11057,63 +10965,39 @@
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-config",
-                                                "mountPath": "/kuiper/etc/sources"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kuiper"
+                                "hostname": "edgex-security-bootstrapper"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
+                    "name": "edgex-security-proxy-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-consul"
+                                "app": "edgex-security-proxy-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-consul"
+                                    "app": "edgex-security-proxy-setup"
                                 }
                             },
                             "spec": {
                                 "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -11125,22 +11009,15 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-consul",
-                                        "image": "consul:1.9.5",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:2.0.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -11150,35 +11027,51 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
                                             },
                                             {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
                                             },
                                             {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
                                             },
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
                                             },
                                             {
-                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ADD_PROXY_ROUTE"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
@@ -11189,16 +11082,21 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-consul"
+                                "hostname": "edgex-security-proxy-setup"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -11301,6 +11199,18 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
                                                 "name": "KONG_PROXY_ACCESS_LOG",
                                                 "value": "/dev/stdout"
                                             },
@@ -11309,40 +11219,28 @@
                                                 "value": "edgex-kong-db"
                                             },
                                             {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
-                                                "value": "/dev/stdout"
+                                                "name": "KONG_PG_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
                                             },
                                             {
                                                 "name": "KONG_DNS_VALID_TTL",
                                                 "value": "1"
                                             },
                                             {
-                                                "name": "KONG_ADMIN_LISTEN",
-                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
                                             },
                                             {
                                                 "name": "KONG_STATUS_LISTEN",
                                                 "value": "0.0.0.0:8100"
                                             },
                                             {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
+                                                "name": "KONG_ADMIN_LISTEN",
+                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
                                             },
                                             {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_PG_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
                                             }
                                         ],
                                         "resources": {},
@@ -11378,7 +11276,227 @@
                                 "hostname": "edgex-kong"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:2.0.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8200",
+                                "protocol": "TCP",
+                                "port": 8200,
+                                "targetPort": 8200
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-vault"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-file",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-logs",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault",
+                                        "image": "vault:1.7.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8200",
+                                                "containerPort": 8200,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
+                                            },
+                                            {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-file",
+                                                "mountPath": "/vault/file"
+                                            },
+                                            {
+                                                "name": "vault-logs",
+                                                "mountPath": "/vault/logs"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -11479,105 +11597,12 @@
                                 "hostname": "edgex-core-data"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.0.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -11663,64 +11688,64 @@
                                 "hostname": "edgex-support-notifications"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
-                    "name": "edgex-vault",
+                    "name": "edgex-support-scheduler",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-8200",
+                                "name": "tcp-59861",
                                 "protocol": "TCP",
-                                "port": 8200,
-                                "targetPort": 8200
+                                "port": 59861,
+                                "targetPort": 59861
                             }
                         ],
                         "selector": {
-                            "app": "edgex-vault"
+                            "app": "edgex-support-scheduler"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-vault"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-vault"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "vault-file",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-logs",
-                                        "emptyDir": {}
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "type": "DirectoryOrCreate"
+                                        }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-vault",
-                                        "image": "vault:1.7.2",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-8200",
-                                                "containerPort": 8200,
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -11733,44 +11758,140 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "vault-file",
-                                                "mountPath": "/vault/file"
-                                            },
-                                            {
-                                                "name": "vault-logs",
-                                                "mountPath": "/vault/logs"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-vault"
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "edgexfoundry/sys-mgmt-agent:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -11856,7 +11977,132 @@
                                 "hostname": "edgex-core-command"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.3.0-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-config",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -11933,12 +12179,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
-                                            },
-                                            {
                                                 "name": "DATABASECONFIG_PATH",
                                                 "value": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
                                             }
                                         ],
                                         "resources": {},
@@ -11970,7 +12216,326 @@
                                 "hostname": "edgex-redis"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kong-db",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5432",
+                                "protocol": "TCP",
+                                "port": 5432,
+                                "targetPort": 5432
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kong-db"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kong-db"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kong-db"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume3",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "postgres-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "postgres-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kong-db",
+                                        "image": "postgres:12.3-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5432",
+                                                "containerPort": 5432,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "POSTGRES_DB",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "POSTGRES_USER",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "POSTGRES_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/var/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume3",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "postgres-config",
+                                                "mountPath": "/tmp/postgres-config"
+                                            },
+                                            {
+                                                "name": "postgres-data",
+                                                "mountPath": "/var/lib/postgresql/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kong-db"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 }
             ]
@@ -12005,35 +12570,26 @@
             ],
             "components": [
                 {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48081",
-                                "protocol": "TCP",
-                                "port": 48081,
-                                "targetPort": 48081
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
+                    "name": "edgex-proxy",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-metadata"
+                                "app": "edgex-proxy"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-metadata"
+                                    "app": "edgex-proxy"
                                 }
                             },
                             "spec": {
                                 "volumes": [
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
@@ -12044,19 +12600,110 @@
                                     {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-core-metadata",
+                                            "path": "/tmp/edgex/secrets/edgex-security-proxy-setup",
                                             "type": "DirectoryOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/docker-core-metadata-go:1.3.1",
+                                        "name": "edgex-proxy",
+                                        "image": "edgexfoundry/docker-security-proxy-setup-go:1.3.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSERVICE_SERVER",
+                                                "value": "edgex-vault"
+                                            },
+                                            {
+                                                "name": "SECRETSERVICE_TOKENPATH",
+                                                "value": "/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SECRETSERVICE_SNIS",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "SECRETSERVICE_CACERTPATH",
+                                                "value": "/tmp/edgex/secrets/ca/ca.pem"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "kong"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-security-proxy-setup"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-proxy"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-service-configurable-rules",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48100",
+                                "protocol": "TCP",
+                                "port": 48100,
+                                "targetPort": 48100
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-service-configurable-rules"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-service-configurable-rules"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-service-configurable-rules"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-service-configurable-rules",
+                                        "image": "edgexfoundry/docker-app-service-configurable:1.3.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-48081",
-                                                "containerPort": 48081,
+                                                "name": "tcp-48100",
+                                                "containerPort": 48100,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -12069,36 +12716,39 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
+                                                "value": "edgex-app-service-configurable-rules"
                                             },
                                             {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-core-metadata/secrets-token.json"
+                                                "name": "SERVICE_PORT",
+                                                "value": "48100"
+                                            },
+                                            {
+                                                "name": "MESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "BINDING_PUBLISHTOPIC",
+                                                "value": "events"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
                                             }
                                         ],
                                         "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-core-metadata"
-                                            }
-                                        ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-metadata"
+                                "hostname": "edgex-app-service-configurable-rules"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -12187,86 +12837,12 @@
                                 "hostname": "edgex-security-bootstrap-database"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-app-service-configurable-rules",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48100",
-                                "protocol": "TCP",
-                                "port": 48100,
-                                "targetPort": 48100
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-service-configurable-rules"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-service-configurable-rules"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-service-configurable-rules"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-service-configurable-rules",
-                                        "image": "edgexfoundry/docker-app-service-configurable:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48100",
-                                                "containerPort": 48100,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-service-configurable-rules"
-                                            },
-                                            {
-                                                "name": "SERVICE_PORT",
-                                                "value": "48100"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "BINDING_PUBLISHTOPIC",
-                                                "value": "events"
-                                            },
-                                            {
-                                                "name": "MESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-service-configurable-rules"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -12370,7 +12946,1282 @@
                                 "hostname": "edgex-core-data"
                             }
                         },
-                        "strategy": {}
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48082",
+                                "protocol": "TCP",
+                                "port": 48082,
+                                "targetPort": 48082
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-core-command",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/docker-core-command-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48082",
+                                                "containerPort": 48082,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-core-command/secrets-token.json"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-49990",
+                                "protocol": "TCP",
+                                "port": 49990,
+                                "targetPort": 49990
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/docker-device-virtual-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-49990",
+                                                "containerPort": 49990,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": ""
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": ""
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "",
+                                        "image": "kong:2.0.5",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KONG_PG_PASSWORD",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "kong-db"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ]
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "redis:6.0.9-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48090",
+                                "protocol": "TCP",
+                                "port": 48090,
+                                "targetPort": 48090
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "edgexfoundry/docker-sys-mgmt-agent-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48090",
+                                                "containerPort": 48090,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-secrets-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-secrets-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-secrets-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "secrets-setup-cache",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "vault-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-secrets-setup",
+                                        "image": "edgexfoundry/docker-security-secrets-setup-go:1.3.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "secrets-setup-cache",
+                                                "mountPath": "/etc/edgex/pki"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "vault-init",
+                                                "mountPath": "/vault/init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-secrets-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-49986",
+                                "protocol": "TCP",
+                                "port": 49986,
+                                "targetPort": 49986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/docker-device-rest-go:1.2.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-49986",
+                                                "containerPort": 49986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "kong",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8000",
+                                "protocol": "TCP",
+                                "port": 8000,
+                                "targetPort": 8000
+                            },
+                            {
+                                "name": "tcp-8001",
+                                "protocol": "TCP",
+                                "port": 8001,
+                                "targetPort": 8001
+                            },
+                            {
+                                "name": "tcp-8443",
+                                "protocol": "TCP",
+                                "port": 8443,
+                                "targetPort": 8443
+                            },
+                            {
+                                "name": "tcp-8444",
+                                "protocol": "TCP",
+                                "port": 8444,
+                                "targetPort": 8444
+                            }
+                        ],
+                        "selector": {
+                            "app": "kong"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "kong"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "kong"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "kong",
+                                        "image": "kong:2.0.5",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8000",
+                                                "containerPort": 8000,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8001",
+                                                "containerPort": 8001,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8443",
+                                                "containerPort": 8443,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8444",
+                                                "containerPort": 8444,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_LISTEN",
+                                                "value": "0.0.0.0:8001, 0.0.0.0:8444 ssl"
+                                            },
+                                            {
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "kong-db"
+                                            },
+                                            {
+                                                "name": "KONG_PG_PASSWORD",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/usr/local/kong"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "kong"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-20498",
+                                "protocol": "TCP",
+                                "port": 20498,
+                                "targetPort": 20498
+                            },
+                            {
+                                "name": "tcp-48075",
+                                "protocol": "TCP",
+                                "port": 48075,
+                                "targetPort": 48075
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "emqx/kuiper:1.1.1-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-20498",
+                                                "containerPort": 20498,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-48075",
+                                                "containerPort": 48075,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "48075"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "5566"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "tcp"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-app-service-configurable-rules"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVICESERVER",
+                                                "value": "http://edgex-core-data:48080"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "events"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume3",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-kong",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume4",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-vault",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "edgexfoundry/docker-edgex-consul:1.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_DB",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURE",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_SETUP_DONE_FLAG",
+                                                "value": "/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            },
+                                            {
+                                                "name": "anonymous-volume3",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-kong"
+                                            },
+                                            {
+                                                "name": "anonymous-volume4",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-vault"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48081",
+                                "protocol": "TCP",
+                                "port": 48081,
+                                "targetPort": 48081
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-core-metadata",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/docker-core-metadata-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48081",
+                                                "containerPort": 48081,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-core-metadata/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-core-metadata"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48085",
+                                "protocol": "TCP",
+                                "port": 48085,
+                                "targetPort": 48085
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-support-scheduler",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/docker-support-scheduler-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48085",
+                                                "containerPort": 48085,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-support-scheduler/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-support-scheduler"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48060",
+                                "protocol": "TCP",
+                                "port": 48060,
+                                "targetPort": 48060
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-support-notifications",
+                                            "type": "DirectoryOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/docker-support-notifications-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48060",
+                                                "containerPort": 48060,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-support-notifications/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-support-notifications"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
                 },
                 {
@@ -12477,789 +14328,12 @@
                                 "hostname": "kong-db"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "redis:6.0.9-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-scripts",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume3",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-kong",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume4",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-vault",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-consul",
-                                        "image": "edgexfoundry/docker-edgex-consul:1.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_SETUP_DONE_FLAG",
-                                                "value": "/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
-                                            },
-                                            {
-                                                "name": "EDGEX_DB",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURE",
-                                                "value": "true"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
-                                            },
-                                            {
-                                                "name": "anonymous-volume3",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-kong"
-                                            },
-                                            {
-                                                "name": "anonymous-volume4",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-vault"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-49990",
-                                "protocol": "TCP",
-                                "port": 49990,
-                                "targetPort": 49990
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/docker-device-virtual-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-49990",
-                                                "containerPort": 49990,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-20498",
-                                "protocol": "TCP",
-                                "port": 20498,
-                                "targetPort": 20498
-                            },
-                            {
-                                "name": "tcp-48075",
-                                "protocol": "TCP",
-                                "port": 48075,
-                                "targetPort": 48075
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "emqx/kuiper:1.1.1-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-20498",
-                                                "containerPort": 20498,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-48075",
-                                                "containerPort": 48075,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "48075"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "5566"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "tcp"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-app-service-configurable-rules"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVICESERVER",
-                                                "value": "http://edgex-core-data:48080"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "events"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "kong",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8000",
-                                "protocol": "TCP",
-                                "port": 8000,
-                                "targetPort": 8000
-                            },
-                            {
-                                "name": "tcp-8001",
-                                "protocol": "TCP",
-                                "port": 8001,
-                                "targetPort": 8001
-                            },
-                            {
-                                "name": "tcp-8443",
-                                "protocol": "TCP",
-                                "port": 8443,
-                                "targetPort": 8443
-                            },
-                            {
-                                "name": "tcp-8444",
-                                "protocol": "TCP",
-                                "port": 8444,
-                                "targetPort": 8444
-                            }
-                        ],
-                        "selector": {
-                            "app": "kong"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "kong"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "kong"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-scripts",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "kong",
-                                        "image": "kong:2.0.5",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8000",
-                                                "containerPort": 8000,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8001",
-                                                "containerPort": 8001,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8443",
-                                                "containerPort": 8443,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8444",
-                                                "containerPort": 8444,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_LISTEN",
-                                                "value": "0.0.0.0:8001, 0.0.0.0:8444 ssl"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "kong-db"
-                                            },
-                                            {
-                                                "name": "KONG_PG_PASSWORD",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/usr/local/kong"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "kong"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-49986",
-                                "protocol": "TCP",
-                                "port": 49986,
-                                "targetPort": 49986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/docker-device-rest-go:1.2.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-49986",
-                                                "containerPort": 49986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48082",
-                                "protocol": "TCP",
-                                "port": 48082,
-                                "targetPort": 48082
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-core-command",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/docker-core-command-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48082",
-                                                "containerPort": 48082,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-core-command/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-core-command"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48060",
-                                "protocol": "TCP",
-                                "port": 48060,
-                                "targetPort": 48060
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/docker-support-notifications-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48060",
-                                                "containerPort": 48060,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-support-notifications/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -13336,16 +14410,16 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            },
+                                            {
                                                 "name": "VAULT_ADDR",
                                                 "value": "https://edgex-vault:8200"
                                             },
                                             {
                                                 "name": "VAULT_CONFIG_DIR",
                                                 "value": "/vault/config"
-                                            },
-                                            {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
                                             }
                                         ],
                                         "resources": {},
@@ -13377,78 +14451,12 @@
                                 "hostname": "edgex-vault"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48090",
-                                "protocol": "TCP",
-                                "port": 48090,
-                                "targetPort": 48090
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "edgexfoundry/docker-sys-mgmt-agent-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48090",
-                                                "containerPort": 48090,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {}
                     }
                 },
                 {
@@ -13538,355 +14546,12 @@
                                 "hostname": "edgex-vault-worker"
                             }
                         },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-proxy",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-proxy"
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
                             }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-proxy"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-scripts",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-proxy",
-                                        "image": "edgexfoundry/docker-security-proxy-setup-go:1.3.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSERVICE_SERVER",
-                                                "value": "edgex-vault"
-                                            },
-                                            {
-                                                "name": "SECRETSERVICE_CACERTPATH",
-                                                "value": "/tmp/edgex/secrets/ca/ca.pem"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "SECRETSERVICE_SNIS",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "SECRETSERVICE_TOKENPATH",
-                                                "value": "/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-security-proxy-setup"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-proxy"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-secrets-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-secrets-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-secrets-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "secrets-setup-cache",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "vault-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-secrets-setup",
-                                        "image": "edgexfoundry/docker-security-secrets-setup-go:1.3.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "secrets-setup-cache",
-                                                "mountPath": "/etc/edgex/pki"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "vault-init",
-                                                "mountPath": "/vault/init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-secrets-setup"
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": ""
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": ""
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-scripts",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "",
-                                        "image": "kong:2.0.5",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KONG_PG_PASSWORD",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "kong-db"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ]
-                            }
-                        },
-                        "strategy": {}
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48085",
-                                "protocol": "TCP",
-                                "port": 48085,
-                                "targetPort": 48085
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
                         }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-support-scheduler",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/docker-support-scheduler-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48085",
-                                                "containerPort": 48085,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-support-scheduler/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-support-scheduler"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {}
                     }
                 }
             ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug
/sig iot

#### What this PR does / why we need it:
The default maxSurge value for k8s deployment is 25%, and when replicas is 1, maxSurge is 1 after rounding up. This results in the existence of 2 identical edgex components at the same time after a quick create + update operation, and edgex components use a registration mechanism. If a component preregisters and is terminated by workload, this causes the metadata component to scramble. This chaos manifests itself in the form of other components crashing all the time.

I updated `auto-collector` to directly inject the default maxSurge value of 0 into the config file and the issue was resolved.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2028 