### PR TITLE
fix(iot): the mount type of hostpath for localtime in napa

### DIFF
--- a/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config-nosecty.json
+++ b/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config-nosecty.json
@@ -12,343 +12,6 @@
             ],
             "components": [
                 {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-etc",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-plugins",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "openyurt/ekuiper:1.11.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-etc",
-                                                "mountPath": "/kuiper/etc"
-                                            },
-                                            {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
-                                            },
-                                            {
-                                                "name": "kuiper-plugins",
-                                                "mountPath": "/kuiper/plugins"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "openyurt/support-notifications:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
                     "name": "edgex-core-command",
                     "service": {
                         "ports": [
@@ -382,14 +45,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:3.1.0",
+                                        "image": "openyurt/core-command:3.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59882",
@@ -440,18 +103,31 @@
                     }
                 },
                 {
-                    "name": "edgex-core-common-config-bootstrapper",
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-common-config-bootstrapper"
+                                "app": "edgex-kuiper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-common-config-bootstrapper"
+                                    "app": "edgex-kuiper"
                                 }
                             },
                             "spec": {
@@ -460,283 +136,34 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
-                                    }
-                                ],
-                                "containers": [
+                                    },
                                     {
-                                        "name": "edgex-core-common-config-bootstrapper",
-                                        "image": "openyurt/core-common-config-bootstrapper:3.1.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_REGISTRY_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
+                                        "name": "kuiper-data",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "consul-data",
+                                        "name": "kuiper-etc",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-plugins",
                                         "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-consul",
-                                        "image": "openyurt/consul:1.16.2",
+                                        "name": "edgex-kuiper",
+                                        "image": "openyurt/ekuiper:1.11.5-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -749,16 +176,48 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
                                             },
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
                                             },
                                             {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -766,12 +225,28 @@
                                             {
                                                 "name": "anonymous-volume1",
                                                 "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-etc",
+                                                "mountPath": "/kuiper/etc"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            },
+                                            {
+                                                "name": "kuiper-plugins",
+                                                "mountPath": "/kuiper/plugins"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-app-rules-engine"
+                                "hostname": "edgex-kuiper"
                             }
                         },
                         "strategy": {
@@ -816,14 +291,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-core-metadata",
-                                        "image": "openyurt/core-metadata:3.1.0",
+                                        "image": "openyurt/core-metadata:3.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59881",
@@ -903,14 +378,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-device-rest",
-                                        "image": "openyurt/device-rest:3.1.0",
+                                        "image": "openyurt/device-rest:3.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59986",
@@ -957,48 +432,230 @@
                     }
                 },
                 {
-                    "name": "edgex-redis",
+                    "name": "edgex-core-data",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-6379",
+                                "name": "tcp-59880",
                                 "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                                "port": 59880,
+                                "targetPort": 59880
                             }
                         ],
                         "selector": {
-                            "app": "edgex-redis"
+                            "app": "edgex-core-data"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-core-data"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
+                                    "app": "edgex-core-data"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "db-data",
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
                                         "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:7.0.14-alpine",
+                                        "name": "edgex-core-consul",
+                                        "image": "openyurt/consul:1.16.6",
                                         "ports": [
                                             {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -1012,14 +669,105 @@
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-redis"
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
                             }
                         },
                         "strategy": {
@@ -1064,7 +812,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -1118,31 +866,31 @@
                     }
                 },
                 {
-                    "name": "edgex-device-virtual",
+                    "name": "edgex-support-scheduler",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59900",
+                                "name": "tcp-59861",
                                 "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
+                                "port": 59861,
+                                "targetPort": 59861
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-virtual"
+                            "app": "edgex-support-scheduler"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-virtual"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-virtual"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
@@ -1151,18 +899,18 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:3.1.0",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:3.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -1179,8 +927,16 @@
                                                 "value": "false"
                                             },
                                             {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
+                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
@@ -1193,7 +949,251 @@
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-virtual"
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:7.0.15-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "openyurt/support-notifications:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-common-config-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-common-config-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-common-config-bootstrapper",
+                                        "image": "openyurt/core-common-config-bootstrapper:3.1.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ALL_SERVICES_REGISTRY_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-common-config-bootstrapper"
                             }
                         },
                         "strategy": {
@@ -1228,85 +1228,6 @@
                 }
             ],
             "components": [
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5563",
-                                "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
                 {
                     "name": "edgex-device-rest",
                     "service": {
@@ -1376,264 +1297,6 @@
                     }
                 },
                 {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "openyurt/edgex-ui:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "openyurt/ekuiper:1.4.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
                     "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
@@ -1682,11 +1345,11 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
+                                                "name": "NOTIFICATIONS_SENDER",
                                                 "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "NOTIFICATIONS_SENDER",
+                                                "name": "SERVICE_HOST",
                                                 "value": "edgex-core-metadata"
                                             }
                                         ],
@@ -1774,6 +1437,420 @@
                     }
                 },
                 {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "openyurt/ekuiper:1.4.4-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:6.2.6-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
                     "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
@@ -1822,20 +1899,20 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
                                                 "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
                                                 "value": "edgex-redis"
                                             },
                                             {
                                                 "name": "EDGEX_PROFILE",
                                                 "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -1843,6 +1920,147 @@
                                     }
                                 ],
                                 "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "openyurt/edgex-ui:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
                             }
                         },
                         "strategy": {
@@ -2002,7 +2220,31 @@
                             }
                         }
                     }
-                },
+                }
+            ]
+        },
+        {
+            "versionName": "jakarta",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "false",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "REGISTRY_HOST": "edgex-core-consul"
+                    }
+                }
+            ],
+            "components": [
                 {
                     "name": "edgex-core-command",
                     "service": {
@@ -2035,7 +2277,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:2.2.0",
+                                        "image": "openyurt/core-command:2.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59882",
@@ -2061,248 +2303,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:6.2.6-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "jakarta",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "false",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "REGISTRY_HOST": "edgex-core-consul"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "openyurt/support-notifications:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
                             }
                         },
                         "strategy": {
@@ -2368,6 +2368,10 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
                                                 "name": "EDGEX__DEFAULT__TYPE",
                                                 "value": "redis"
                                             },
@@ -2376,15 +2380,23 @@
                                                 "value": "true"
                                             },
                                             {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
                                                 "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
                                                 "value": "redis"
                                             },
                                             {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "name": "EDGEX__DEFAULT__PORT",
                                                 "value": "6379"
                                             },
                                             {
@@ -2392,23 +2404,11 @@
                                                 "value": "edgex-redis"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
                                             },
                                             {
                                                 "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
                                                 "value": "redis"
                                             }
                                         ],
@@ -2423,82 +2423,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
                             }
                         },
                         "strategy": {
@@ -2578,42 +2502,184 @@
                     }
                 },
                 {
-                    "name": "edgex-device-virtual",
+                    "name": "edgex-ui-go",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59900",
+                                "name": "tcp-4000",
                                 "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
+                                "port": 4000,
+                                "targetPort": 4000
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-virtual"
+                            "app": "edgex-ui-go"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-virtual"
+                                "app": "edgex-ui-go"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-virtual"
+                                    "app": "edgex-ui-go"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:2.1.1",
+                                        "name": "edgex-ui-go",
+                                        "image": "openyurt/edgex-ui:2.1.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:2.1.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "openyurt/support-notifications:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -2627,14 +2693,14 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-virtual"
+                                "hostname": "edgex-support-notifications"
                             }
                         },
                         "strategy": {
@@ -2646,42 +2712,42 @@
                     }
                 },
                 {
-                    "name": "edgex-core-command",
+                    "name": "edgex-support-scheduler",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59882",
+                                "name": "tcp-59861",
                                 "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
+                                "port": 59861,
+                                "targetPort": 59861
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-command"
+                            "app": "edgex-support-scheduler"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-command"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-command"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:2.1.1",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -2694,173 +2760,23 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.1.1",
-                                        "ports": [
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
                                             {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
                                             },
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
+                                                "value": "edgex-support-scheduler"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-consul",
-                                        "image": "openyurt/consul:1.10.3",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
                         "strategy": {
@@ -3018,42 +2934,124 @@
                     }
                 },
                 {
-                    "name": "edgex-app-rules-engine",
+                    "name": "edgex-core-consul",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59701",
+                                "name": "tcp-8500",
                                 "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
+                                "port": 8500,
+                                "targetPort": 8500
                             }
                         ],
                         "selector": {
-                            "app": "edgex-app-rules-engine"
+                            "app": "edgex-core-consul"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-app-rules-engine"
+                                "app": "edgex-core-consul"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-app-rules-engine"
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "openyurt/consul:1.10.3",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:2.1.2",
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3066,27 +3064,15 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
+                                                "value": "edgex-device-virtual"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-app-rules-engine"
+                                "hostname": "edgex-device-virtual"
                             }
                         },
                         "strategy": {
@@ -3098,42 +3084,42 @@
                     }
                 },
                 {
-                    "name": "edgex-ui-go",
+                    "name": "edgex-sys-mgmt-agent",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-4000",
+                                "name": "tcp-58890",
                                 "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
+                                "port": 58890,
+                                "targetPort": 58890
                             }
                         ],
                         "selector": {
-                            "app": "edgex-ui-go"
+                            "app": "edgex-sys-mgmt-agent"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-ui-go"
+                                "app": "edgex-sys-mgmt-agent"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-ui-go"
+                                    "app": "edgex-sys-mgmt-agent"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-ui-go",
-                                        "image": "openyurt/edgex-ui:2.1.0",
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3144,11 +3130,25 @@
                                                 }
                                             }
                                         ],
+                                        "env": [
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            }
+                                        ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-ui-go"
+                                "hostname": "edgex-sys-mgmt-agent"
                             }
                         },
                         "strategy": {
@@ -3263,42 +3263,53 @@
             ],
             "components": [
                 {
-                    "name": "edgex-device-virtual",
+                    "name": "edgex-core-data",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59900",
+                                "name": "tcp-5563",
                                 "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-virtual"
+                            "app": "edgex-core-data"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-virtual"
+                                "app": "edgex-core-data"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-virtual"
+                                    "app": "edgex-core-data"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:2.3.0",
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:2.3.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3312,14 +3323,14 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
+                                                "value": "edgex-core-data"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-virtual"
+                                "hostname": "edgex-core-data"
                             }
                         },
                         "strategy": {
@@ -3399,6 +3410,82 @@
                     }
                 },
                 {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "openyurt/core-command:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            },
+                                            {
+                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
                     "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
@@ -3447,12 +3534,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
                                                 "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
                                                 "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
                                             },
                                             {
                                                 "name": "EDGEX_PROFILE",
@@ -3468,274 +3555,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "openyurt/ekuiper:1.7.1-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "openyurt/core-metadata:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
                             }
                         },
                         "strategy": {
@@ -3829,53 +3648,122 @@
                     }
                 },
                 {
-                    "name": "edgex-core-data",
+                    "name": "edgex-redis",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-5563",
+                                "name": "tcp-6379",
                                 "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
+                                "port": 6379,
+                                "targetPort": 6379
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-data"
+                            "app": "edgex-redis"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-data"
+                                "app": "edgex-redis"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-redis"
                                 }
                             },
                             "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:2.3.0",
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:7.0.5-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
                                                 "protocol": "TCP"
-                                            },
+                                            }
+                                        ],
+                                        "envFrom": [
                                             {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "openyurt/ekuiper:1.7.1-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3888,15 +3776,213 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
                         "strategy": {
@@ -3976,6 +4062,146 @@
                     }
                 },
                 {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "openyurt/core-metadata:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
                     "name": "edgex-support-notifications",
                     "service": {
                         "ports": [
@@ -4042,232 +4268,6 @@
                             }
                         }
                     }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:7.0.5-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "openyurt/core-command:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
                 }
             ]
         },
@@ -4283,137 +4283,25 @@
             ],
             "components": [
                 {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
+                    "name": "edgex-core-common-config-bootstrapper",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-consul"
+                                "app": "edgex-core-common-config-bootstrapper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-consul"
+                                    "app": "edgex-core-common-config-bootstrapper"
                                 }
                             },
                             "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-consul",
-                                        "image": "openyurt/consul:1.15.2",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kuiper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "openyurt/ekuiper:1.9.2-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-core-common-config-bootstrapper",
+                                        "image": "openyurt/core-common-config-bootstrapper:3.0.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -4423,285 +4311,27 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
                                             },
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
                                                 "value": "edgex-redis"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
                                                 "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
                                             },
                                             {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/support-scheduler:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
+                                                "name": "ALL_SERVICES_REGISTRY_HOST",
+                                                "value": "edgex-core-consul"
                                             },
                                             {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
+                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:3.0.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "openyurt/core-metadata:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
+                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
                                                 "value": "edgex-core-metadata"
                                             }
                                         ],
@@ -4709,7 +4339,151 @@
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-metadata"
+                                "hostname": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/device-virtual:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "openyurt/device-rest:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
                             }
                         },
                         "strategy": {
@@ -4795,42 +4569,42 @@
                     }
                 },
                 {
-                    "name": "edgex-device-virtual",
+                    "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59900",
+                                "name": "tcp-59881",
                                 "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
+                                "port": 59881,
+                                "targetPort": 59881
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-virtual"
+                            "app": "edgex-core-metadata"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-virtual"
+                                "app": "edgex-core-metadata"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-virtual"
+                                    "app": "edgex-core-metadata"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:3.0.0",
+                                        "name": "edgex-core-metadata",
+                                        "image": "openyurt/core-metadata:3.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -4843,19 +4617,19 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            },
-                                            {
                                                 "name": "EDGEX_SECURITY_SECRET_STORE",
                                                 "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-virtual"
+                                "hostname": "edgex-core-metadata"
                             }
                         },
                         "strategy": {
@@ -4867,42 +4641,42 @@
                     }
                 },
                 {
-                    "name": "edgex-support-notifications",
+                    "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59860",
+                                "name": "tcp-59701",
                                 "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
+                                "port": 59701,
+                                "targetPort": 59701
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-notifications"
+                            "app": "edgex-app-rules-engine"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-notifications"
+                                "app": "edgex-app-rules-engine"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-notifications"
+                                    "app": "edgex-app-rules-engine"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-support-notifications",
-                                        "image": "openyurt/support-notifications:3.0.0",
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:3.0.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -4915,19 +4689,105 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
                                             },
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-notifications"
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "openyurt/consul:1.15.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
                             }
                         },
                         "strategy": {
@@ -5015,182 +4875,42 @@
                     }
                 },
                 {
-                    "name": "edgex-core-common-config-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-common-config-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-common-config-bootstrapper",
-                                        "image": "openyurt/core-common-config-bootstrapper:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_REGISTRY_HOST",
-                                                "value": "edgex-core-consul"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-common-config-bootstrapper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
+                    "name": "edgex-support-notifications",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59986",
+                                "name": "tcp-59860",
                                 "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
+                                "port": 59860,
+                                "targetPort": 59860
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-rest"
+                            "app": "edgex-support-notifications"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-rest"
+                                "app": "edgex-support-notifications"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-rest"
+                                    "app": "edgex-support-notifications"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-device-rest",
-                                        "image": "openyurt/device-rest:3.0.0",
+                                        "name": "edgex-support-notifications",
+                                        "image": "openyurt/support-notifications:3.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -5204,7 +4924,7 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "value": "edgex-support-notifications"
                                             },
                                             {
                                                 "name": "EDGEX_SECURITY_SECRET_STORE",
@@ -5215,7 +4935,7 @@
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-support-notifications"
                             }
                         },
                         "strategy": {
@@ -5275,12 +4995,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_SECURITY_SECRET_STORE",
-                                                "value": "false"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-ui-go"
+                                            },
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
                                             }
                                         ],
                                         "resources": {},
@@ -5288,6 +5008,286 @@
                                     }
                                 ],
                                 "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "openyurt/ekuiper:1.9.2-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/support-scheduler:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURITY_SECRET_STORE",
