### PR TITLE
fix: masterservice missing clusterIPs field.

### DIFF
--- a/pkg/yurthub/filter/masterservice/filter.go
+++ b/pkg/yurthub/filter/masterservice/filter.go
@@ -91,6 +91,7 @@ func (msf *masterServiceFilter) Filter(obj runtime.Object, _ <-chan struct{}) ru
 func (msf *masterServiceFilter) mutateMasterService(svc *v1.Service) {
 	if svc.Namespace == MasterServiceNamespace && svc.Name == MasterServiceName {
 		svc.Spec.ClusterIP = msf.host
+		svc.Spec.ClusterIPs = []string{msf.host}
 		for j := range svc.Spec.Ports {
 			if svc.Spec.Ports[j].Name == MasterServicePortName {
 				svc.Spec.Ports[j].Port = msf.port

--- a/pkg/yurthub/filter/masterservice/filter_test.go
+++ b/pkg/yurthub/filter/masterservice/filter_test.go
@@ -79,7 +79,8 @@ func TestFilter(t *testing.T) {
 					Namespace: MasterServiceNamespace,
 				},
 				Spec: corev1.ServiceSpec{
-					ClusterIP: "10.96.0.1",
+					ClusterIP:  "10.96.0.1",
+					ClusterIPs: []string{"10.96.0.1"},
 					Ports: []corev1.ServicePort{
 						{
 							Port: 443,
@@ -94,7 +95,8 @@ func TestFilter(t *testing.T) {
 					Namespace: MasterServiceNamespace,
 				},
 				Spec: corev1.ServiceSpec{
-					ClusterIP: masterServiceHost,
+					ClusterIP:  masterServiceHost,
+					ClusterIPs: []string{masterServiceHost},
 					Ports: []corev1.ServicePort{
 						{
 							Port: masterServicePort,
@@ -111,7 +113,8 @@ func TestFilter(t *testing.T) {
 					Namespace: MasterServiceNamespace,
 				},
 				Spec: corev1.ServiceSpec{
-					ClusterIP: "10.96.0.1",
+					ClusterIP:  "10.96.0.1",
+					ClusterIPs: []string{"10.96.0.1"},
 					Ports: []corev1.ServicePort{
 						{
 							Port: 443,
@@ -126,7 +129,8 @@ func TestFilter(t *testing.T) {
 					Namespace: MasterServiceNamespace,
 				},
 				Spec: corev1.ServiceSpec{
-					ClusterIP: "10.96.0.1",
+					ClusterIP:  "10.96.0.1",
+					ClusterIPs: []string{"10.96.0.1"},
 					Ports: []corev1.ServicePort{
 						{
 							Port: 443,

--- a/pkg/yurthub/filter/responsefilter/filter_test.go
+++ b/pkg/yurthub/filter/responsefilter/filter_test.go
@@ -769,7 +769,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 							Namespace: masterservice.MasterServiceNamespace,
 						},
 						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.0.1",
+							ClusterIP:  "10.96.0.1",
+							ClusterIPs: []string{"10.96.0.1"},
 							Ports: []corev1.ServicePort{
 								{
 									Port: 443,
@@ -784,7 +785,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 							Namespace: masterservice.MasterServiceNamespace,
 						},
 						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
+							ClusterIP:  "10.96.105.188",
+							ClusterIPs: []string{"10.96.105.188"},
 							Ports: []corev1.ServicePort{
 								{
 									Port: 80,
@@ -806,7 +808,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 							Namespace: masterservice.MasterServiceNamespace,
 						},
 						Spec: corev1.ServiceSpec{
-							ClusterIP: masterHost,
+							ClusterIP:  masterHost,
+							ClusterIPs: []string{masterHost},
 							Ports: []corev1.ServicePort{
 								{
 									Port: masterPortInt,
@@ -821,7 +824,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 							Namespace: masterservice.MasterServiceNamespace,
 						},
 						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
+							ClusterIP:  "10.96.105.188",
+							ClusterIPs: []string{"10.96.105.188"},
 							Ports: []corev1.ServicePort{
 								{
 									Port: 80,
@@ -852,7 +856,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 							Namespace: masterservice.MasterServiceNamespace,
 						},
 						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
+							ClusterIP:  "10.96.105.188",
+							ClusterIPs: []string{"10.96.105.188"},
 							Ports: []corev1.ServicePort{
 								{
 									Port: 80,
@@ -874,7 +879,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 							Namespace: masterservice.MasterServiceNamespace,
 						},
 						Spec: corev1.ServiceSpec{
-							ClusterIP: "10.96.105.188",
+							ClusterIP:  "10.96.105.188",
+							ClusterIPs: []string{"10.96.105.188"},
 							Ports: []corev1.ServicePort{
 								{
 									Port: 80,
@@ -903,7 +909,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 					Namespace: masterservice.MasterServiceNamespace,
 				},
 				Spec: corev1.ServiceSpec{
-					ClusterIP: "10.96.105.188",
+					ClusterIP:  "10.96.105.188",
+					ClusterIPs: []string{"10.96.105.188"},
 					Ports: []corev1.ServicePort{
 						{
 							Port: 80,
@@ -922,7 +929,8 @@ func TestResponseFilterForListRequest(t *testing.T) {
 					Namespace: masterservice.MasterServiceNamespace,
 				},
 				Spec: corev1.ServiceSpec{
-					ClusterIP: masterHost,
+					ClusterIP:  masterHost,
+					ClusterIPs: []string{masterHost},
 					Ports: []corev1.ServicePort{
 						{
 							Port: masterPortInt,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:

Set `clusterIPs` field for masterservice filter.

CoreDNS will read it: https://github.com/coredns/coredns/blob/v1.11.3/plugin/kubernetes/kubernetes.go#L507

About [`ClusterIPs`](https://kubernetes.io/zh-cn/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
