### PR TITLE
feat: use secrets.SYNC_OPENYURTIO_CHARTS_KEY to sync charts to openyurtio/charts repo.

### DIFF
--- a/.github/workflows/sync-charts.yaml
+++ b/.github/workflows/sync-charts.yaml
@@ -15,15 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get the version
-        id: get_version
-        run: |
-          echo "CHART_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
       - name: Sync to openyurtio/charts Repo
         env:
-          SSH_DEPLOY_KEY: ${{ secrets.SYNC_CHARTS_SECRET }}
-          VERSION: ${{ steps.get_version.outputs.CHART_VERSION }}
+          SSH_DEPLOY_KEY: ${{ secrets.SYNC_OPENYURTIO_CHARTS_KEY }}
           COMMIT_ID: ${{ github.sha }}
         run: |
           bash ./hack/lib/sync-charts.sh

--- a/hack/lib/sync-charts.sh
+++ b/hack/lib/sync-charts.sh
@@ -75,8 +75,7 @@ cp -R openyurt/charts/yurt-manager/* charts/charts/yurt-manager/
 cp -R openyurt/charts/yurthub/* charts/charts/yurthub/
 cp -R openyurt/charts/yurt-iot-dock/* charts/charts/yurt-iot-dock/
 
-echo "push to openyurtio/charts"
-echo "version: $VERSION, commit: $COMMIT_ID"
+echo "push to openyurtio/charts from commit: $COMMIT_ID"
 
 cd charts
 
@@ -84,7 +83,6 @@ if [ -z "$(git status --porcelain)" ]; then
   echo "nothing need to push, finished!"
 else
   git add .
-  git commit -m "align with openyurt charts $VERSION from commit $COMMIT_ID"
-  git tag "$VERSION"
+  git commit -m "align with openyurt helm charts from commit $COMMIT_ID"
   git push origin main
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind feature

#### What this PR does / why we need it:
because `secrets.SYNC_CHARTS_SECRET` is used for syncing charts to `openyurtio/openyurt-helm` repo. so we create a new key named `SYNC_OPENYURTIO_CHARTS_KEY` for syncing charts to `openyurtio/charts` repo.

moreover, charts releaser only rely on the version filed in the Chart.yaml of helm chart, so we remove the `$VERSION` info in the `sync-charts.sh`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