+                                                "value": "false"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
                         "strategy": {
@@ -5322,313 +5322,6 @@
                 }
             ],
             "components": [
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "openyurt/core-metadata:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "openyurt/app-service-configurable:2.0.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/sys-mgmt-agent:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5563",
-                                "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/core-data:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
                 {
                     "name": "edgex-support-scheduler",
                     "service": {
@@ -5774,42 +5467,53 @@
                     }
                 },
                 {
-                    "name": "edgex-support-notifications",
+                    "name": "edgex-core-data",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59860",
+                                "name": "tcp-5563",
                                 "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-notifications"
+                            "app": "edgex-core-data"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-notifications"
+                                "app": "edgex-core-data"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-notifications"
+                                    "app": "edgex-core-data"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-support-notifications",
-                                        "image": "openyurt/support-notifications:2.0.0",
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/core-data:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -5823,14 +5527,14 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
+                                                "value": "edgex-core-data"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-notifications"
+                                "hostname": "edgex-core-data"
                             }
                         },
                         "strategy": {
@@ -5964,10 +5668,6 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
                                                 "name": "EDGEX__DEFAULT__TOPIC",
                                                 "value": "rules-events"
                                             },
@@ -5990,6 +5690,10 @@
                                             {
                                                 "name": "EDGEX__DEFAULT__PROTOCOL",
                                                 "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -6014,116 +5718,42 @@
                     }
                 },
                 {
-                    "name": "edgex-redis",
+                    "name": "edgex-support-notifications",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-6379",
+                                "name": "tcp-59860",
                                 "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                                "port": 59860,
+                                "targetPort": 59860
                             }
                         ],
                         "selector": {
-                            "app": "edgex-redis"
+                            "app": "edgex-support-notifications"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-support-notifications"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:6.2.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
+                                    "app": "edgex-support-notifications"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-device-virtual",
-                                        "image": "openyurt/device-virtual:2.0.0",
+                                        "name": "edgex-support-notifications",
+                                        "image": "openyurt/support-notifications:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -6137,14 +5767,170 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-virtual"
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/sys-mgmt-agent:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "openyurt/app-service-configurable:2.0.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
                             }
                         },
                         "strategy": {
@@ -6236,120 +6022,16 @@
                             }
                         }
                     }
-                }
-            ]
-        },
-        {
-            "versionName": "hanoi",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "CLIENTS_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_COREDATA_HOST": "edgex-core-data",
-                        "CLIENTS_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_RULESENGINE_HOST": "edgex-kuiper",
-                        "CLIENTS_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "CLIENTS_VIRTUALDEVICE_HOST": "edgex-device-virtual",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "false",
-                        "LOGGING_ENABLEREMOTE": "false",
-                        "REGISTRY_HOST": "edgex-core-consul",
-                        "SERVICE_SERVERBINDADDR": "0.0.0.0"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48090",
-                                "protocol": "TCP",
-                                "port": 48090,
-                                "targetPort": 48090
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "openyurt/docker-sys-mgmt-agent-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48090",
-                                                "containerPort": 48090,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
                 },
                 {
                     "name": "edgex-device-virtual",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-49990",
+                                "name": "tcp-59900",
                                 "protocol": "TCP",
-                                "port": 49990,
-                                "targetPort": 49990
+                                "port": 59900,
+                                "targetPort": 59900
                             }
                         ],
                         "selector": {
@@ -6373,11 +6055,11 @@
                                 "containers": [
                                     {
                                         "name": "edgex-device-virtual",
-                                        "image": "openyurt/docker-device-virtual-go:1.3.1",
+                                        "image": "openyurt/device-virtual:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-49990",
-                                                "containerPort": 49990,
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -6414,10 +6096,10 @@
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-48081",
+                                "name": "tcp-59881",
                                 "protocol": "TCP",
-                                "port": 48081,
-                                "targetPort": 48081
+                                "port": 59881,
+                                "targetPort": 59881
                             }
                         ],
                         "selector": {
@@ -6441,11 +6123,11 @@
                                 "containers": [
                                     {
                                         "name": "edgex-core-metadata",
-                                        "image": "openyurt/docker-core-metadata-go:1.3.1",
+                                        "image": "openyurt/core-metadata:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-48081",
-                                                "containerPort": 48081,
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -6481,6 +6163,108 @@
                         }
                     }
                 },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:6.2.4-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "hanoi",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "CLIENTS_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_COREDATA_HOST": "edgex-core-data",
+                        "CLIENTS_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_RULESENGINE_HOST": "edgex-kuiper",
+                        "CLIENTS_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "CLIENTS_VIRTUALDEVICE_HOST": "edgex-device-virtual",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "false",
+                        "LOGGING_ENABLEREMOTE": "false",
+                        "REGISTRY_HOST": "edgex-core-consul",
+                        "SERVICE_SERVERBINDADDR": "0.0.0.0"
+                    }
+                }
+            ],
+            "components": [
                 {
                     "name": "edgex-device-rest",
                     "service": {
@@ -6539,6 +6323,80 @@
                                     }
                                 ],
                                 "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "openyurt/redis:6.0.9-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
                             }
                         },
                         "strategy": {
@@ -6618,90 +6476,6 @@
                     }
                 },
                 {
-                    "name": "edgex-app-service-configurable-rules",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48100",
-                                "protocol": "TCP",
-                                "port": 48100,
-                                "targetPort": 48100
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-service-configurable-rules"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-service-configurable-rules"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-service-configurable-rules"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-service-configurable-rules",
-                                        "image": "openyurt/docker-app-service-configurable:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48100",
-                                                "containerPort": 48100,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_PORT",
-                                                "value": "48100"
-                                            },
-                                            {
-                                                "name": "MESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "BINDING_PUBLISHTOPIC",
-                                                "value": "events"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-service-configurable-rules"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-service-configurable-rules"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
                     "name": "edgex-core-command",
                     "service": {
                         "ports": [
@@ -6770,53 +6544,42 @@
                     }
                 },
                 {
-                    "name": "edgex-core-data",
+                    "name": "edgex-device-virtual",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-5563",
+                                "name": "tcp-49990",
                                 "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-48080",
-                                "protocol": "TCP",
-                                "port": 48080,
-                                "targetPort": 48080
+                                "port": 49990,
+                                "targetPort": 49990
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-data"
+                            "app": "edgex-device-virtual"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-data"
+                                "app": "edgex-device-virtual"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-device-virtual"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "openyurt/docker-core-data-go:1.3.1",
+                                        "name": "edgex-device-virtual",
+                                        "image": "openyurt/docker-device-virtual-go:1.3.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-48080",
-                                                "containerPort": 48080,
+                                                "name": "tcp-49990",
+                                                "containerPort": 49990,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -6830,14 +6593,14 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "value": "edgex-device-virtual"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-device-virtual"
                             }
                         },
                         "strategy": {
@@ -6849,48 +6612,53 @@
                     }
                 },
                 {
-                    "name": "edgex-redis",
+                    "name": "edgex-kuiper",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-6379",
+                                "name": "tcp-20498",
                                 "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                                "port": 20498,
+                                "targetPort": 20498
+                            },
+                            {
+                                "name": "tcp-48075",
+                                "protocol": "TCP",
+                                "port": 48075,
+                                "targetPort": 48075
                             }
                         ],
                         "selector": {
-                            "app": "edgex-redis"
+                            "app": "edgex-kuiper"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-kuiper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
+                                    "app": "edgex-kuiper"
                                 }
                             },
                             "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-redis",
-                                        "image": "openyurt/redis:6.0.9-alpine",
+                                        "name": "edgex-kuiper",
+                                        "image": "openyurt/kuiper:1.1.1-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
+                                                "name": "tcp-20498",
+                                                "containerPort": 20498,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-48075",
+                                                "containerPort": 48075,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -6901,17 +6669,277 @@
                                                 }
                                             }
                                         ],
-                                        "resources": {},
-                                        "volumeMounts": [
+                                        "env": [
                                             {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "5566"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "tcp"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-app-service-configurable-rules"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVICESERVER",
+                                                "value": "http://edgex-core-data:48080"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "events"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "48075"
                                             }
                                         ],
+                                        "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-redis"
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48085",
+                                "protocol": "TCP",
+                                "port": 48085,
+                                "targetPort": 48085
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "openyurt/docker-support-scheduler-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48085",
+                                                "containerPort": 48085,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48090",
+                                "protocol": "TCP",
+                                "port": 48090,
+                                "targetPort": 48090
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "openyurt/docker-sys-mgmt-agent-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48090",
+                                                "containerPort": 48090,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-service-configurable-rules",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48100",
+                                "protocol": "TCP",
+                                "port": 48100,
+                                "targetPort": 48100
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-service-configurable-rules"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-service-configurable-rules"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-service-configurable-rules"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-service-configurable-rules",
+                                        "image": "openyurt/docker-app-service-configurable:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48100",
+                                                "containerPort": 48100,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "BINDING_PUBLISHTOPIC",
+                                                "value": "events"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "MESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SERVICE_PORT",
+                                                "value": "48100"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-service-configurable-rules"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-service-configurable-rules"
                             }
                         },
                         "strategy": {
@@ -7023,42 +7051,53 @@
                     }
                 },
                 {
-                    "name": "edgex-support-scheduler",
+                    "name": "edgex-core-data",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-48085",
+                                "name": "tcp-5563",
                                 "protocol": "TCP",
-                                "port": 48085,
-                                "targetPort": 48085
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-48080",
+                                "protocol": "TCP",
+                                "port": 48080,
+                                "targetPort": 48080
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-scheduler"
+                            "app": "edgex-core-data"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-core-data"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
+                                    "app": "edgex-core-data"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "openyurt/docker-support-scheduler-go:1.3.1",
+                                        "name": "edgex-core-data",
+                                        "image": "openyurt/docker-core-data-go:1.3.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-48085",
-                                                "containerPort": 48085,
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-48080",
+                                                "containerPort": 48080,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -7071,23 +7110,15 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
+                                                "value": "edgex-core-data"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-scheduler"
+                                "hostname": "edgex-core-data"
                             }
                         },
                         "strategy": {
@@ -7099,53 +7130,42 @@
                     }
                 },
                 {
-                    "name": "edgex-kuiper",
+                    "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-20498",
+                                "name": "tcp-48081",
                                 "protocol": "TCP",
-                                "port": 20498,
-                                "targetPort": 20498
-                            },
-                            {
-                                "name": "tcp-48075",
-                                "protocol": "TCP",
-                                "port": 48075,
-                                "targetPort": 48075
+                                "port": 48081,
+                                "targetPort": 48081
                             }
                         ],
                         "selector": {
-                            "app": "edgex-kuiper"
+                            "app": "edgex-core-metadata"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-core-metadata"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
+                                    "app": "edgex-core-metadata"
                                 }
                             },
                             "spec": {
                                 "containers": [
                                     {
-                                        "name": "edgex-kuiper",
-                                        "image": "openyurt/kuiper:1.1.1-alpine",
+                                        "name": "edgex-core-metadata",
+                                        "image": "openyurt/docker-core-metadata-go:1.3.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-20498",
-                                                "containerPort": 20498,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-48075",
-                                                "containerPort": 48075,
+                                                "name": "tcp-48081",
+                                                "containerPort": 48081,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -7158,39 +7178,19 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-app-service-configurable-rules"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__SERVICESERVER",
-                                                "value": "http://edgex-core-data:48080"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "events"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "48075"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "5566"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "tcp"
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kuiper"
+                                "hostname": "edgex-core-metadata"
                             }
                         },
                         "strategy": {

--- a/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config.json
+++ b/pkg/yurtmanager/controller/platformadmin/config/EdgeXConfig/config.json
@@ -30,31 +30,228 @@
             ],
             "components": [
                 {
-                    "name": "edgex-kuiper",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59720",
-                                "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kuiper"
-                        }
-                    },
+                    "name": "edgex-security-bootstrapper",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-security-bootstrapper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
+                                    "app": "edgex-security-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:3.1.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-nginx",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8443",
+                                "protocol": "TCP",
+                                "port": 8443,
+                                "targetPort": 8443
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-nginx"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-nginx"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-nginx"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume3",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume4",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-templates",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-tls",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-nginx",
+                                        "image": "nginx:1.25.5-alpine-slim",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8443",
+                                                "containerPort": 8443,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/etc/nginx/conf.d"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/var/cache/nginx"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume3",
+                                                "mountPath": "/var/log/nginx"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume4",
+                                                "mountPath": "/var/run"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "nginx-templates",
+                                                "mountPath": "/etc/nginx/templates"
+                                            },
+                                            {
+                                                "name": "nginx-tls",
+                                                "mountPath": "/etc/ssl/nginx"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-nginx"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
                                 }
                             },
                             "spec": {
@@ -67,42 +264,25 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-etc",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-plugins",
-                                        "emptyDir": {}
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "FileOrCreate"
+                                        }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.11.4-alpine",
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:3.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -115,48 +295,8 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
@@ -170,34 +310,336 @@
                                                 "mountPath": "/etc/localtime"
                                             },
                                             {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-etc",
-                                                "mountPath": "/kuiper/etc"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
-                                            },
-                                            {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
-                                            },
-                                            {
-                                                "name": "kuiper-plugins",
-                                                "mountPath": "/kuiper/plugins"
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kuiper"
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-proxy-auth",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59842",
+                                "protocol": "TCP",
+                                "port": 59842,
+                                "targetPort": 59842
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-proxy-auth"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-proxy-auth"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-proxy-auth"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-auth",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-proxy-auth",
+                                        "image": "edgexfoundry/security-proxy-auth:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59842",
+                                                "containerPort": 59842,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-proxy-auth"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-auth"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-proxy-auth"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-secretstore-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-secretstore-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:3.1.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:3.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-ui-go"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
                             }
                         },
                         "strategy": {
@@ -246,21 +688,21 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:3.1.0",
+                                        "image": "edgexfoundry/device-rest:3.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59986",
@@ -348,21 +790,21 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/core-data",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:3.1.0",
+                                        "image": "edgexfoundry/core-data:3.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59880",
@@ -413,72 +855,62 @@
                     }
                 },
                 {
-                    "name": "edgex-nginx",
+                    "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-8443",
+                                "name": "tcp-59701",
                                 "protocol": "TCP",
-                                "port": 8443,
-                                "targetPort": 8443
+                                "port": 59701,
+                                "targetPort": 59701
                             }
                         ],
                         "selector": {
-                            "app": "edgex-nginx"
+                            "app": "edgex-app-rules-engine"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-nginx"
+                                "app": "edgex-app-rules-engine"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-nginx"
+                                    "app": "edgex-app-rules-engine"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume3",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume4",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "nginx-templates",
-                                        "emptyDir": {}
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
                                     },
                                     {
-                                        "name": "nginx-tls",
-                                        "emptyDir": {}
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "FileOrCreate"
+                                        }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-nginx",
-                                        "image": "nginx:1.25.3-alpine-slim",
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:3.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-8443",
-                                                "containerPort": 8443,
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -489,41 +921,320 @@
                                                 }
                                             }
                                         ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            }
+                                        ],
                                         "resources": {},
                                         "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/etc/nginx/conf.d"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/var/cache/nginx"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume3",
-                                                "mountPath": "/var/log/nginx"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume4",
-                                                "mountPath": "/var/run"
-                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "nginx-templates",
-                                                "mountPath": "/etc/nginx/templates"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
                                             },
                                             {
-                                                "name": "nginx-tls",
-                                                "mountPath": "/etc/ssl/nginx"
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-nginx"
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/core-command:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EXTERNALMQTT_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-etc",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-plugins",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.11.5-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-etc",
+                                                "mountPath": "/kuiper/etc"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            },
+                                            {
+                                                "name": "kuiper-plugins",
+                                                "mountPath": "/kuiper/plugins"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
                             }
                         },
                         "strategy": {
@@ -572,21 +1283,21 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:3.1.0",
+                                        "image": "edgexfoundry/support-scheduler:3.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59861",
@@ -634,719 +1345,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-proxy-auth",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59842",
-                                "protocol": "TCP",
-                                "port": 59842,
-                                "targetPort": 59842
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-proxy-auth"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-proxy-auth"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-proxy-auth"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-auth",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-proxy-auth",
-                                        "image": "edgexfoundry/security-proxy-auth:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59842",
-                                                "containerPort": 59842,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-proxy-auth"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-auth"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-proxy-auth"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:3.1.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-vault",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8200",
-                                "protocol": "TCP",
-                                "port": 8200,
-                                "targetPort": 8200
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-vault"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-vault"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-vault"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-file",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-logs",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-vault",
-                                        "image": "hashicorp/vault:1.14.5",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8200",
-                                                "containerPort": 8200,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
-                                            },
-                                            {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
-                                            },
-                                            {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "vault-file",
-                                                "mountPath": "/vault/file"
-                                            },
-                                            {
-                                                "name": "vault-logs",
-                                                "mountPath": "/vault/logs"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-vault"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:3.1.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-ui-go"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
                             }
                         },
                         "strategy": {
@@ -1407,14 +1405,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-core-consul",
-                                        "image": "hashicorp/consul:1.16.2",
+                                        "image": "hashicorp/consul:1.16.6",
                                         "ports": [
                                             {
                                                 "name": "tcp-8500",
@@ -1435,8 +1433,8 @@
                                                 "value": "/consul/config/consul_acl_done"
                                             },
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
                                             },
                                             {
                                                 "name": "EDGEX_ADD_REGISTRY_ACL_ROLES"
@@ -1446,12 +1444,12 @@
                                                 "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
                                             },
                                             {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
                                                 "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
                                                 "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
                                             }
                                         ],
                                         "resources": {},
