### PR TITLE
improve restmapper for gateway resource

### DIFF
--- a/pkg/yurthub/kubernetes/meta/restmapper_test.go
+++ b/pkg/yurthub/kubernetes/meta/restmapper_test.go
@@ -237,3 +237,31 @@ func dynamicRESTMapperToString(m map[schema.GroupVersionResource]schema.GroupVer
 	}
 	return resultMapper
 }
+
+func TestKindToResource(t *testing.T) {
+	testCases := []struct {
+		Kind             string
+		Plural, Singular string
+	}{
+		{Kind: "Pod", Plural: "pods", Singular: "pod"},
+
+		{Kind: "Gateway", Plural: "gateways", Singular: "gateway"},
+
+		{Kind: "ReplicationController", Plural: "replicationcontrollers", Singular: "replicationcontroller"},
+
+		// Add "ies" when ending with "y"
+		{Kind: "ImageRepository", Plural: "imagerepositories", Singular: "imagerepository"},
+		// Add "es" when ending with "s"
+		{Kind: "miss", Plural: "misses", Singular: "miss"},
+		// Add "s" otherwise
+		{Kind: "lowercase", Plural: "lowercases", Singular: "lowercase"},
+	}
+	for i, testCase := range testCases {
+		version := schema.GroupVersion{}
+
+		plural, singular := specifiedKindToResource(version.WithKind(testCase.Kind))
+		if singular != version.WithResource(testCase.Singular) || plural != version.WithResource(testCase.Plural) {
+			t.Errorf("%d: unexpected plural and singular: %v %v", i, plural, singular)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
because plural of gateway is gateways instead of gatewaies in raven, so we need to deal with gateway resource specially in restmapper of yurthub component.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
