### PR TITLE
rename ConcurrentNodepools to ConcurrentNodePoolWorkers

### DIFF
--- a/cmd/yurt-manager/app/options/nodepoolcontroller.go
+++ b/cmd/yurt-manager/app/options/nodepoolcontroller.go
@@ -30,7 +30,7 @@ func NewNodePoolControllerOptions() *NodePoolControllerOptions {
 	return &NodePoolControllerOptions{
 		&config.NodePoolControllerConfiguration{
 			EnableSyncNodePoolConfigurations: true,
-			ConcurrentNodepools:              3,
+			ConcurrentNodePoolWorkers:        3,
 		},
 	}
 }
@@ -42,7 +42,7 @@ func (n *NodePoolControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.BoolVar(&n.EnableSyncNodePoolConfigurations, "enable-sync-nodepool-configurations", n.EnableSyncNodePoolConfigurations, "enable to sync nodepool configurations(including labels, annotations, taints in spec) to nodes in the nodepool.")
-	fs.Int32Var(&n.ConcurrentNodepools, "concurrent-nodepools", n.ConcurrentNodepools, "The number of node pools that are allowed to reconcile concurrently.")
+	fs.Int32Var(&n.ConcurrentNodePoolWorkers, "concurrent-nodepool-workers", n.ConcurrentNodePoolWorkers, "The number of nodepool objects that are allowed to reconcile concurrently.")
 }
 
 // ApplyTo fills up nodePool config with options.
@@ -51,7 +51,7 @@ func (o *NodePoolControllerOptions) ApplyTo(cfg *config.NodePoolControllerConfig
 		return nil
 	}
 	cfg.EnableSyncNodePoolConfigurations = o.EnableSyncNodePoolConfigurations
-	cfg.ConcurrentNodepools = o.ConcurrentNodepools
+	cfg.ConcurrentNodePoolWorkers = o.ConcurrentNodePoolWorkers
 
 	return nil
 }

--- a/pkg/yurtmanager/controller/nodepool/config/types.go
+++ b/pkg/yurtmanager/controller/nodepool/config/types.go
@@ -19,5 +19,5 @@ package config
 // NodePoolControllerConfiguration contains elements describing NodePoolController.
 type NodePoolControllerConfiguration struct {
 	EnableSyncNodePoolConfigurations bool
-	ConcurrentNodepools              int32
+	ConcurrentNodePoolWorkers        int32
 }

--- a/pkg/yurtmanager/controller/nodepool/nodepool_controller.go
+++ b/pkg/yurtmanager/controller/nodepool/nodepool_controller.go
@@ -68,7 +68,7 @@ func Add(ctx context.Context, c *config.CompletedConfig, mgr manager.Manager) er
 
 	// Create a new controller
 	ctrl, err := controller.New(names.NodePoolController, mgr, controller.Options{
-		Reconciler: r, MaxConcurrentReconciles: int(c.ComponentConfig.NodePoolController.ConcurrentNodepools),
+		Reconciler: r, MaxConcurrentReconciles: int(c.ComponentConfig.NodePoolController.ConcurrentNodePoolWorkers),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:
The parameter `ConcurrentNodepools ` is not match with NodePool controller, so rename it to `ConcurrentNodePoolWorkers`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