@@ -1492,320 +1490,6 @@
                     }
                 },
                 {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-command",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/core-command:3.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXTERNALMQTT_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/etc/localtime"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/core-command"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
                     "name": "edgex-security-proxy-setup",
                     "deployment": {
                         "selector": {
@@ -1826,7 +1510,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
@@ -1849,7 +1533,7 @@
                                         "name": "anonymous-volume2",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
@@ -1860,7 +1544,7 @@
                                 "containers": [
                                     {
                                         "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:3.1.0",
+                                        "image": "edgexfoundry/security-proxy-setup:3.1.1",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -1870,44 +1554,44 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
+                                                "name": "EDGEX_ADD_PROXY_ROUTE",
+                                                "value": "device-rest.http://edgex-device-rest:59986"
                                             },
                                             {
                                                 "name": "ROUTES_SYS_MGMT_AGENT_HOST",
                                                 "value": "edgex-sys-mgmt-agent"
                                             },
                                             {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
                                                 "name": "ROUTES_CORE_DATA_HOST",
                                                 "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
                                             },
                                             {
                                                 "name": "ROUTES_CORE_CONSUL_HOST",
                                                 "value": "edgex-core-consul"
                                             },
                                             {
-                                                "name": "EDGEX_ADD_PROXY_ROUTE",
-                                                "value": "device-rest.http://edgex-device-rest:59986"
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
                                             },
                                             {
                                                 "name": "ROUTES_RULES_ENGINE_HOST",
                                                 "value": "edgex-kuiper"
                                             },
                                             {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
                                                 "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
                                                 "value": "edgex-support-scheduler"
                                             },
                                             {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
                                             }
                                         ],
                                         "resources": {},
@@ -1945,6 +1629,108 @@
                                     }
                                 ],
                                 "hostname": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-notifications",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
                             }
                         },
                         "strategy": {
@@ -2005,14 +1791,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-redis",
-                                        "image": "redis:7.0.14-alpine",
+                                        "image": "redis:7.0.15-alpine",
                                         "ports": [
                                             {
                                                 "name": "tcp-6379",
@@ -2099,21 +1885,21 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/etc/localtime",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/core-common-config-bootstrapper",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-core-common-config-bootstrapper",
-                                        "image": "edgexfoundry/core-common-config-bootstrapper:3.1.0",
+                                        "image": "edgexfoundry/core-common-config-bootstrapper:3.1.1",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -2123,12 +1909,8 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
+                                                "name": "ALL_SERVICES_REGISTRY_HOST",
+                                                "value": "edgex-core-consul"
                                             },
                                             {
                                                 "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
@@ -2139,8 +1921,12 @@
                                                 "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "ALL_SERVICES_REGISTRY_HOST",
-                                                "value": "edgex-core-consul"
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -2162,6 +1948,220 @@
                                     }
                                 ],
                                 "hostname": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8200",
+                                "protocol": "TCP",
+                                "port": 8200,
+                                "targetPort": 8200
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-vault"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-file",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-logs",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault",
+                                        "image": "hashicorp/vault:1.14.10",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8200",
+                                                "containerPort": 8200,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
+                                            },
+                                            {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            },
+                                            {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-file",
+                                                "mountPath": "/vault/file"
+                                            },
+                                            {
+                                                "name": "vault-logs",
+                                                "mountPath": "/vault/logs"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/etc/localtime",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:3.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/etc/localtime"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
                             }
                         },
                         "strategy": {
@@ -2220,22 +2220,43 @@
             ],
             "components": [
                 {
-                    "name": "edgex-security-proxy-setup",
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
+                                "app": "edgex-core-consul"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-security-proxy-setup"
+                                    "app": "edgex-core-consul"
                                 }
                             },
                             "spec": {
                                 "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -2247,146 +2268,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:2.2.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
-                                            },
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.2.0",
+                                        "name": "edgex-core-consul",
+                                        "image": "consul:1.10.10",
                                         "ports": [
                                             {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -2399,20 +2293,134 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            },
+                                            {
+                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-58890",
+                                "protocol": "TCP",
+                                "port": 58890,
+                                "targetPort": 58890
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "edgexfoundry/sys-mgmt-agent:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
+                                                "value": "edgex-sys-mgmt-agent"
                                             },
                                             {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
                                             }
                                         ],
                                         "resources": {},
@@ -2423,13 +2431,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-app-rules-engine"
+                                "hostname": "edgex-sys-mgmt-agent"
                             }
                         },
                         "strategy": {
@@ -2507,16 +2515,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
+                                                "name": "VAULT_UI",
+                                                "value": "true"
                                             },
                                             {
                                                 "name": "VAULT_CONFIG_DIR",
                                                 "value": "/vault/config"
                                             },
                                             {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
                                             }
                                         ],
                                         "resources": {},
@@ -2553,31 +2561,31 @@
                     }
                 },
                 {
-                    "name": "edgex-support-scheduler",
+                    "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59861",
+                                "name": "tcp-59701",
                                 "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                                "port": 59701,
+                                "targetPort": 59701
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-scheduler"
+                            "app": "edgex-app-rules-engine"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-app-rules-engine"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
+                                    "app": "edgex-app-rules-engine"
                                 }
                             },
                             "spec": {
@@ -2589,19 +2597,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.2.0",
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:2.2.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -2614,16 +2622,20 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
                                             },
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -2634,13 +2646,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-scheduler"
+                                "hostname": "edgex-app-rules-engine"
                             }
                         },
                         "strategy": {
@@ -2652,70 +2664,31 @@
                     }
                 },
                 {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
+                    "name": "edgex-security-bootstrapper",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-consul"
+                                "app": "edgex-security-bootstrapper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-consul"
+                                    "app": "edgex-security-bootstrapper"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
                                         "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
-                                        }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-consul",
-                                        "image": "consul:1.10.10",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:2.2.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -2731,46 +2704,19 @@
                                             {
                                                 "name": "EDGEX_GROUP",
                                                 "value": "2001"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            },
-                                            {
-                                                "name": "ADD_REGISTRY_ACL_ROLES"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-consul"
+                                "hostname": "edgex-security-bootstrapper"
                             }
                         },
                         "strategy": {
@@ -2782,31 +2728,18 @@
                     }
                 },
                 {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
+                    "name": "edgex-security-secretstore-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-security-secretstore-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
+                                    "app": "edgex-security-secretstore-setup"
                                 }
                             },
                             "spec": {
@@ -2816,7 +2749,7 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "db-data",
+                                        "name": "tmpfs-volume2",
                                         "emptyDir": {}
                                     },
                                     {
@@ -2824,28 +2757,33 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "redis-config",
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kong",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
-                                        }
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-redis",
-                                        "image": "redis:6.2.6-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.2.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -2855,12 +2793,23 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "DATABASECONFIG_PATH",
-                                                "value": "/run/redis/conf"
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
                                             },
                                             {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
+                                                "name": "ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
                                             }
                                         ],
                                         "resources": {},
@@ -2870,212 +2819,38 @@
                                                 "mountPath": "/run"
                                             },
                                             {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
                                             },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "redis-config",
-                                                "mountPath": "/run/redis/conf"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
                                             },
                                             {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                                "name": "kong",
+                                                "mountPath": "/tmp/kong"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-command",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/core-command:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-command"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
+                                "hostname": "edgex-security-secretstore-setup"
                             }
                         },
                         "strategy": {
@@ -3165,12 +2940,12 @@
                                                 "value": "kong"
                                             },
                                             {
-                                                "name": "POSTGRES_USER",
-                                                "value": "kong"
-                                            },
-                                            {
                                                 "name": "POSTGRES_PASSWORD_FILE",
                                                 "value": "/tmp/postgres-config/.pgpassword"
+                                            },
+                                            {
+                                                "name": "POSTGRES_USER",
+                                                "value": "kong"
                                             }
                                         ],
                                         "resources": {},
@@ -3215,175 +2990,31 @@
                     }
                 },
                 {
-                    "name": "edgex-kuiper",
+                    "name": "edgex-device-virtual",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59720",
+                                "name": "tcp-59900",
                                 "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
+                                "port": 59900,
+                                "targetPort": 59900
                             }
                         ],
                         "selector": {
-                            "app": "edgex-kuiper"
+                            "app": "edgex-device-virtual"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-device-virtual"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.4.4-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
+                                    "app": "edgex-device-virtual"
                                 }
                             },
                             "spec": {
@@ -3395,19 +3026,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:2.2.0",
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:2.2.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3421,7 +3052,7 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
+                                                "value": "edgex-device-virtual"
                                             }
                                         ],
                                         "resources": {},
@@ -3432,13 +3063,510 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-rest"
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kong",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8000",
+                                "protocol": "TCP",
+                                "port": 8000,
+                                "targetPort": 8000
+                            },
+                            {
+                                "name": "tcp-8100",
+                                "protocol": "TCP",
+                                "port": 8100,
+                                "targetPort": 8100
+                            },
+                            {
+                                "name": "tcp-8443",
+                                "protocol": "TCP",
+                                "port": 8443,
+                                "targetPort": 8443
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kong"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kong"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kong"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "postgres-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kong",
+                                        "image": "kong:2.6.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8000",
+                                                "containerPort": 8000,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8100",
+                                                "containerPort": 8100,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8443",
+                                                "containerPort": 8443,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KONG_SSL_CIPHER_SUITE",
+                                                "value": "modern"
+                                            },
+                                            {
+                                                "name": "KONG_STATUS_LISTEN",
+                                                "value": "0.0.0.0:8100"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_VALID_TTL",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "edgex-kong-db"
+                                            },
+                                            {
+                                                "name": "KONG_NGINX_WORKER_PROCESSES",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_PG_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
+                                            },
+                                            {
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_LISTEN",
+                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            },
+                                            {
+                                                "name": "postgres-config",
+                                                "mountPath": "/tmp/postgres-config"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/usr/local/kong"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kong"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-proxy-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-proxy-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:2.2.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ADD_PROXY_ROUTE"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
+                                            },
+                                            {
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/core-command:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
                             }
                         },
                         "strategy": {
@@ -3549,7 +3677,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -3603,43 +3731,175 @@
                     }
                 },
                 {
-                    "name": "edgex-kong",
+                    "name": "edgex-kuiper",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-8000",
+                                "name": "tcp-59720",
                                 "protocol": "TCP",
-                                "port": 8000,
-                                "targetPort": 8000
-                            },
-                            {
-                                "name": "tcp-8100",
-                                "protocol": "TCP",
-                                "port": 8100,
-                                "targetPort": 8100
-                            },
-                            {
-                                "name": "tcp-8443",
-                                "protocol": "TCP",
-                                "port": 8443,
-                                "targetPort": 8443
+                                "port": 59720,
+                                "targetPort": 59720
                             }
                         ],
                         "selector": {
-                            "app": "edgex-kong"
+                            "app": "edgex-kuiper"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kong"
+                                "app": "edgex-kuiper"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kong"
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.4.4-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
                                 }
                             },
                             "spec": {
@@ -3649,7 +3909,7 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "tmpfs-volume2",
+                                        "name": "db-data",
                                         "emptyDir": {}
                                     },
                                     {
@@ -3657,39 +3917,25 @@
                                         "emptyDir": {}
                                     },
                                     {
+                                        "name": "redis-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
+                                            "type": "FileOrCreate"
                                         }
-                                    },
-                                    {
-                                        "name": "postgres-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-kong",
-                                        "image": "kong:2.6.1",
+                                        "name": "edgex-redis",
+                                        "image": "redis:6.2.6-alpine",
                                         "ports": [
                                             {
-                                                "name": "tcp-8000",
-                                                "containerPort": 8000,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8100",
-                                                "containerPort": 8100,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8443",
-                                                "containerPort": 8443,
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -3702,56 +3948,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KONG_STATUS_LISTEN",
-                                                "value": "0.0.0.0:8100"
+                                                "name": "DATABASECONFIG_PATH",
+                                                "value": "/run/redis/conf"
                                             },
                                             {
-                                                "name": "KONG_SSL_CIPHER_SUITE",
-                                                "value": "modern"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_NGINX_WORKER_PROCESSES",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "edgex-kong-db"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_VALID_TTL",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
-                                            },
-                                            {
-                                                "name": "KONG_PG_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_LISTEN",
-                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
                                             }
                                         ],
                                         "resources": {},
@@ -3761,284 +3963,26 @@
                                                 "mountPath": "/run"
                                             },
                                             {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
+                                                "name": "db-data",
+                                                "mountPath": "/data"
                                             },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "redis-config",
+                                                "mountPath": "/run/redis/conf"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            },
-                                            {
-                                                "name": "postgres-config",
-                                                "mountPath": "/tmp/postgres-config"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/usr/local/kong"
+                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kong"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:2.2.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "edgexfoundry/sys-mgmt-agent:2.2.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
+                                "hostname": "edgex-redis"
                             }
                         },
                         "strategy": {
@@ -4093,7 +4037,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/core-data",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -4122,12 +4066,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
                                             }
                                         ],
                                         "resources": {},
@@ -4156,30 +4100,35 @@
                     }
                 },
                 {
-                    "name": "edgex-security-secretstore-setup",
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-security-secretstore-setup"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
                                 "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -4187,31 +4136,22 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "type": "FileOrCreate"
                                         }
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.2.0",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -4221,64 +4161,124 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
                                             },
                                             {
-                                                "name": "ADD_SECRETSTORE_TOKENS"
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/tmp/kong"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-security-secretstore-setup"
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:2.2.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
                             }
                         },
                         "strategy": {
@@ -4334,55 +4334,35 @@
             ],
             "components": [
                 {
-                    "name": "edgex-kong",
+                    "name": "edgex-support-notifications",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-8000",
+                                "name": "tcp-59860",
                                 "protocol": "TCP",
-                                "port": 8000,
-                                "targetPort": 8000
-                            },
-                            {
-                                "name": "tcp-8100",
-                                "protocol": "TCP",
-                                "port": 8100,
-                                "targetPort": 8100
-                            },
-                            {
-                                "name": "tcp-8443",
-                                "protocol": "TCP",
-                                "port": 8443,
-                                "targetPort": 8443
+                                "port": 59860,
+                                "targetPort": 59860
                             }
                         ],
                         "selector": {
-                            "app": "edgex-kong"
+                            "app": "edgex-support-notifications"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kong"
+                                "app": "edgex-support-notifications"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kong"
+                                    "app": "edgex-support-notifications"
                                 }
                             },
                             "spec": {
                                 "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -4390,37 +4370,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/support-notifications",
+                                            "type": "FileOrCreate"
                                         }
