### PR TITLE
improve pod webhook for adapting hostnetwork mode nodepool

### DIFF
--- a/pkg/yurtmanager/webhook/pod/v1alpha1/pod_default.go
+++ b/pkg/yurtmanager/webhook/pod/v1alpha1/pod_default.go
@@ -27,6 +27,11 @@ import (
 	"github.com/openyurtio/openyurt/pkg/apis/apps"
 )
 
+const (
+	NodePoolHostNetworkLabelKey       = "nodepool.openyurt.io/hostnetwork"
+	NodePoolHostNetworkLabelForbidden = "true"
+)
+
 // Default implements builder.CustomDefaulter.
 func (webhook *PodHandler) Default(ctx context.Context, obj runtime.Object) error {
 	pod, ok := obj.(*corev1.Pod)
@@ -35,34 +40,58 @@ func (webhook *PodHandler) Default(ctx context.Context, obj runtime.Object) erro
 	}
 
 	// Add NodeAffinity to pods in order to avoid pods to be scheduled on the nodes in the hostNetwork mode NodePool
-	annotations := pod.ObjectMeta.GetAnnotations()
-	if annotations != nil && annotations[apps.AnnotationExcludeHostNetworkPool] == "true" {
-		excludeHostNetworkTerm := corev1.NodeSelectorTerm{
-			MatchExpressions: []corev1.NodeSelectorRequirement{
+	if pod.Annotations[apps.AnnotationExcludeHostNetworkPool] != "true" {
+		return nil
+	}
+
+	excludeHostNetworkRequirement := corev1.NodeSelectorRequirement{
+		Key:      NodePoolHostNetworkLabelKey,
+		Operator: corev1.NodeSelectorOpNotIn,
+		Values:   []string{NodePoolHostNetworkLabelForbidden},
+	}
+
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &corev1.Affinity{}
+	}
+
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		pod.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+
+	if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
 				{
-					Key:      "nodepool.openyurt.io/hostnetwork",
-					Operator: corev1.NodeSelectorOpNotIn,
-					Values:   []string{"true"},
+					MatchExpressions: []corev1.NodeSelectorRequirement{},
 				},
 			},
 		}
-
-		if pod.Spec.Affinity == nil {
-			pod.Spec.Affinity = &corev1.Affinity{}
-		}
-
-		if pod.Spec.Affinity.NodeAffinity == nil {
-			pod.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
-		}
-
-		if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
-		}
-
+	} else if len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
 		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
 			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			excludeHostNetworkTerm,
-		)
+			corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{},
+			})
 	}
+
+	for i, term := range pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+		needToAddAffinity := true
+		for _, expr := range term.MatchExpressions {
+			if expr.Key == NodePoolHostNetworkLabelKey && expr.Operator == corev1.NodeSelectorOpNotIn {
+				if len(expr.Values) == 1 && expr.Values[0] == NodePoolHostNetworkLabelForbidden {
+					needToAddAffinity = false
+					break
+				}
+			}
+		}
+
+		if needToAddAffinity {
+			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions = append(
+				pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions,
+				excludeHostNetworkRequirement,
+			)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

 /kind enhancement

#### What this PR does / why we need it:
Because of terms in pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms are ORed, not ANDed, so we need to add excludeHostNetworkRequirement for each NodeSelectorTerms.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
