### PR TITLE
improve independent webhook

### DIFF
--- a/pkg/yurtmanager/webhook/node/v1/node_handler.go
+++ b/pkg/yurtmanager/webhook/node/v1/node_handler.go
@@ -20,7 +20,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	yurtClient "github.com/openyurtio/openyurt/cmd/yurt-manager/app/client"
@@ -37,17 +36,7 @@ func (webhook *NodeHandler) SetupWebhookWithManager(mgr ctrl.Manager) (string, s
 	// init
 	webhook.Client = yurtClient.GetClientByControllerNameOrDie(mgr, names.NodePoolController)
 
-	gvk, err := apiutil.GVKForObject(&v1.Node{}, mgr.GetScheme())
-	if err != nil {
-		return "", "", err
-	}
-	return util.GenerateMutatePath(gvk),
-		util.GenerateValidatePath(gvk),
-		ctrl.NewWebhookManagedBy(mgr).
-			For(&v1.Node{}).
-			WithDefaulter(webhook).
-			WithValidator(webhook).
-			Complete()
+	return util.RegisterIndependentWebhook(mgr, &v1.Node{}, webhook, webhook)
 }
 
 // +kubebuilder:webhook:path=/validate-core-openyurt-io-v1-node,mutating=false,failurePolicy=ignore,sideEffects=None,admissionReviewVersions=v1,groups="",resources=nodes,verbs=update,versions=v1,name=validate.core.v1.node.openyurt.io

--- a/pkg/yurtmanager/webhook/pod/v1alpha1/pod_handler.go
+++ b/pkg/yurtmanager/webhook/pod/v1alpha1/pod_handler.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/util"
@@ -31,18 +30,7 @@ const (
 
 // SetupWebhookWithManager sets up Cluster webhooks. mutate path, validate path, error
 func (webhook *PodHandler) SetupWebhookWithManager(mgr ctrl.Manager) (string, string, error) {
-	// init
-
-	gvk, err := apiutil.GVKForObject(&corev1.Pod{}, mgr.GetScheme())
-	if err != nil {
-		return "", "", err
-	}
-	return util.GenerateMutatePath(gvk),
-		util.GenerateValidatePath(gvk),
-		ctrl.NewWebhookManagedBy(mgr).
-			For(&corev1.Pod{}).
-			WithDefaulter(webhook).
-			Complete()
+	return util.RegisterIndependentWebhook(mgr, &corev1.Pod{}, webhook, nil)
 }
 
 // +kubebuilder:webhook:path=/mutate-core-openyurt-io-v1-pod,mutating=true,failurePolicy=ignore,sideEffects=None,admissionReviewVersions=v1;v1beta1,groups="",resources=pods,verbs=create,versions=v1,name=mutate.core.v1.pod.openyurt.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:

Because of Group is empty for `node` and `pod` resource, so webhook paths are not registered correctly.
The detail logs are as following:

```
I0618 03:23:08.492989       1 webhook.go:158] controller-runtime/builder "msg"="Registering a mutating webhook" "GVK"={"Group":"","Version":"v1","Kind":"Node"} "path"="/mutate--v1-node"
I0618 03:23:08.493039       1 server.go:183] controller-runtime/webhook "msg"="Registering webhook" "path"="/mutate--v1-node"
I0618 03:23:08.493061       1 webhook.go:189] controller-runtime/builder "msg"="Registering a validating webhook" "GVK"={"Group":"","Version":"v1","Kind":"Node"} "path"="/validate--v1-node"
I0618 03:23:08.493085       1 server.go:183] controller-runtime/webhook "msg"="Registering webhook" "path"="/validate--v1-node
```

so add a new func named `RegisterIndependentWebhook ` to deal with these kind of webhook registration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