-                                    },
-                                    {
-                                        "name": "postgres-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-kong",
-                                        "image": "kong:2.5.1",
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-8000",
-                                                "containerPort": 8000,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8100",
-                                                "containerPort": 8100,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8443",
-                                                "containerPort": 8443,
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -4433,89 +4395,25 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KONG_PG_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
-                                            },
-                                            {
-                                                "name": "KONG_STATUS_LISTEN",
-                                                "value": "0.0.0.0:8100"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_VALID_TTL",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_SSL_CIPHER_SUITE",
-                                                "value": "modern"
-                                            },
-                                            {
-                                                "name": "KONG_NGINX_WORKER_PROCESSES",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_LISTEN",
-                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "edgex-kong-db"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
-                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            },
-                                            {
-                                                "name": "postgres-config",
-                                                "mountPath": "/tmp/postgres-config"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/usr/local/kong"
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kong"
+                                "hostname": "edgex-support-notifications"
                             }
                         },
                         "strategy": {
@@ -4564,7 +4462,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/sys-mgmt-agent",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -4626,35 +4524,30 @@
                     }
                 },
                 {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
+                    "name": "edgex-security-secretstore-setup",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-command"
+                                "app": "edgex-security-secretstore-setup"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-command"
+                                    "app": "edgex-security-secretstore-setup"
                                 }
                             },
                             "spec": {
                                 "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
                                     {
                                         "name": "edgex-init",
                                         "emptyDir": {}
@@ -4662,22 +4555,31 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-command",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
                                         }
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/core-command:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.1.1",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -4687,25 +4589,64 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "ADD_SECRETSTORE_TOKENS"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/tmp/kong"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-command"
+                                "hostname": "edgex-security-secretstore-setup"
                             }
                         },
                         "strategy": {
@@ -4717,31 +4658,37 @@
                     }
                 },
                 {
-                    "name": "edgex-support-scheduler",
+                    "name": "edgex-core-data",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59861",
+                                "name": "tcp-5563",
                                 "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-scheduler"
+                            "app": "edgex-core-data"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-scheduler"
+                                "app": "edgex-core-data"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-scheduler"
+                                    "app": "edgex-core-data"
                                 }
                             },
                             "spec": {
@@ -4753,19 +4700,24 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.1.1",
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/core-data:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -4779,15 +4731,11 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
                                             }
                                         ],
                                         "resources": {},
@@ -4798,116 +4746,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                                "mountPath": "/tmp/edgex/secrets/core-data"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.1.2",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
+                                "hostname": "edgex-core-data"
                             }
                         },
                         "strategy": {
@@ -5047,31 +4892,43 @@
                     }
                 },
                 {
-                    "name": "edgex-redis",
+                    "name": "edgex-kong",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-6379",
+                                "name": "tcp-8000",
                                 "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                                "port": 8000,
+                                "targetPort": 8000
+                            },
+                            {
+                                "name": "tcp-8100",
+                                "protocol": "TCP",
+                                "port": 8100,
+                                "targetPort": 8100
+                            },
+                            {
+                                "name": "tcp-8443",
+                                "protocol": "TCP",
+                                "port": 8443,
+                                "targetPort": 8443
                             }
                         ],
                         "selector": {
-                            "app": "edgex-redis"
+                            "app": "edgex-kong"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-kong"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
+                                    "app": "edgex-kong"
                                 }
                             },
                             "spec": {
@@ -5081,7 +4938,7 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "db-data",
+                                        "name": "tmpfs-volume2",
                                         "emptyDir": {}
                                     },
                                     {
@@ -5089,25 +4946,39 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "redis-config",
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "postgres-config",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
-                                        }
+                                        "name": "kong",
+                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-redis",
-                                        "image": "redis:6.2.6-alpine",
+                                        "name": "edgex-kong",
+                                        "image": "kong:2.5.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
+                                                "name": "tcp-8000",
+                                                "containerPort": 8000,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8100",
+                                                "containerPort": 8100,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8443",
+                                                "containerPort": 8443,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -5120,12 +4991,56 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
+                                                "name": "KONG_ADMIN_LISTEN",
+                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
                                             },
                                             {
-                                                "name": "DATABASECONFIG_PATH",
-                                                "value": "/run/redis/conf"
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_NGINX_WORKER_PROCESSES",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "edgex-kong-db"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_SSL_CIPHER_SUITE",
+                                                "value": "modern"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_STATUS_LISTEN",
+                                                "value": "0.0.0.0:8100"
+                                            },
+                                            {
+                                                "name": "KONG_PG_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_VALID_TTL",
+                                                "value": "1"
                                             }
                                         ],
                                         "resources": {},
@@ -5135,26 +5050,30 @@
                                                 "mountPath": "/run"
                                             },
                                             {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
                                             },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "redis-config",
-                                                "mountPath": "/run/redis/conf"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
                                             },
                                             {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                                "name": "postgres-config",
+                                                "mountPath": "/tmp/postgres-config"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/usr/local/kong"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-redis"
+                                "hostname": "edgex-kong"
                             }
                         },
                         "strategy": {
@@ -5203,7 +5122,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -5257,6 +5176,574 @@
                     }
                 },
                 {
+                    "name": "edgex-security-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:2.1.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/core-command:2.1.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:2.1.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:2.1.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "consul:1.10.3",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-proxy-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-proxy-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:2.1.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "ADD_PROXY_ROUTE"
+                                            },
+                                            {
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
                     "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
@@ -5294,7 +5781,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -5341,140 +5828,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.1.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
-                                            },
-                                            {
-                                                "name": "ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/tmp/kong"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
                             }
                         },
                         "strategy": {
@@ -5552,12 +5905,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
                                             },
                                             {
                                                 "name": "KUIPER__BASIC__RESTPORT",
@@ -5568,32 +5921,32 @@
                                                 "value": "redis"
                                             },
                                             {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
                                                 "name": "EDGEX__DEFAULT__SERVER",
                                                 "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
                                             },
                                             {
                                                 "name": "KUIPER__BASIC__CONSOLELOG",
                                                 "value": "true"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
                                                 "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
                                                 "value": "6379"
                                             },
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
                                             },
                                             {
                                                 "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
                                                 "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
                                             }
                                         ],
                                         "resources": {},
@@ -5619,318 +5972,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-consul",
-                                        "image": "consul:1.10.3",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "ADD_REGISTRY_ACL_ROLES"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
                             }
                         },
                         "strategy": {
@@ -6008,16 +6049,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
+                                                "name": "VAULT_UI",
+                                                "value": "true"
                                             },
                                             {
                                                 "name": "VAULT_ADDR",
                                                 "value": "http://edgex-vault:8200"
                                             },
                                             {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
                                             }
                                         ],
                                         "resources": {},
@@ -6043,585 +6084,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-vault"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-proxy-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-proxy-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:2.1.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-ui-go",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-4000",
-                                "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-ui-go"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-ui-go"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-ui-go"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:2.1.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:2.1.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5563",
-                                "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-data",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:2.1.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "levski",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "API_GATEWAY_HOST": "edgex-kong",
-                        "API_GATEWAY_STATUS_PORT": "8100",
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "true",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
-                        "REGISTRY_HOST": "edgex-core-consul",
-                        "SECRETSTORE_HOST": "edgex-vault",
-                        "SECRETSTORE_PORT": "8200",
-                        "SPIFFE_ENDPOINTSOCKET": "/tmp/edgex/secrets/spiffe/public/api.sock",
-                        "SPIFFE_TRUSTBUNDLE_PATH": "/tmp/edgex/secrets/spiffe/trust/bundle",
-                        "SPIFFE_TRUSTDOMAIN": "edgexfoundry.org",
-                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
-                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
-                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
-                        "STAGEGATE_DATABASE_PORT": "6379",
-                        "STAGEGATE_DATABASE_READYPORT": "6379",
-                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
-                        "STAGEGATE_KONGDB_PORT": "5432",
-                        "STAGEGATE_KONGDB_READYPORT": "54325",
-                        "STAGEGATE_READY_TORUNPORT": "54329",
-                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
-                        "STAGEGATE_REGISTRY_PORT": "8500",
-                        "STAGEGATE_REGISTRY_READYPORT": "54324",
-                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
-                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
-                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
-                    }
-                }
-            ],
-            "components": [
-                {
-                    "name": "edgex-security-proxy-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-proxy-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:2.3.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-proxy-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:2.3.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrapper"
                             }
                         },
                         "strategy": {
@@ -6682,14 +6144,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-redis",
-                                        "image": "redis:7.0.5-alpine",
+                                        "image": "redis:6.2.6-alpine",
                                         "ports": [
                                             {
                                                 "name": "tcp-6379",
@@ -6706,12 +6168,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
-                                            },
-                                            {
                                                 "name": "DATABASECONFIG_PATH",
                                                 "value": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
                                             }
                                         ],
                                         "resources": {},
@@ -6741,295 +6203,6 @@
                                     }
                                 ],
                                 "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59986",
-                                "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-command",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/core-command:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-command"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-58890",
-                                "protocol": "TCP",
-                                "port": 58890,
-                                "targetPort": 58890
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "edgexfoundry/sys-mgmt-agent:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-58890",
-                                                "containerPort": 58890,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
                             }
                         },
                         "strategy": {
@@ -7078,14 +6251,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.3.0",
+                                        "image": "edgexfoundry/support-scheduler:2.1.1",
                                         "ports": [
                                             {
                                                 "name": "tcp-59861",
@@ -7102,12 +6275,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
                                             },
                                             {
                                                 "name": "INTERVALACTIONS_SCRUBAGED_HOST",
@@ -7140,181 +6313,31 @@
                     }
                 },
                 {
-                    "name": "edgex-kuiper",
+                    "name": "edgex-device-rest",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59720",
+                                "name": "tcp-59986",
                                 "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
+                                "port": 59986,
+                                "targetPort": 59986
                             }
                         ],
                         "selector": {
-                            "app": "edgex-kuiper"
+                            "app": "edgex-device-rest"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-device-rest"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.7.1-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
-                                                "value": "redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/kuiper/etc/connections"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/kuiper/etc/sources"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kuiper"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5563",
-                                "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-device-rest"
                                 }
                             },
                             "spec": {
@@ -7326,24 +6349,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-data",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:2.3.0",
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:2.1.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -7357,11 +6375,7 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
+                                                "value": "edgex-device-rest"
                                             }
                                         ],
                                         "resources": {},
@@ -7372,13 +6386,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-device-rest"
                             }
                         },
                         "strategy": {
@@ -7388,644 +6402,54 @@
                             }
                         }
                     }
-                },
+                }
+            ]
+        },
+        {
+            "versionName": "levski",
+            "configMaps": [
                 {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.3.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/tmp/kong"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-vault",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8200",
-                                "protocol": "TCP",
-                                "port": 8200,
-                                "targetPort": 8200
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-vault"
-                        }
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
                     },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-vault"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-vault"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-file",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-logs",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-vault",
-                                        "image": "vault:1.11.4",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8200",
-                                                "containerPort": 8200,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
-                                            },
-                                            {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "vault-file",
-                                                "mountPath": "/vault/file"
-                                            },
-                                            {
-                                                "name": "vault-logs",
-                                                "mountPath": "/vault/logs"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-vault"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
+                    "data": {
+                        "API_GATEWAY_HOST": "edgex-kong",
+                        "API_GATEWAY_STATUS_PORT": "8100",
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "true",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
+                        "REGISTRY_HOST": "edgex-core-consul",
+                        "SECRETSTORE_HOST": "edgex-vault",
+                        "SECRETSTORE_PORT": "8200",
+                        "SPIFFE_ENDPOINTSOCKET": "/tmp/edgex/secrets/spiffe/public/api.sock",
+                        "SPIFFE_TRUSTBUNDLE_PATH": "/tmp/edgex/secrets/spiffe/trust/bundle",
+                        "SPIFFE_TRUSTDOMAIN": "edgexfoundry.org",
+                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
+                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
+                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
+                        "STAGEGATE_DATABASE_PORT": "6379",
+                        "STAGEGATE_DATABASE_READYPORT": "6379",
+                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
+                        "STAGEGATE_KONGDB_PORT": "5432",
+                        "STAGEGATE_KONGDB_READYPORT": "54325",
+                        "STAGEGATE_READY_TORUNPORT": "54329",
+                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
+                        "STAGEGATE_REGISTRY_PORT": "8500",
+                        "STAGEGATE_REGISTRY_READYPORT": "54324",
+                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
+                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
+                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
                     }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-app-rules-engine",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59701",
-                                "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-app-rules-engine"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-app-rules-engine"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-app-rules-engine"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-app-rules-engine"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-kong",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8000",
-                                "protocol": "TCP",
-                                "port": 8000,
-                                "targetPort": 8000
-                            },
-                            {
-                                "name": "tcp-8100",
-                                "protocol": "TCP",
-                                "port": 8100,
-                                "targetPort": 8100
-                            },
-                            {
-                                "name": "tcp-8443",
-                                "protocol": "TCP",
-                                "port": 8443,
-                                "targetPort": 8443
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-kong"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-kong"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-kong"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "postgres-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-kong",
-                                        "image": "kong:2.8.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8000",
-                                                "containerPort": 8000,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8100",
-                                                "containerPort": 8100,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-8443",
-                                                "containerPort": 8443,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_STATUS_LISTEN",
-                                                "value": "0.0.0.0:8100"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_LISTEN",
-                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_NGINX_WORKER_PROCESSES",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_DNS_VALID_TTL",
-                                                "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_PG_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
-                                            },
-                                            {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "edgex-kong-db"
-                                            },
-                                            {
-                                                "name": "KONG_SSL_CIPHER_SUITE",
-                                                "value": "modern"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            },
-                                            {
-                                                "name": "postgres-config",
-                                                "mountPath": "/tmp/postgres-config"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/usr/local/kong"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-kong"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
+                }
+            ],
+            "components": [
                 {
                     "name": "edgex-kong-db",
                     "service": {
@@ -8155,6 +6579,70 @@
                     }
                 },
                 {
+                    "name": "edgex-security-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:2.3.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
                     "name": "edgex-ui-go",
                     "service": {
                         "ports": [
@@ -8223,31 +6711,31 @@
                     }
                 },
                 {
-                    "name": "edgex-support-notifications",
+                    "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59860",
+                                "name": "tcp-59701",
                                 "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
+                                "port": 59701,
+                                "targetPort": 59701
                             }
                         ],
                         "selector": {
-                            "app": "edgex-support-notifications"
+                            "app": "edgex-app-rules-engine"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-support-notifications"
+                                "app": "edgex-app-rules-engine"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-support-notifications"
+                                    "app": "edgex-app-rules-engine"
                                 }
                             },
                             "spec": {
@@ -8259,19 +6747,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:2.3.0",
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:2.3.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -8284,8 +6772,20 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -8296,13 +6796,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-notifications"
+                                "hostname": "edgex-app-rules-engine"
                             }
                         },
                         "strategy": {
@@ -8313,261 +6813,6 @@
                         }
                     }
                 },
-                {
-                    "name": "edgex-core-consul",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8500",
-                                "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-consul"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-consul"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-consul"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-consul",
-                                        "image": "consul:1.13.2",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            },
-                                            {
-                                                "name": "ADD_REGISTRY_ACL_ROLES"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:2.3.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "versionName": "minnesota",
-            "configMaps": [
-                {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
-                    },
-                    "data": {
-                        "EDGEX_SECURITY_SECRET_STORE": "true",
-                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
-                        "SECRETSTORE_HOST": "edgex-vault",
-                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
-                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
-                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
-                        "STAGEGATE_DATABASE_PORT": "6379",
-                        "STAGEGATE_DATABASE_READYPORT": "6379",
-                        "STAGEGATE_READY_TORUNPORT": "54329",
-                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
-                        "STAGEGATE_REGISTRY_PORT": "8500",
-                        "STAGEGATE_REGISTRY_READYPORT": "54324",
-                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
-                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
-                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
-                    }
-                }
-            ],
-            "components": [
                 {
                     "name": "edgex-support-scheduler",
                     "service": {
@@ -8606,14 +6851,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:3.0.0",
+                                        "image": "edgexfoundry/support-scheduler:2.3.0",
                                         "ports": [
                                             {
                                                 "name": "tcp-59861",
@@ -8630,16 +6875,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
                                             },
                                             {
                                                 "name": "INTERVALACTIONS_SCRUBAGED_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
                                             }
                                         ],
                                         "resources": {},
@@ -8712,16 +6957,12 @@
                                     {
                                         "name": "kuiper-sources",
                                         "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-log",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.9.2-alpine",
+                                        "image": "lfedge/ekuiper:1.7.1-alpine",
                                         "ports": [
                                             {
                                                 "name": "tcp-59720",
@@ -8738,39 +6979,23 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "edgex/rules-events"
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
                                             },
                                             {
                                                 "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
                                                 "value": "redis"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
                                             },
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
                                                 "value": "redis"
                                             },
                                             {
-                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "name": "EDGEX__DEFAULT__TYPE",
                                                 "value": "redis"
                                             },
                                             {
@@ -8778,8 +7003,24 @@
                                                 "value": "6379"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
                                             }
                                         ],
                                         "resources": {},
@@ -8799,10 +7040,6 @@
                                             {
                                                 "name": "kuiper-sources",
                                                 "mountPath": "/kuiper/etc/sources"
-                                            },
-                                            {
-                                                "name": "kuiper-log",
-                                                "mountPath": "/kuiper/log"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
@@ -8820,67 +7057,55 @@
                     }
                 },
                 {
-                    "name": "edgex-core-consul",
+                    "name": "edgex-core-command",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-8500",
+                                "name": "tcp-59882",
                                 "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
+                                "port": 59882,
+                                "targetPort": 59882
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-consul"
+                            "app": "edgex-core-command"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-consul"
+                                "app": "edgex-core-command"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-consul"
+                                    "app": "edgex-core-command"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-consul",
-                                        "image": "hashicorp/consul:1.15.2",
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/core-command:2.3.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -8893,130 +7118,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
+                                                "name": "MESSAGEQUEUE_EXTERNAL_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
                                             },
-                                            {
-                                                "name": "EDGEX_ADD_REGISTRY_ACL_ROLES"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
-                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
-                                            },
-                                            {
-                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
-                                                "value": "/consul/config/consul_acl_done"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "MESSAGEQUEUE_INTERNAL_HOST",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -9027,104 +7138,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
+                                                "mountPath": "/tmp/edgex/secrets/core-command"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-data",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
+                                "hostname": "edgex-core-command"
                             }
                         },
                         "strategy": {
@@ -9185,14 +7205,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-redis",
-                                        "image": "redis:7.0.11-alpine",
+                                        "image": "redis:7.0.5-alpine",
                                         "ports": [
                                             {
                                                 "name": "tcp-6379",
@@ -9255,31 +7275,31 @@
                     }
                 },
                 {
-                    "name": "edgex-device-rest",
+                    "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59986",
+                                "name": "tcp-59881",
                                 "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
+                                "port": 59881,
+                                "targetPort": 59881
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-rest"
+                            "app": "edgex-core-metadata"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-rest"
+                                "app": "edgex-core-metadata"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-rest"
+                                    "app": "edgex-core-metadata"
                                 }
                             },
                             "spec": {
@@ -9291,19 +7311,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:3.0.0",
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:2.3.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -9317,7 +7337,11 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
@@ -9328,13 +7352,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-rest"
+                                "hostname": "edgex-core-metadata"
                             }
                         },
                         "strategy": {
@@ -9346,42 +7370,55 @@
                     }
                 },
                 {
-                    "name": "edgex-ui-go",
+                    "name": "edgex-sys-mgmt-agent",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-4000",
+                                "name": "tcp-58890",
                                 "protocol": "TCP",
-                                "port": 4000,
-                                "targetPort": 4000
+                                "port": 58890,
+                                "targetPort": 58890
                             }
                         ],
                         "selector": {
-                            "app": "edgex-ui-go"
+                            "app": "edgex-sys-mgmt-agent"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-ui-go"
+                                "app": "edgex-sys-mgmt-agent"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-ui-go"
+                                    "app": "edgex-sys-mgmt-agent"
                                 }
                             },
                             "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/sys-mgmt-agent",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-ui-go",
-                                        "image": "edgexfoundry/edgex-ui:3.0.0",
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "edgexfoundry/sys-mgmt-agent:2.3.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-4000",
-                                                "containerPort": 4000,
+                                                "name": "tcp-58890",
+                                                "containerPort": 58890,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -9395,65 +7432,15 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-ui-go"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-ui-go"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-bootstrapper",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-bootstrapper"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-bootstrapper"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrapper",
-                                        "image": "edgexfoundry/security-bootstrapper:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
+                                                "value": "edgex-sys-mgmt-agent"
                                             },
                                             {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
                                             }
                                         ],
                                         "resources": {},
@@ -9461,12 +7448,16 @@
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/sys-mgmt-agent"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-security-bootstrapper"
+                                "hostname": "edgex-sys-mgmt-agent"
                             }
                         },
                         "strategy": {
@@ -9499,33 +7490,21 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-templates",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "nginx-tls",
+                                        "name": "consul-acl-token",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
-                                    },
-                                    {
-                                        "name": "consul-acl-token",
-                                        "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-security-proxy-setup",
-                                        "image": "edgexfoundry/security-proxy-setup:3.0.0",
+                                        "image": "edgexfoundry/security-proxy-setup:2.3.0",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -9535,44 +7514,47 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_ADD_PROXY_ROUTE",
-                                                "value": "device-rest.http://edgex-device-rest:59986"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
                                             },
                                             {
                                                 "name": "ROUTES_CORE_DATA_HOST",
                                                 "value": "edgex-core-data"
                                             },
                                             {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
                                             },
                                             {
-                                                "name": "ROUTES_CORE_COMMAND_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
-                                                "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_CONSUL_HOST",
-                                                "value": "edgex-core-consul"
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
                                             },
                                             {
                                                 "name": "ROUTES_RULES_ENGINE_HOST",
                                                 "value": "edgex-kuiper"
                                             },
                                             {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "ADD_PROXY_ROUTE"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
                                             }
                                         ],
                                         "resources": {},
@@ -9582,30 +7564,542 @@
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
-                                                "name": "nginx-templates",
-                                                "mountPath": "/etc/nginx/templates"
-                                            },
-                                            {
-                                                "name": "nginx-tls",
-                                                "mountPath": "/etc/ssl/nginx"
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
                                                 "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
-                                            },
-                                            {
-                                                "name": "consul-acl-token",
-                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
                                 "hostname": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kong",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8000",
+                                "protocol": "TCP",
+                                "port": 8000,
+                                "targetPort": 8000
+                            },
+                            {
+                                "name": "tcp-8100",
+                                "protocol": "TCP",
+                                "port": 8100,
+                                "targetPort": 8100
+                            },
+                            {
+                                "name": "tcp-8443",
+                                "protocol": "TCP",
+                                "port": 8443,
+                                "targetPort": 8443
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kong"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kong"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kong"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "postgres-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kong",
+                                        "image": "kong:2.8.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8000",
+                                                "containerPort": 8000,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8100",
+                                                "containerPort": 8100,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-8443",
+                                                "containerPort": 8443,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KONG_STATUS_LISTEN",
+                                                "value": "0.0.0.0:8100"
+                                            },
+                                            {
+                                                "name": "KONG_SSL_CIPHER_SUITE",
+                                                "value": "modern"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_LISTEN",
+                                                "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
+                                            },
+                                            {
+                                                "name": "KONG_NGINX_WORKER_PROCESSES",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_VALID_TTL",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "edgex-kong-db"
+                                            },
+                                            {
+                                                "name": "KONG_PG_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_PROXY_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            },
+                                            {
+                                                "name": "postgres-config",
+                                                "mountPath": "/tmp/postgres-config"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/usr/local/kong"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kong"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-secretstore-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-secretstore-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.3.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/tmp/kong"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/core-data:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
                             }
                         },
                         "strategy": {
@@ -9654,14 +8148,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:3.0.0",
+                                        "image": "edgexfoundry/support-notifications:2.3.0",
                                         "ports": [
                                             {
                                                 "name": "tcp-59860",
@@ -9708,6 +8202,464 @@
                     }
                 },
                 {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:2.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "consul:1.13.2",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8200",
+                                "protocol": "TCP",
+                                "port": 8200,
+                                "targetPort": 8200
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-vault"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-file",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-logs",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault",
+                                        "image": "vault:1.11.4",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8200",
+                                                "containerPort": 8200,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
+                                            },
+                                            {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-file",
+                                                "mountPath": "/vault/file"
+                                            },
+                                            {
+                                                "name": "vault-logs",
+                                                "mountPath": "/vault/logs"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "versionName": "minnesota",
+            "configMaps": [
+                {
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "EDGEX_SECURITY_SECRET_STORE": "true",
+                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
+                        "SECRETSTORE_HOST": "edgex-vault",
+                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
+                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
+                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
+                        "STAGEGATE_DATABASE_PORT": "6379",
+                        "STAGEGATE_DATABASE_READYPORT": "6379",
+                        "STAGEGATE_READY_TORUNPORT": "54329",
+                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
+                        "STAGEGATE_REGISTRY_PORT": "8500",
+                        "STAGEGATE_REGISTRY_READYPORT": "54324",
+                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
+                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
+                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
+                    }
+                }
+            ],
+            "components": [
+                {
+                    "name": "edgex-proxy-auth",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59842",
+                                "protocol": "TCP",
+                                "port": 59842,
+                                "targetPort": 59842
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-proxy-auth"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-proxy-auth"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-proxy-auth"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-auth",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-proxy-auth",
+                                        "image": "edgexfoundry/security-proxy-auth:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59842",
+                                                "containerPort": 59842,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-proxy-auth"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-auth"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-proxy-auth"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
                     "name": "edgex-core-common-config-bootstrapper",
                     "deployment": {
                         "selector": {
@@ -9732,7 +8684,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/core-common-config-bootstrapper",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -9749,24 +8701,24 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
+                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
+                                                "value": "edgex-redis"
                                             },
                                             {
                                                 "name": "APP_SERVICES_CLIENTS_CORE_METADATA_HOST",
                                                 "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "ALL_SERVICES_DATABASE_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "ALL_SERVICES_MESSAGEBUS_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
                                                 "name": "ALL_SERVICES_REGISTRY_HOST",
                                                 "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "DEVICE_SERVICES_CLIENTS_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "ALL_SERVICES_DATABASE_HOST",
+                                                "value": "edgex-redis"
                                             }
                                         ],
                                         "resources": {},
@@ -9784,6 +8736,240 @@
                                     }
                                 ],
                                 "hostname": "edgex-core-common-config-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59882",
+                                "protocol": "TCP",
+                                "port": 59882,
+                                "targetPort": 59882
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-command",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/core-command:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59882",
+                                                "containerPort": 59882,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EXTERNALMQTT_URL",
+                                                "value": "tcp://edgex-mqtt-broker:1883"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-proxy-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-proxy-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-proxy-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-templates",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "nginx-tls",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-proxy-setup",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-proxy-setup",
+                                        "image": "edgexfoundry/security-proxy-setup:3.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "ROUTES_CORE_COMMAND_HOST",
+                                                "value": "edgex-core-command"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_CONSUL_HOST",
+                                                "value": "edgex-core-consul"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "ROUTES_DEVICE_VIRTUAL_HOST",
+                                                "value": "device-virtual"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_PROXY_ROUTE",
+                                                "value": "device-rest.http://edgex-device-rest:59986"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "nginx-templates",
+                                                "mountPath": "/etc/nginx/templates"
+                                            },
+                                            {
+                                                "name": "nginx-tls",
+                                                "mountPath": "/etc/ssl/nginx"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-proxy-setup"
+                                            },
+                                            {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-proxy-setup"
                             }
                         },
                         "strategy": {
@@ -9861,16 +9047,16 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "VAULT_ADDR",
+                                                "value": "http://edgex-vault:8200"
+                                            },
+                                            {
                                                 "name": "VAULT_CONFIG_DIR",
                                                 "value": "/vault/config"
                                             },
                                             {
                                                 "name": "VAULT_UI",
                                                 "value": "true"
-                                            },
-                                            {
-                                                "name": "VAULT_ADDR",
-                                                "value": "http://edgex-vault:8200"
                                             }
                                         ],
                                         "resources": {},
@@ -10029,409 +9215,6 @@
                     }
                 },
                 {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59882",
-                                "protocol": "TCP",
-                                "port": 59882,
-                                "targetPort": 59882
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-command",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/core-command:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59882",
-                                                "containerPort": 59882,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "EXTERNALMQTT_URL",
-                                                "value": "tcp://edgex-mqtt-broker:1883"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-command"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-proxy-auth",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59842",
-                                "protocol": "TCP",
-                                "port": 59842,
-                                "targetPort": 59842
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-proxy-auth"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-proxy-auth"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-proxy-auth"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-proxy-auth",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-proxy-auth",
-                                        "image": "edgexfoundry/security-proxy-auth:3.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59842",
-                                                "containerPort": 59842,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-proxy-auth"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-proxy-auth"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-proxy-auth"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kuiper-sources",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-connections",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:3.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kuiper-sources",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "kuiper-connections",
-                                                "mountPath": "/tmp/kuiper-connections"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
                     "name": "edgex-app-rules-engine",
                     "service": {
                         "ports": [
@@ -10469,7 +9252,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -10525,51 +9308,991 @@
                             }
                         }
                     }
-                }
-            ]
-        },
-        {
-            "versionName": "ireland",
-            "configMaps": [
+                },
                 {
-                    "metadata": {
-                        "name": "common-variables",
-                        "creationTimestamp": null
+                    "name": "edgex-ui-go",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-4000",
+                                "protocol": "TCP",
+                                "port": 4000,
+                                "targetPort": 4000
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-ui-go"
+                        }
                     },
-                    "data": {
-                        "API_GATEWAY_HOST": "edgex-kong",
-                        "API_GATEWAY_STATUS_PORT": "8100",
-                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
-                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
-                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
-                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
-                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
-                        "DATABASES_PRIMARY_HOST": "edgex-redis",
-                        "EDGEX_SECURITY_SECRET_STORE": "true",
-                        "MESSAGEQUEUE_HOST": "edgex-redis",
-                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
-                        "REGISTRY_HOST": "edgex-core-consul",
-                        "SECRETSTORE_HOST": "edgex-vault",
-                        "SECRETSTORE_PORT": "8200",
-                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
-                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
-                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
-                        "STAGEGATE_DATABASE_PORT": "6379",
-                        "STAGEGATE_DATABASE_READYPORT": "6379",
-                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
-                        "STAGEGATE_KONGDB_PORT": "5432",
-                        "STAGEGATE_KONGDB_READYPORT": "54325",
-                        "STAGEGATE_READY_TORUNPORT": "54329",
-                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
-                        "STAGEGATE_REGISTRY_PORT": "8500",
-                        "STAGEGATE_REGISTRY_READYPORT": "54324",
-                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
-                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
-                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-ui-go"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-ui-go"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-ui-go",
+                                        "image": "edgexfoundry/edgex-ui:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-4000",
+                                                "containerPort": 4000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-ui-go"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-ui-go"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
                     }
-                }
-            ],
-            "components": [
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "redis-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "redis:7.0.11-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "DATABASECONFIG_PATH",
+                                                "value": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "redis-config",
+                                                "mountPath": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-bootstrapper",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-bootstrapper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-bootstrapper",
+                                        "image": "edgexfoundry/security-bootstrapper:3.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-secretstore-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-secretstore-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:3.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],message-bus[device-rest],redisdb[device-virtual],message-bus[device-virtual]"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX_ADD_SECRETSTORE_TOKENS"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/tmp/kuiper-connections"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-notifications",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-rest",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59986",
+                                "protocol": "TCP",
+                                "port": 59986,
+                                "targetPort": 59986
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-rest"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-rest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-rest"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-rest"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/core-data:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-connections",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-sources",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-log",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.9.2-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "CONNECTION__EDGEX__REDISMSGBUS__PORT",
+                                                "value": "6379"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "edgex/rules-events"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-connections",
+                                                "mountPath": "/kuiper/etc/connections"
+                                            },
+                                            {
+                                                "name": "kuiper-sources",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            },
+                                            {
+                                                "name": "kuiper-log",
+                                                "mountPath": "/kuiper/log"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59881",
+                                "protocol": "TCP",
+                                "port": 59881,
+                                "targetPort": 59881
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59900",
+                                "protocol": "TCP",
+                                "port": 59900,
+                                "targetPort": 59900
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:3.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
                 {
                     "name": "edgex-core-consul",
                     "service": {
@@ -10620,14 +10343,14 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
                                         "name": "edgex-core-consul",
-                                        "image": "consul:1.9.5",
+                                        "image": "hashicorp/consul:1.15.2",
                                         "ports": [
                                             {
                                                 "name": "tcp-8500",
@@ -10644,19 +10367,23 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
                                                 "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
                                                 "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
                                             },
                                             {
-                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                                "name": "EDGEX_ADD_REGISTRY_ACL_ROLES"
                                             },
                                             {
                                                 "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
                                                 "value": "/consul/config/consul_acl_done"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
                                             },
                                             {
                                                 "name": "EDGEX_USER",
@@ -10701,31 +10428,31 @@
                     }
                 },
                 {
-                    "name": "edgex-device-rest",
+                    "name": "edgex-support-scheduler",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59986",
+                                "name": "tcp-59861",
                                 "protocol": "TCP",
-                                "port": 59986,
-                                "targetPort": 59986
+                                "port": 59861,
+                                "targetPort": 59861
                             }
                         ],
                         "selector": {
-                            "app": "edgex-device-rest"
+                            "app": "edgex-support-scheduler"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-device-rest"
+                                "app": "edgex-support-scheduler"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-device-rest"
+                                    "app": "edgex-support-scheduler"
                                 }
                             },
                             "spec": {
@@ -10737,19 +10464,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-rest",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/device-rest:2.0.0",
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:3.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59986",
-                                                "containerPort": 59986,
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -10762,8 +10489,16 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
                                             }
                                         ],
                                         "resources": {},
@@ -10774,13 +10509,13 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-rest"
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-device-rest"
+                                "hostname": "edgex-support-scheduler"
                             }
                         },
                         "strategy": {
@@ -10790,133 +10525,51 @@
                             }
                         }
                     }
-                },
+                }
+            ]
+        },
+        {
+            "versionName": "ireland",
+            "configMaps": [
                 {
-                    "name": "edgex-security-secretstore-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-security-secretstore-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "kong",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-secretstore-setup",
-                                        "image": "edgexfoundry/security-secretstore-setup:2.0.0",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "ADD_SECRETSTORE_TOKENS"
-                                            },
-                                            {
-                                                "name": "ADD_KNOWN_SECRETS",
-                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
-                                            },
-                                            {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
-                                                "name": "EDGEX_USER",
-                                                "value": "2002"
-                                            },
-                                            {
-                                                "name": "SECUREMESSAGEBUS_TYPE",
-                                                "value": "redis"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "kong",
-                                                "mountPath": "/tmp/kong"
-                                            },
-                                            {
-                                                "name": "kuiper-config",
-                                                "mountPath": "/tmp/kuiper"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-secretstore-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
+                    "metadata": {
+                        "name": "common-variables",
+                        "creationTimestamp": null
+                    },
+                    "data": {
+                        "API_GATEWAY_HOST": "edgex-kong",
+                        "API_GATEWAY_STATUS_PORT": "8100",
+                        "CLIENTS_CORE_COMMAND_HOST": "edgex-core-command",
+                        "CLIENTS_CORE_DATA_HOST": "edgex-core-data",
+                        "CLIENTS_CORE_METADATA_HOST": "edgex-core-metadata",
+                        "CLIENTS_SUPPORT_NOTIFICATIONS_HOST": "edgex-support-notifications",
+                        "CLIENTS_SUPPORT_SCHEDULER_HOST": "edgex-support-scheduler",
+                        "DATABASES_PRIMARY_HOST": "edgex-redis",
+                        "EDGEX_SECURITY_SECRET_STORE": "true",
+                        "MESSAGEQUEUE_HOST": "edgex-redis",
+                        "PROXY_SETUP_HOST": "edgex-security-proxy-setup",
+                        "REGISTRY_HOST": "edgex-core-consul",
+                        "SECRETSTORE_HOST": "edgex-vault",
+                        "SECRETSTORE_PORT": "8200",
+                        "STAGEGATE_BOOTSTRAPPER_HOST": "edgex-security-bootstrapper",
+                        "STAGEGATE_BOOTSTRAPPER_STARTPORT": "54321",
+                        "STAGEGATE_DATABASE_HOST": "edgex-redis",
+                        "STAGEGATE_DATABASE_PORT": "6379",
+                        "STAGEGATE_DATABASE_READYPORT": "6379",
+                        "STAGEGATE_KONGDB_HOST": "edgex-kong-db",
+                        "STAGEGATE_KONGDB_PORT": "5432",
+                        "STAGEGATE_KONGDB_READYPORT": "54325",
+                        "STAGEGATE_READY_TORUNPORT": "54329",
+                        "STAGEGATE_REGISTRY_HOST": "edgex-core-consul",
+                        "STAGEGATE_REGISTRY_PORT": "8500",
+                        "STAGEGATE_REGISTRY_READYPORT": "54324",
+                        "STAGEGATE_SECRETSTORESETUP_HOST": "edgex-security-secretstore-setup",
+                        "STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT": "54322",
+                        "STAGEGATE_WAITFOR_TIMEOUT": "60s"
                     }
-                },
+                }
+            ],
+            "components": [
                 {
                     "name": "edgex-security-bootstrapper",
                     "deployment": {
@@ -10952,12 +10605,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX_GROUP",
-                                                "value": "2001"
-                                            },
-                                            {
                                                 "name": "EDGEX_USER",
                                                 "value": "2002"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
                                             }
                                         ],
                                         "resources": {},
@@ -10971,6 +10624,644 @@
                                     }
                                 ],
                                 "hostname": "edgex-security-bootstrapper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-app-rules-engine",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59701",
+                                "protocol": "TCP",
+                                "port": 59701,
+                                "targetPort": 59701
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-app-rules-engine"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-app-rules-engine"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-app-rules-engine"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/app-rules-engine",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-app-rules-engine",
+                                        "image": "edgexfoundry/app-service-configurable:2.0.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59701",
+                                                "containerPort": 59701,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_PROFILE",
+                                                "value": "rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-app-rules-engine"
+                                            },
+                                            {
+                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
+                                                "value": "edgex-redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-app-rules-engine"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "redis-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "redis:6.2.4-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "DATABASECONFIG_PATH",
+                                                "value": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "DATABASECONFIG_NAME",
+                                                "value": "redis.conf"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "redis-config",
+                                                "mountPath": "/run/redis/conf"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59861",
+                                "protocol": "TCP",
+                                "port": 59861,
+                                "targetPort": 59861
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-scheduler",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/support-scheduler:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59861",
+                                                "containerPort": 59861,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59860",
+                                "protocol": "TCP",
+                                "port": 59860,
+                                "targetPort": 59860
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/support-notifications",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/support-notifications:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59860",
+                                                "containerPort": 59860,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-kuiper",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-59720",
+                                "protocol": "TCP",
+                                "port": 59720,
+                                "targetPort": 59720
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-kuiper"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-kuiper"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-kuiper"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-kuiper",
+                                        "image": "lfedge/ekuiper:1.3.0-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-59720",
+                                                "containerPort": 59720,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "59720"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TOPIC",
+                                                "value": "rules-events"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PROTOCOL",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__SERVER",
+                                                "value": "edgex-redis"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "EDGEX__DEFAULT__PORT",
+                                                "value": "6379"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "kuiper-data",
+                                                "mountPath": "/kuiper/data"
+                                            },
+                                            {
+                                                "name": "kuiper-config",
+                                                "mountPath": "/kuiper/etc/sources"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-kuiper"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-59880",
+                                "protocol": "TCP",
+                                "port": 59880,
+                                "targetPort": 59880
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-data",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/core-data:2.0.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-59880",
+                                                "containerPort": 59880,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
                             }
                         },
                         "strategy": {
@@ -11010,7 +11301,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -11027,12 +11318,39 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_METADATA_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "ROUTES_CORE_DATA_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
                                                 "name": "ROUTES_CORE_COMMAND_HOST",
                                                 "value": "edgex-core-command"
                                             },
                                             {
-                                                "name": "ROUTES_SUPPORT_SCHEDULER_HOST",
-                                                "value": "edgex-support-scheduler"
+                                                "name": "ADD_PROXY_ROUTE"
+                                            },
+                                            {
+                                                "name": "ROUTES_RULES_ENGINE_HOST",
+                                                "value": "edgex-kuiper"
+                                            },
+                                            {
+                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
+                                                "value": "edgex-support-notifications"
                                             },
                                             {
                                                 "name": "ROUTES_CORE_CONSUL_HOST",
@@ -11041,33 +11359,6 @@
                                             {
                                                 "name": "ROUTES_DEVICE_VIRTUAL_HOST",
                                                 "value": "device-virtual"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_DATA_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "ROUTES_SUPPORT_NOTIFICATIONS_HOST",
-                                                "value": "edgex-support-notifications"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "ROUTES_RULES_ENGINE_HOST",
-                                                "value": "edgex-kuiper"
-                                            },
-                                            {
-                                                "name": "ROUTES_CORE_METADATA_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "ROUTES_SYS_MGMT_AGENT_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "ADD_PROXY_ROUTE"
                                             }
                                         ],
                                         "resources": {},
@@ -11157,7 +11448,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
@@ -11199,48 +11490,48 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
                                             },
                                             {
-                                                "name": "KONG_DNS_ORDER",
-                                                "value": "LAST,A,CNAME"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ERROR_LOG",
-                                                "value": "/dev/stderr"
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
                                             },
                                             {
                                                 "name": "KONG_PROXY_ACCESS_LOG",
                                                 "value": "/dev/stdout"
                                             },
                                             {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "edgex-kong-db"
-                                            },
-                                            {
-                                                "name": "KONG_PG_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
-                                            },
-                                            {
                                                 "name": "KONG_DNS_VALID_TTL",
                                                 "value": "1"
-                                            },
-                                            {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
-                                            },
-                                            {
-                                                "name": "KONG_STATUS_LISTEN",
-                                                "value": "0.0.0.0:8100"
                                             },
                                             {
                                                 "name": "KONG_ADMIN_LISTEN",
                                                 "value": "127.0.0.1:8001, 127.0.0.1:8444 ssl"
                                             },
                                             {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
-                                                "value": "/dev/stdout"
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_PG_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
+                                            },
+                                            {
+                                                "name": "KONG_STATUS_LISTEN",
+                                                "value": "0.0.0.0:8100"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "edgex-kong-db"
+                                            },
+                                            {
+                                                "name": "KONG_DNS_ORDER",
+                                                "value": "LAST,A,CNAME"
                                             }
                                         ],
                                         "resources": {},
@@ -11285,31 +11576,31 @@
                     }
                 },
                 {
-                    "name": "edgex-app-rules-engine",
+                    "name": "edgex-device-rest",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59701",
+                                "name": "tcp-59986",
                                 "protocol": "TCP",
-                                "port": 59701,
-                                "targetPort": 59701
+                                "port": 59986,
+                                "targetPort": 59986
                             }
                         ],
                         "selector": {
-                            "app": "edgex-app-rules-engine"
+                            "app": "edgex-device-rest"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-app-rules-engine"
+                                "app": "edgex-device-rest"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-app-rules-engine"
+                                    "app": "edgex-device-rest"
                                 }
                             },
                             "spec": {
@@ -11321,19 +11612,19 @@
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/app-rules-engine",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/device-rest",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-app-rules-engine",
-                                        "image": "edgexfoundry/app-service-configurable:2.0.1",
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/device-rest:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59701",
-                                                "containerPort": 59701,
+                                                "name": "tcp-59986",
+                                                "containerPort": 59986,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -11346,20 +11637,8 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_PUBLISHHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_PROFILE",
-                                                "value": "rules-engine"
-                                            },
-                                            {
-                                                "name": "TRIGGER_EDGEXMESSAGEBUS_SUBSCRIBEHOST_HOST",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-app-rules-engine"
+                                                "value": "edgex-device-rest"
                                             }
                                         ],
                                         "resources": {},
@@ -11370,13 +11649,139 @@
                                             },
                                             {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/app-rules-engine"
+                                                "mountPath": "/tmp/edgex/secrets/device-rest"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-app-rules-engine"
+                                "hostname": "edgex-device-rest"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-security-secretstore-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-security-secretstore-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-security-secretstore-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "kong",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "kuiper-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-security-secretstore-setup",
+                                        "image": "edgexfoundry/security-secretstore-setup:2.0.0",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECUREMESSAGEBUS_TYPE",
+                                                "value": "redis"
+                                            },
+                                            {
+                                                "name": "ADD_SECRETSTORE_TOKENS"
+                                            },
+                                            {
+                                                "name": "ADD_KNOWN_SECRETS",
+                                                "value": "redisdb[app-rules-engine],redisdb[device-rest],redisdb[device-virtual]"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
+                                            },
+                                            {
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "edgex-init",
+                                                "mountPath": "/edgex-init"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "kong",
+                                                "mountPath": "/tmp/kong"
+                                            },
+                                            {
+                                                "name": "kuiper-config",
+                                                "mountPath": "/tmp/kuiper"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-security-secretstore-setup"
                             }
                         },
                         "strategy": {
@@ -11454,16 +11859,16 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            },
+                                            {
                                                 "name": "VAULT_ADDR",
                                                 "value": "http://edgex-vault:8200"
                                             },
                                             {
                                                 "name": "VAULT_UI",
                                                 "value": "true"
-                                            },
-                                            {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
                                             }
                                         ],
                                         "resources": {},
@@ -11500,66 +11905,67 @@
                     }
                 },
                 {
-                    "name": "edgex-core-data",
+                    "name": "edgex-core-consul",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-5563",
+                                "name": "tcp-8500",
                                 "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-59880",
-                                "protocol": "TCP",
-                                "port": 59880,
-                                "targetPort": 59880
+                                "port": 8500,
+                                "targetPort": 8500
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-data"
+                            "app": "edgex-core-consul"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-data"
+                                "app": "edgex-core-consul"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-data"
+                                    "app": "edgex-core-consul"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
                                         "name": "edgex-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-acl-token",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-data",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/core-data:2.0.0",
+                                        "name": "edgex-core-consul",
+                                        "image": "consul:1.9.5",
                                         "ports": [
                                             {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-59880",
-                                                "containerPort": 59880,
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -11572,219 +11978,52 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
+                                                "name": "STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH",
+                                                "value": "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
                                             },
                                             {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/core-data/secrets-token.json"
+                                                "name": "EDGEX_USER",
+                                                "value": "2002"
+                                            },
+                                            {
+                                                "name": "STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH",
+                                                "value": "/consul/config/consul_acl_done"
+                                            },
+                                            {
+                                                "name": "ADD_REGISTRY_ACL_ROLES"
+                                            },
+                                            {
+                                                "name": "EDGEX_GROUP",
+                                                "value": "2001"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
                                             },
                                             {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59860",
-                                "protocol": "TCP",
-                                "port": 59860,
-                                "targetPort": 59860
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/support-notifications:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59860",
-                                                "containerPort": 59860,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
                                             {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
+                                                "name": "consul-acl-token",
+                                                "mountPath": "/tmp/edgex/secrets/consul-acl-token"
+                                            },
+                                            {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-notifications"
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59861",
-                                "protocol": "TCP",
-                                "port": 59861,
-                                "targetPort": 59861
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/support-scheduler",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/support-scheduler:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59861",
-                                                "containerPort": 59861,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/support-scheduler"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
+                                "hostname": "edgex-core-consul"
                             }
                         },
                         "strategy": {
@@ -11833,7 +12072,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/sys-mgmt-agent",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -11857,16 +12096,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            },
-                                            {
                                                 "name": "SERVICE_HOST",
                                                 "value": "edgex-sys-mgmt-agent"
                                             },
                                             {
                                                 "name": "EXECUTORPATH",
                                                 "value": "/sys-mgmt-executor"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
                                             }
                                         ],
                                         "resources": {},
@@ -11932,7 +12171,7 @@
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/core-command",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
@@ -11986,31 +12225,31 @@
                     }
                 },
                 {
-                    "name": "edgex-kuiper",
+                    "name": "edgex-core-metadata",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-59720",
+                                "name": "tcp-59881",
                                 "protocol": "TCP",
-                                "port": 59720,
-                                "targetPort": 59720
+                                "port": 59881,
+                                "targetPort": 59881
                             }
                         ],
                         "selector": {
-                            "app": "edgex-kuiper"
+                            "app": "edgex-core-metadata"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-kuiper"
+                                "app": "edgex-core-metadata"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-kuiper"
+                                    "app": "edgex-core-metadata"
                                 }
                             },
                             "spec": {
@@ -12020,22 +12259,21 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "kuiper-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "kuiper-config",
-                                        "emptyDir": {}
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/core-metadata",
+                                            "type": "FileOrCreate"
+                                        }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-kuiper",
-                                        "image": "lfedge/ekuiper:1.3.0-alpine",
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/core-metadata:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-59720",
-                                                "containerPort": 59720,
+                                                "name": "tcp-59881",
+                                                "containerPort": 59881,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -12048,32 +12286,12 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "EDGEX__DEFAULT__TOPIC",
-                                                "value": "rules-events"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
                                             },
                                             {
-                                                "name": "EDGEX__DEFAULT__TYPE",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PORT",
-                                                "value": "6379"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__PROTOCOL",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX__DEFAULT__SERVER",
-                                                "value": "edgex-redis"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "59720"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
                                             }
                                         ],
                                         "resources": {},
@@ -12083,18 +12301,14 @@
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "kuiper-data",
-                                                "mountPath": "/kuiper/data"
-                                            },
-                                            {
-                                                "name": "kuiper-config",
-                                                "mountPath": "/kuiper/etc/sources"
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-kuiper"
+                                "hostname": "edgex-core-metadata"
                             }
                         },
                         "strategy": {
@@ -12106,67 +12320,55 @@
                     }
                 },
                 {
-                    "name": "edgex-redis",
+                    "name": "edgex-device-virtual",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-6379",
+                                "name": "tcp-59900",
                                 "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
+                                "port": 59900,
+                                "targetPort": 59900
                             }
                         ],
                         "selector": {
-                            "app": "edgex-redis"
+                            "app": "edgex-device-virtual"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-redis"
+                                "app": "edgex-device-virtual"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-redis"
+                                    "app": "edgex-device-virtual"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
                                         "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "redis-config",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/security-bootstrapper-redis",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/device-virtual",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-redis",
-                                        "image": "redis:6.2.4-alpine",
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/device-virtual:2.0.0",
                                         "ports": [
                                             {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
+                                                "name": "tcp-59900",
+                                                "containerPort": 59900,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -12179,41 +12381,25 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "DATABASECONFIG_PATH",
-                                                "value": "/run/redis/conf"
-                                            },
-                                            {
-                                                "name": "DATABASECONFIG_NAME",
-                                                "value": "redis.conf"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            },
-                                            {
                                                 "name": "edgex-init",
                                                 "mountPath": "/edgex-init"
                                             },
                                             {
-                                                "name": "redis-config",
-                                                "mountPath": "/run/redis/conf"
-                                            },
-                                            {
                                                 "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/security-bootstrapper-redis"
+                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-redis"
+                                "hostname": "edgex-device-virtual"
                             }
                         },
                         "strategy": {
@@ -12299,16 +12485,16 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "POSTGRES_DB",
-                                                "value": "kong"
+                                                "name": "POSTGRES_PASSWORD_FILE",
+                                                "value": "/tmp/postgres-config/.pgpassword"
                                             },
                                             {
                                                 "name": "POSTGRES_USER",
                                                 "value": "kong"
                                             },
                                             {
-                                                "name": "POSTGRES_PASSWORD_FILE",
-                                                "value": "/tmp/postgres-config/.pgpassword"
+                                                "name": "POSTGRES_DB",
+                                                "value": "kong"
                                             }
                                         ],
                                         "resources": {},
@@ -12351,192 +12537,6 @@
                             }
                         }
                     }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59900",
-                                "protocol": "TCP",
-                                "port": 59900,
-                                "targetPort": 59900
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/device-virtual",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/device-virtual:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59900",
-                                                "containerPort": 59900,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/device-virtual"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-59881",
-                                "protocol": "TCP",
-                                "port": 59881,
-                                "targetPort": 59881
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "edgex-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/core-metadata:2.0.0",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-59881",
-                                                "containerPort": 59881,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "edgex-init",
-                                                "mountPath": "/edgex-init"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/core-metadata"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
                 }
             ]
         },
@@ -12570,45 +12570,49 @@
             ],
             "components": [
                 {
-                    "name": "edgex-proxy",
+                    "name": "edgex-security-bootstrap-database",
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-proxy"
+                                "app": "edgex-security-bootstrap-database"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-proxy"
+                                    "app": "edgex-security-bootstrap-database"
                                 }
                             },
                             "spec": {
                                 "volumes": [
                                     {
-                                        "name": "consul-scripts",
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
                                         "emptyDir": {}
                                     },
                                     {
                                         "name": "anonymous-volume1",
                                         "hostPath": {
                                             "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
+                                            "type": "FileOrCreate"
                                         }
                                     },
                                     {
                                         "name": "anonymous-volume2",
                                         "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-security-proxy-setup",
-                                            "type": "DirectoryOrCreate"
+                                            "path": "/tmp/edgex/secrets/edgex-security-bootstrap-redis",
+                                            "type": "FileOrCreate"
                                         }
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "edgex-proxy",
-                                        "image": "edgexfoundry/docker-security-proxy-setup-go:1.3.1",
+                                        "name": "edgex-security-bootstrap-database",
+                                        "image": "edgexfoundry/docker-security-bootstrap-redis-go:1.3.1",
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -12618,31 +12622,23 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "SECRETSERVICE_SERVER",
-                                                "value": "edgex-vault"
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-security-bootstrap-redis/secrets-token.json"
                                             },
                                             {
-                                                "name": "SECRETSERVICE_TOKENPATH",
-                                                "value": "/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "SECRETSERVICE_SNIS",
-                                                "value": "edgex-kong"
-                                            },
-                                            {
-                                                "name": "SECRETSERVICE_CACERTPATH",
-                                                "value": "/tmp/edgex/secrets/ca/ca.pem"
-                                            },
-                                            {
-                                                "name": "KONGURL_SERVER",
-                                                "value": "kong"
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-security-bootstrap-database"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
                                             },
                                             {
                                                 "name": "anonymous-volume1",
@@ -12650,13 +12646,877 @@
                                             },
                                             {
                                                 "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-security-proxy-setup"
+                                                "mountPath": "/tmp/edgex/secrets/edgex-security-bootstrap-redis"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-proxy"
+                                "hostname": "edgex-security-bootstrap-database"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-secrets-setup",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-secrets-setup"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-secrets-setup"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "secrets-setup-cache",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "vault-init",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-secrets-setup",
+                                        "image": "edgexfoundry/docker-security-secrets-setup-go:1.3.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "secrets-setup-cache",
+                                                "mountPath": "/etc/edgex/pki"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "vault-init",
+                                                "mountPath": "/vault/init"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-secrets-setup"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-metadata",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48081",
+                                "protocol": "TCP",
+                                "port": 48081,
+                                "targetPort": 48081
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-metadata"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-metadata"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-metadata"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-core-metadata",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-metadata",
+                                        "image": "edgexfoundry/docker-core-metadata-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48081",
+                                                "containerPort": 48081,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "NOTIFICATIONS_SENDER",
+                                                "value": "edgex-core-metadata"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-core-metadata/secrets-token.json"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-core-metadata"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-metadata"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-data",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5563",
+                                "protocol": "TCP",
+                                "port": 5563,
+                                "targetPort": 5563
+                            },
+                            {
+                                "name": "tcp-48080",
+                                "protocol": "TCP",
+                                "port": 48080,
+                                "targetPort": 48080
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-data"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-data"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-data"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-core-data",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-data",
+                                        "image": "edgexfoundry/docker-core-data-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5563",
+                                                "containerPort": 5563,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "name": "tcp-48080",
+                                                "containerPort": 48080,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-core-data/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-core-data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-data"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-sys-mgmt-agent",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48090",
+                                "protocol": "TCP",
+                                "port": 48090,
+                                "targetPort": 48090
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-sys-mgmt-agent"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-sys-mgmt-agent"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-sys-mgmt-agent",
+                                        "image": "edgexfoundry/docker-sys-mgmt-agent-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48090",
+                                                "containerPort": 48090,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-sys-mgmt-agent"
+                                            },
+                                            {
+                                                "name": "METRICSMECHANISM",
+                                                "value": "executor"
+                                            },
+                                            {
+                                                "name": "EXECUTORPATH",
+                                                "value": "/sys-mgmt-executor"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-sys-mgmt-agent"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-redis",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-6379",
+                                "protocol": "TCP",
+                                "port": 6379,
+                                "targetPort": 6379
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-redis"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-redis"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-redis"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "db-data",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-redis",
+                                        "image": "redis:6.0.9-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-6379",
+                                                "containerPort": 6379,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "db-data",
+                                                "mountPath": "/data"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-redis"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8200",
+                                "protocol": "TCP",
+                                "port": 8200,
+                                "targetPort": 8200
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-vault"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-vault",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "vault-file",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-init",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "vault-logs",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault",
+                                        "image": "vault:1.5.3",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8200",
+                                                "containerPort": 8200,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "VAULT_CONFIG_DIR",
+                                                "value": "/vault/config"
+                                            },
+                                            {
+                                                "name": "VAULT_UI",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "VAULT_ADDR",
+                                                "value": "https://edgex-vault:8200"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/vault/config"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-vault"
+                                            },
+                                            {
+                                                "name": "vault-file",
+                                                "mountPath": "/vault/file"
+                                            },
+                                            {
+                                                "name": "vault-init",
+                                                "mountPath": "/vault/init"
+                                            },
+                                            {
+                                                "name": "vault-logs",
+                                                "mountPath": "/vault/logs"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-notifications",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48060",
+                                "protocol": "TCP",
+                                "port": 48060,
+                                "targetPort": 48060
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-notifications"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-notifications"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-notifications"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-support-notifications",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-notifications",
+                                        "image": "edgexfoundry/docker-support-notifications-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48060",
+                                                "containerPort": 48060,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-support-notifications/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-notifications"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-support-notifications"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-notifications"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-command",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48082",
+                                "protocol": "TCP",
+                                "port": 48082,
+                                "targetPort": 48082
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-command"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-command"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-command"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-core-command",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-command",
+                                        "image": "edgexfoundry/docker-core-command-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48082",
+                                                "containerPort": 48082,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-core-command/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-core-command"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-core-command"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-command"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-vault-worker",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-vault-worker"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-vault-worker"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "tmpfs-volume2",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "vault-config",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-vault-worker",
+                                        "image": "edgexfoundry/docker-security-secretstore-setup-go:1.3.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SECRETSTORE_SETUP_DONE_FLAG",
+                                                "value": "/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/run"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume2",
+                                                "mountPath": "/vault"
+                                            },
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets"
+                                            },
+                                            {
+                                                "name": "vault-config",
+                                                "mountPath": "/vault/config"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-vault-worker"
                             }
                         },
                         "strategy": {
@@ -12752,18 +13612,31 @@
                     }
                 },
                 {
-                    "name": "edgex-security-bootstrap-database",
+                    "name": "kong-db",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-5432",
+                                "protocol": "TCP",
+                                "port": 5432,
+                                "targetPort": 5432
+                            }
+                        ],
+                        "selector": {
+                            "app": "kong-db"
+                        }
+                    },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-security-bootstrap-database"
+                                "app": "kong-db"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-security-bootstrap-database"
+                                    "app": "kong-db"
                                 }
                             },
                             "spec": {
@@ -12777,379 +13650,25 @@
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-security-bootstrap-redis",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-security-bootstrap-database",
-                                        "image": "edgexfoundry/docker-security-bootstrap-redis-go:1.3.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-security-bootstrap-database"
-                                            },
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-security-bootstrap-redis/secrets-token.json"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-security-bootstrap-redis"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-security-bootstrap-database"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-data",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5563",
-                                "protocol": "TCP",
-                                "port": 5563,
-                                "targetPort": 5563
-                            },
-                            {
-                                "name": "tcp-48080",
-                                "protocol": "TCP",
-                                "port": 48080,
-                                "targetPort": 48080
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-data"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-data"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-data"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-core-data",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-data",
-                                        "image": "edgexfoundry/docker-core-data-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-5563",
-                                                "containerPort": 5563,
-                                                "protocol": "TCP"
-                                            },
-                                            {
-                                                "name": "tcp-48080",
-                                                "containerPort": 48080,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-core-data/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-core-data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-data"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-command",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48082",
-                                "protocol": "TCP",
-                                "port": 48082,
-                                "targetPort": 48082
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-command"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-command"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-command"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-core-command",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-command",
-                                        "image": "edgexfoundry/docker-core-command-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48082",
-                                                "containerPort": 48082,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-core-command"
-                                            },
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-core-command/secrets-token.json"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-core-command"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-command"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-virtual",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-49990",
-                                "protocol": "TCP",
-                                "port": 49990,
-                                "targetPort": 49990
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-virtual"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-virtual"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-virtual"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-virtual",
-                                        "image": "edgexfoundry/docker-device-virtual-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-49990",
-                                                "containerPort": 49990,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-virtual"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-virtual"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": ""
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": ""
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
+                                        "name": "tmpfs-volume3",
                                         "emptyDir": {}
                                     },
                                     {
-                                        "name": "consul-scripts",
+                                        "name": "postgres-data",
                                         "emptyDir": {}
                                     }
                                 ],
                                 "containers": [
                                     {
-                                        "name": "",
-                                        "image": "kong:2.0.5",
+                                        "name": "kong-db",
+                                        "image": "postgres:12.3-alpine",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-5432",
+                                                "containerPort": 5432,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
                                         "envFrom": [
                                             {
                                                 "configMapRef": {
@@ -13159,339 +13678,41 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KONG_PG_PASSWORD",
+                                                "name": "POSTGRES_DB",
                                                 "value": "kong"
                                             },
                                             {
-                                                "name": "KONG_DATABASE",
-                                                "value": "postgres"
+                                                "name": "POSTGRES_PASSWORD",
+                                                "value": "kong"
                                             },
                                             {
-                                                "name": "KONG_PG_HOST",
-                                                "value": "kong-db"
+                                                "name": "POSTGRES_USER",
+                                                "value": "kong"
                                             }
                                         ],
                                         "resources": {},
                                         "volumeMounts": [
                                             {
                                                 "name": "tmpfs-volume1",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ]
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-redis",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-6379",
-                                "protocol": "TCP",
-                                "port": 6379,
-                                "targetPort": 6379
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-redis"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-redis"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-redis"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "db-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-redis",
-                                        "image": "redis:6.0.9-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-6379",
-                                                "containerPort": 6379,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "db-data",
-                                                "mountPath": "/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-redis"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-sys-mgmt-agent",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48090",
-                                "protocol": "TCP",
-                                "port": 48090,
-                                "targetPort": 48090
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-sys-mgmt-agent"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-sys-mgmt-agent"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-sys-mgmt-agent",
-                                        "image": "edgexfoundry/docker-sys-mgmt-agent-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48090",
-                                                "containerPort": 48090,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EXECUTORPATH",
-                                                "value": "/sys-mgmt-executor"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-sys-mgmt-agent"
-                                            },
-                                            {
-                                                "name": "METRICSMECHANISM",
-                                                "value": "executor"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-sys-mgmt-agent"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-secrets-setup",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-secrets-setup"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-secrets-setup"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "secrets-setup-cache",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "vault-init",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-secrets-setup",
-                                        "image": "edgexfoundry/docker-security-secrets-setup-go:1.3.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/tmp"
+                                                "mountPath": "/var/run"
                                             },
                                             {
                                                 "name": "tmpfs-volume2",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "tmpfs-volume3",
                                                 "mountPath": "/run"
                                             },
                                             {
-                                                "name": "secrets-setup-cache",
-                                                "mountPath": "/etc/edgex/pki"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "vault-init",
-                                                "mountPath": "/vault/init"
+                                                "name": "postgres-data",
+                                                "mountPath": "/var/lib/postgresql/data"
                                             }
                                         ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-secrets-setup"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-device-rest",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-49986",
-                                "protocol": "TCP",
-                                "port": 49986,
-                                "targetPort": 49986
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-device-rest"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-device-rest"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-device-rest"
-                                }
-                            },
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "edgex-device-rest",
-                                        "image": "edgexfoundry/docker-device-rest-go:1.2.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-49986",
-                                                "containerPort": 49986,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-device-rest"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-device-rest"
+                                "hostname": "kong-db"
                             }
                         },
                         "strategy": {
@@ -13602,6 +13823,14 @@
                                         ],
                                         "env": [
                                             {
+                                                "name": "KONG_PROXY_ERROR_LOG",
+                                                "value": "/dev/stderr"
+                                            },
+                                            {
+                                                "name": "KONG_ADMIN_ACCESS_LOG",
+                                                "value": "/dev/stdout"
+                                            },
+                                            {
                                                 "name": "KONG_ADMIN_ERROR_LOG",
                                                 "value": "/dev/stderr"
                                             },
@@ -13623,14 +13852,6 @@
                                             },
                                             {
                                                 "name": "KONG_PROXY_ACCESS_LOG",
-                                                "value": "/dev/stdout"
-                                            },
-                                            {
-                                                "name": "KONG_PROXY_ERROR_LOG",
-                                                "value": "/dev/stderr"
-                                            },
-                                            {
-                                                "name": "KONG_ADMIN_ACCESS_LOG",
                                                 "value": "/dev/stdout"
                                             }
                                         ],
@@ -13657,6 +13878,501 @@
                                     }
                                 ],
                                 "hostname": "kong"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-core-consul",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-8500",
+                                "protocol": "TCP",
+                                "port": 8500,
+                                "targetPort": 8500
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-core-consul"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-core-consul"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-core-consul"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-config",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-data",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-consul",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume3",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-kong",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume4",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-vault",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-core-consul",
+                                        "image": "edgexfoundry/docker-edgex-consul:1.3.0",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-8500",
+                                                "containerPort": 8500,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "EDGEX_SECURE",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_SETUP_DONE_FLAG",
+                                                "value": "/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
+                                            },
+                                            {
+                                                "name": "EDGEX_DB",
+                                                "value": "redis"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-config",
+                                                "mountPath": "/consul/config"
+                                            },
+                                            {
+                                                "name": "consul-data",
+                                                "mountPath": "/consul/data"
+                                            },
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
+                                            },
+                                            {
+                                                "name": "anonymous-volume3",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-kong"
+                                            },
+                                            {
+                                                "name": "anonymous-volume4",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-vault"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-core-consul"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-support-scheduler",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-48085",
+                                "protocol": "TCP",
+                                "port": 48085,
+                                "targetPort": 48085
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-support-scheduler"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-support-scheduler"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-support-scheduler"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-support-scheduler",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-support-scheduler",
+                                        "image": "edgexfoundry/docker-support-scheduler-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-48085",
+                                                "containerPort": 48085,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-support-scheduler"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
+                                                "value": "edgex-core-data"
+                                            },
+                                            {
+                                                "name": "SECRETSTORE_TOKENFILE",
+                                                "value": "/tmp/edgex/secrets/edgex-support-scheduler/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
+                                                "value": "edgex-core-data"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-support-scheduler"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-support-scheduler"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-proxy",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-proxy"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-proxy"
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "anonymous-volume1",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/ca",
+                                            "type": "FileOrCreate"
+                                        }
+                                    },
+                                    {
+                                        "name": "anonymous-volume2",
+                                        "hostPath": {
+                                            "path": "/tmp/edgex/secrets/edgex-security-proxy-setup",
+                                            "type": "FileOrCreate"
+                                        }
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "edgex-proxy",
+                                        "image": "edgexfoundry/docker-security-proxy-setup-go:1.3.1",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KONGURL_SERVER",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "SECRETSERVICE_TOKENPATH",
+                                                "value": "/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json"
+                                            },
+                                            {
+                                                "name": "SECRETSERVICE_SNIS",
+                                                "value": "edgex-kong"
+                                            },
+                                            {
+                                                "name": "SECRETSERVICE_SERVER",
+                                                "value": "edgex-vault"
+                                            },
+                                            {
+                                                "name": "SECRETSERVICE_CACERTPATH",
+                                                "value": "/tmp/edgex/secrets/ca/ca.pem"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            },
+                                            {
+                                                "name": "anonymous-volume1",
+                                                "mountPath": "/tmp/edgex/secrets/ca"
+                                            },
+                                            {
+                                                "name": "anonymous-volume2",
+                                                "mountPath": "/tmp/edgex/secrets/edgex-security-proxy-setup"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-proxy"
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "",
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": ""
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": ""
+                                }
+                            },
+                            "spec": {
+                                "volumes": [
+                                    {
+                                        "name": "tmpfs-volume1",
+                                        "emptyDir": {}
+                                    },
+                                    {
+                                        "name": "consul-scripts",
+                                        "emptyDir": {}
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "name": "",
+                                        "image": "kong:2.0.5",
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "KONG_PG_PASSWORD",
+                                                "value": "kong"
+                                            },
+                                            {
+                                                "name": "KONG_DATABASE",
+                                                "value": "postgres"
+                                            },
+                                            {
+                                                "name": "KONG_PG_HOST",
+                                                "value": "kong-db"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "volumeMounts": [
+                                            {
+                                                "name": "tmpfs-volume1",
+                                                "mountPath": "/tmp"
+                                            },
+                                            {
+                                                "name": "consul-scripts",
+                                                "mountPath": "/consul/scripts"
+                                            }
+                                        ],
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ]
+                            }
+                        },
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 0
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "edgex-device-virtual",
+                    "service": {
+                        "ports": [
+                            {
+                                "name": "tcp-49990",
+                                "protocol": "TCP",
+                                "port": 49990,
+                                "targetPort": 49990
+                            }
+                        ],
+                        "selector": {
+                            "app": "edgex-device-virtual"
+                        }
+                    },
+                    "deployment": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "edgex-device-virtual"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "creationTimestamp": null,
+                                "labels": {
+                                    "app": "edgex-device-virtual"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "edgex-device-virtual",
+                                        "image": "edgexfoundry/docker-device-virtual-go:1.3.1",
+                                        "ports": [
+                                            {
+                                                "name": "tcp-49990",
+                                                "containerPort": 49990,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "envFrom": [
+                                            {
+                                                "configMapRef": {
+                                                    "name": "common-variables"
+                                                }
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "SERVICE_HOST",
+                                                "value": "edgex-device-virtual"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "IfNotPresent"
+                                    }
+                                ],
+                                "hostname": "edgex-device-virtual"
                             }
                         },
                         "strategy": {
@@ -13727,14 +14443,6 @@
                                         ],
                                         "env": [
                                             {
-                                                "name": "KUIPER__BASIC__CONSOLELOG",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "KUIPER__BASIC__RESTPORT",
-                                                "value": "48075"
-                                            },
-                                            {
                                                 "name": "EDGEX__DEFAULT__PORT",
                                                 "value": "5566"
                                             },
@@ -13753,6 +14461,14 @@
                                             {
                                                 "name": "EDGEX__DEFAULT__TOPIC",
                                                 "value": "events"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__CONSOLELOG",
+                                                "value": "true"
+                                            },
+                                            {
+                                                "name": "KUIPER__BASIC__RESTPORT",
+                                                "value": "48075"
                                             }
                                         ],
                                         "resources": {},
@@ -13771,206 +14487,42 @@
                     }
                 },
                 {
-                    "name": "edgex-core-consul",
+                    "name": "edgex-device-rest",
                     "service": {
                         "ports": [
                             {
-                                "name": "tcp-8500",
+                                "name": "tcp-49986",
                                 "protocol": "TCP",
-                                "port": 8500,
-                                "targetPort": 8500
+                                "port": 49986,
+                                "targetPort": 49986
                             }
                         ],
                         "selector": {
-                            "app": "edgex-core-consul"
+                            "app": "edgex-device-rest"
                         }
                     },
                     "deployment": {
                         "selector": {
                             "matchLabels": {
-                                "app": "edgex-core-consul"
+                                "app": "edgex-device-rest"
                             }
                         },
                         "template": {
                             "metadata": {
                                 "creationTimestamp": null,
                                 "labels": {
-                                    "app": "edgex-core-consul"
+                                    "app": "edgex-device-rest"
                                 }
                             },
                             "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "consul-config",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-data",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-scripts",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-consul",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume3",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-kong",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume4",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-vault",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
                                 "containers": [
                                     {
-                                        "name": "edgex-core-consul",
-                                        "image": "edgexfoundry/docker-edgex-consul:1.3.0",
+                                        "name": "edgex-device-rest",
+                                        "image": "edgexfoundry/docker-device-rest-go:1.2.1",
                                         "ports": [
                                             {
-                                                "name": "tcp-8500",
-                                                "containerPort": 8500,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "EDGEX_DB",
-                                                "value": "redis"
-                                            },
-                                            {
-                                                "name": "EDGEX_SECURE",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "SECRETSTORE_SETUP_DONE_FLAG",
-                                                "value": "/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "consul-config",
-                                                "mountPath": "/consul/config"
-                                            },
-                                            {
-                                                "name": "consul-data",
-                                                "mountPath": "/consul/data"
-                                            },
-                                            {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-consul"
-                                            },
-                                            {
-                                                "name": "anonymous-volume3",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-kong"
-                                            },
-                                            {
-                                                "name": "anonymous-volume4",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-vault"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-core-consul"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-core-metadata",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48081",
-                                "protocol": "TCP",
-                                "port": 48081,
-                                "targetPort": 48081
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-core-metadata"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-core-metadata"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-core-metadata"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-core-metadata",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-core-metadata",
-                                        "image": "edgexfoundry/docker-core-metadata-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48081",
-                                                "containerPort": 48081,
+                                                "name": "tcp-49986",
+                                                "containerPort": 49986,
                                                 "protocol": "TCP"
                                             }
                                         ],
@@ -13984,566 +14536,14 @@
                                         "env": [
                                             {
                                                 "name": "SERVICE_HOST",
-                                                "value": "edgex-core-metadata"
-                                            },
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-core-metadata/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "NOTIFICATIONS_SENDER",
-                                                "value": "edgex-core-metadata"
+                                                "value": "edgex-device-rest"
                                             }
                                         ],
                                         "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-core-metadata"
-                                            }
-                                        ],
                                         "imagePullPolicy": "IfNotPresent"
                                     }
                                 ],
-                                "hostname": "edgex-core-metadata"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-scheduler",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48085",
-                                "protocol": "TCP",
-                                "port": 48085,
-                                "targetPort": 48085
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-scheduler"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-scheduler"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-scheduler"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-support-scheduler",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-scheduler",
-                                        "image": "edgexfoundry/docker-support-scheduler-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48085",
-                                                "containerPort": 48085,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-support-scheduler/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-scheduler"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBPUSHED_HOST",
-                                                "value": "edgex-core-data"
-                                            },
-                                            {
-                                                "name": "INTERVALACTIONS_SCRUBAGED_HOST",
-                                                "value": "edgex-core-data"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-support-scheduler"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-scheduler"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-support-notifications",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-48060",
-                                "protocol": "TCP",
-                                "port": 48060,
-                                "targetPort": 48060
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-support-notifications"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-support-notifications"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-support-notifications"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/ca",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "anonymous-volume2",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-support-notifications",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-support-notifications",
-                                        "image": "edgexfoundry/docker-support-notifications-go:1.3.1",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-48060",
-                                                "containerPort": 48060,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_TOKENFILE",
-                                                "value": "/tmp/edgex/secrets/edgex-support-notifications/secrets-token.json"
-                                            },
-                                            {
-                                                "name": "SERVICE_HOST",
-                                                "value": "edgex-support-notifications"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/ca"
-                                            },
-                                            {
-                                                "name": "anonymous-volume2",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-support-notifications"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-support-notifications"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "kong-db",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-5432",
-                                "protocol": "TCP",
-                                "port": 5432,
-                                "targetPort": 5432
-                            }
-                        ],
-                        "selector": {
-                            "app": "kong-db"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "kong-db"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "kong-db"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume3",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "postgres-data",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "kong-db",
-                                        "image": "postgres:12.3-alpine",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-5432",
-                                                "containerPort": 5432,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "POSTGRES_USER",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "POSTGRES_DB",
-                                                "value": "kong"
-                                            },
-                                            {
-                                                "name": "POSTGRES_PASSWORD",
-                                                "value": "kong"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/var/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/tmp"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume3",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "postgres-data",
-                                                "mountPath": "/var/lib/postgresql/data"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "kong-db"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-vault",
-                    "service": {
-                        "ports": [
-                            {
-                                "name": "tcp-8200",
-                                "protocol": "TCP",
-                                "port": 8200,
-                                "targetPort": 8200
-                            }
-                        ],
-                        "selector": {
-                            "app": "edgex-vault"
-                        }
-                    },
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-vault"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-vault"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets/edgex-vault",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "vault-file",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-init",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "vault-logs",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-vault",
-                                        "image": "vault:1.5.3",
-                                        "ports": [
-                                            {
-                                                "name": "tcp-8200",
-                                                "containerPort": 8200,
-                                                "protocol": "TCP"
-                                            }
-                                        ],
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "VAULT_UI",
-                                                "value": "true"
-                                            },
-                                            {
-                                                "name": "VAULT_ADDR",
-                                                "value": "https://edgex-vault:8200"
-                                            },
-                                            {
-                                                "name": "VAULT_CONFIG_DIR",
-                                                "value": "/vault/config"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/vault/config"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets/edgex-vault"
-                                            },
-                                            {
-                                                "name": "vault-file",
-                                                "mountPath": "/vault/file"
-                                            },
-                                            {
-                                                "name": "vault-init",
-                                                "mountPath": "/vault/init"
-                                            },
-                                            {
-                                                "name": "vault-logs",
-                                                "mountPath": "/vault/logs"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-vault"
-                            }
-                        },
-                        "strategy": {
-                            "type": "RollingUpdate",
-                            "rollingUpdate": {
-                                "maxSurge": 0
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "edgex-vault-worker",
-                    "deployment": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "edgex-vault-worker"
-                            }
-                        },
-                        "template": {
-                            "metadata": {
-                                "creationTimestamp": null,
-                                "labels": {
-                                    "app": "edgex-vault-worker"
-                                }
-                            },
-                            "spec": {
-                                "volumes": [
-                                    {
-                                        "name": "tmpfs-volume1",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "tmpfs-volume2",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "consul-scripts",
-                                        "emptyDir": {}
-                                    },
-                                    {
-                                        "name": "anonymous-volume1",
-                                        "hostPath": {
-                                            "path": "/tmp/edgex/secrets",
-                                            "type": "DirectoryOrCreate"
-                                        }
-                                    },
-                                    {
-                                        "name": "vault-config",
-                                        "emptyDir": {}
-                                    }
-                                ],
-                                "containers": [
-                                    {
-                                        "name": "edgex-vault-worker",
-                                        "image": "edgexfoundry/docker-security-secretstore-setup-go:1.3.1",
-                                        "envFrom": [
-                                            {
-                                                "configMapRef": {
-                                                    "name": "common-variables"
-                                                }
-                                            }
-                                        ],
-                                        "env": [
-                                            {
-                                                "name": "SECRETSTORE_SETUP_DONE_FLAG",
-                                                "value": "/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
-                                            }
-                                        ],
-                                        "resources": {},
-                                        "volumeMounts": [
-                                            {
-                                                "name": "tmpfs-volume1",
-                                                "mountPath": "/run"
-                                            },
-                                            {
-                                                "name": "tmpfs-volume2",
-                                                "mountPath": "/vault"
-                                            },
-                                            {
-                                                "name": "consul-scripts",
-                                                "mountPath": "/consul/scripts"
-                                            },
-                                            {
-                                                "name": "anonymous-volume1",
-                                                "mountPath": "/tmp/edgex/secrets"
-                                            },
-                                            {
-                                                "name": "vault-config",
-                                                "mountPath": "/vault/config"
-                                            }
-                                        ],
-                                        "imagePullPolicy": "IfNotPresent"
-                                    }
-                                ],
-                                "hostname": "edgex-vault-worker"
+                                "hostname": "edgex-device-rest"
                             }
                         },
                         "strategy": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
 /kind bug
/sig iot

#### What this PR does / why we need it:
In the napa version, the host's `/etc/localtime` file is mounted as a file, whereas previously the default bind type for `openyurt/auto-collector` was a folder. This pr is fixed to file.
This may have caused pr #2103 to fail iot e2e.