### PR TITLE
feat: support yurtadm to join nodes to tenant-K8s in local mode

### DIFF
--- a/pkg/yurtadm/cmd/join/joindata/data.go
+++ b/pkg/yurtadm/cmd/join/joindata/data.go
@@ -36,6 +36,8 @@ type YurtJoinData interface {
 	JoinToken() string
 	PauseImage() string
 	YurtHubImage() string
+	YurtHubBinary() string
+	HostControlPlaneAddr() string
 	YurtHubServer() string
 	YurtHubTemplate() string
 	YurtHubManifest() string

--- a/pkg/yurtadm/cmd/join/phases/postcheck.go
+++ b/pkg/yurtadm/cmd/join/phases/postcheck.go
@@ -20,28 +20,48 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/kubernetes"
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
 
 // RunPostCheck executes the node health check and clean process.
 func RunPostCheck(data joindata.YurtJoinData) error {
+	if data.NodeRegistration().WorkingMode == constants.LocalNode {
+		// modify /etc/kubernetes/kubelet.conf, set apiserver address to VIP, which is service address of apiservers in Host-K8s
+		// apiVersion: v1
+		// clusters:
+		// - cluster:
+		//    server: http://VIP:PORT
+		klog.V(1).Infof("configure kubelet service, set apiserver address to %s for loadbalancing", data.ServerAddr())
+		if err := kubernetes.SetKubeletConfigForLocalNode(data.ServerAddr()); err != nil {
+			return err
+		}
+		klog.V(1).Infof("restart kubelet service")
+		if err := kubernetes.RestartKubeletService(); err != nil {
+			return err
+		}
+	}
+
 	klog.V(1).Infof("check kubelet status.")
 	if err := kubernetes.CheckKubeletStatus(); err != nil {
 		return err
 	}
 	klog.V(1).Infof("kubelet service is active")
 
-	klog.V(1).Infof("waiting hub agent ready.")
-	if err := yurthub.CheckYurthubHealthz(data.YurtHubServer()); err != nil {
-		return err
-	}
-	klog.V(1).Infof("hub agent is ready")
+	// check staticpod yurthub for edge node and cloud node
+	if data.NodeRegistration().WorkingMode != constants.LocalNode {
+		klog.V(1).Infof("waiting hub agent ready.")
+		if err := yurthub.CheckYurthubHealthz(data.YurtHubServer()); err != nil {
+			return err
+		}
+		klog.V(1).Infof("staticpod yurthub agent is ready")
 
-	if err := yurthub.CleanHubBootstrapConfig(); err != nil {
-		return err
+		if err := yurthub.CleanHubBootstrapConfig(); err != nil {
+			return err
+		}
+		klog.V(1).Infof("clean yurthub bootstrap config file success")
 	}
-	klog.V(1).Infof("clean yurthub bootstrap config file success")
 
 	return nil
 }

--- a/pkg/yurtadm/cmd/join/phases/prepare.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare.go
@@ -62,17 +62,20 @@ func RunPrepare(data joindata.YurtJoinData) error {
 	if err := yurtadmutil.EnableKubeletService(); err != nil {
 		return err
 	}
-	if err := yurtadmutil.SetKubeletUnitConfig(); err != nil {
-		return err
-	}
-	if err := yurtadmutil.SetKubeletConfigForNode(); err != nil {
-		return err
-	}
-	if err := yurthub.SetHubBootstrapConfig(data.ServerAddr(), data.JoinToken(), data.CaCertHashes()); err != nil {
-		return err
-	}
-	if err := yurthub.AddYurthubStaticYaml(data, constants.StaticPodPath); err != nil {
-		return err
+	if data.NodeRegistration().WorkingMode != constants.LocalNode {
+		// the following steps are only for edge/cloud node
+		if err := yurtadmutil.SetKubeletUnitConfig(); err != nil {
+			return err
+		}
+		if err := yurtadmutil.SetKubeletConfigForNode(); err != nil {
+			return err
+		}
+		if err := yurthub.SetHubBootstrapConfig(data.ServerAddr(), data.JoinToken(), data.CaCertHashes()); err != nil {
+			return err
+		}
+		if err := yurthub.AddYurthubStaticYaml(data, constants.StaticPodPath); err != nil {
+			return err
+		}
 	}
 	if len(data.StaticPodTemplateList()) != 0 {
 		// deploy user specified static pods

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -35,6 +35,8 @@ const (
 	PauseImagePath                = "registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.2"
 	DefaultCertificatesDir        = "/etc/kubernetes/pki"
 	DefaultDockerCRISocket        = "/var/run/dockershim.sock"
+	YurthubServiceFilepath        = "/etc/systemd/system/yurthub.service"
+	YurthubEnvironmentFilePath    = "/etc/systemd/system/yurthub.default"
 	YurthubYamlName               = "yurthub.yaml"
 	YurthubStaticPodManifest      = "yurthub"
 	YurthubNamespace              = "kube-system"
@@ -72,6 +74,7 @@ const (
 
 	EdgeNode  = "edge"
 	CloudNode = "cloud"
+	LocalNode = "local"
 
 	// CertificatesDir
 	CertificatesDir = "cert-dir"
@@ -107,6 +110,10 @@ const (
 	Namespace = "namespace"
 	// YurtHubImage flag sets the yurthub image for worker node.
 	YurtHubImage = "yurthub-image"
+	// YurtHubBinary flag sets the yurthub Binary for worker node.
+	YurtHubBinary = "yurthub-binary"
+	// HostControlPlaneAddr flag sets the address of host kubernetes cluster
+	HostControlPlaneAddr = "host-control-plane-addr"
 	// YurtHubServerAddr flag set the address of yurthub server (not proxy server!)
 	YurtHubServerAddr = "yurthub-server-addr"
 	// ServerAddr flag set the address of kubernetes kube-apiserver
@@ -272,5 +279,21 @@ spec:
   hostNetwork: true
   priorityClassName: system-node-critical
   priority: 2000001000
+`
+
+	YurthubSyetmdServiceContent = `
+[Unit]
+Description=local mode yurthub is deployed in systemd
+Documentation=https://github.com/openyurtio/openyurt/pull/2124
+
+[Service]
+EnvironmentFile=/etc/systemd/system/yurthub.default
+ExecStart=/usr/bin/yurthub --working-mode ${WORKINGMODE} --node-name ${NODENAME} --server-addr ${SERVERADDR} --host-control-plane-address ${HOSTCONTROLPLANEADDRESS}
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
 `
 )

--- a/pkg/yurtadm/util/initsystem/initsystem.go
+++ b/pkg/yurtadm/util/initsystem/initsystem.go
@@ -27,4 +27,13 @@ type InitSystem interface {
 
 	// ServiceIsActive ensures the service is running, or attempting to run. (crash looping in the case of kubelet)
 	ServiceIsActive(service string) bool
+
+	// ServiceToStart tries to start a specific service
+	ServiceStart(service string) error
+
+	// ServiceStop tries to stop a specific service
+	ServiceStop(service string) error
+
+	// ServiceRestart tries to reload the environment and restart the specific service
+	ServiceRestart(service string) error
 }

--- a/pkg/yurtadm/util/initsystem/initsystem_unix.go
+++ b/pkg/yurtadm/util/initsystem/initsystem_unix.go
@@ -52,6 +52,24 @@ func (openrc OpenRCInitSystem) ServiceIsActive(service string) bool {
 	return !strings.Contains(outStr, "stopped") && !strings.Contains(outStr, "does not exist")
 }
 
+// ServiceStart tries to start a specific service
+func (openrc OpenRCInitSystem) ServiceStart(service string) error {
+	args := []string{service, "start"}
+	return exec.Command("rc-service", args...).Run()
+}
+
+// ServiceStop tries to stop a specific service
+func (openrc OpenRCInitSystem) ServiceStop(service string) error {
+	args := []string{service, "stop"}
+	return exec.Command("rc-service", args...).Run()
+}
+
+// ServiceRestart tries to reload the environment and restart the specific service
+func (openrc OpenRCInitSystem) ServiceRestart(service string) error {
+	args := []string{service, "restart"}
+	return exec.Command("rc-service", args...).Run()
+}
+
 // SystemdInitSystem defines systemd
 type SystemdInitSystem struct{}
 
@@ -92,6 +110,32 @@ func (sysd SystemdInitSystem) ServiceIsActive(service string) bool {
 		return true
 	}
 	return false
+}
+
+// ServiceStart tries to start a specific service
+func (sysd SystemdInitSystem) ServiceStart(service string) error {
+	// Before we try to start any service, make sure that systemd is ready
+	if err := sysd.reloadSystemd(); err != nil {
+		return err
+	}
+	args := []string{"start", service}
+	return exec.Command("systemctl", args...).Run()
+}
+
+// ServiceRestart tries to reload the environment and restart the specific service
+func (sysd SystemdInitSystem) ServiceRestart(service string) error {
+	// Before we try to restart any service, make sure that systemd is ready
+	if err := sysd.reloadSystemd(); err != nil {
+		return err
+	}
+	args := []string{"restart", service}
+	return exec.Command("systemctl", args...).Run()
+}
+
+// ServiceStop tries to stop a specific service
+func (sysd SystemdInitSystem) ServiceStop(service string) error {
+	args := []string{"stop", service}
+	return exec.Command("systemctl", args...).Run()
 }
 
 // GetInitSystem returns an InitSystem for the current system, or nil

--- a/pkg/yurtadm/util/localnode/localnode.go
+++ b/pkg/yurtadm/util/localnode/localnode.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localnode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/util/initsystem"
+	"k8s.io/klog/v2"
+)
+
+// DeployYurthubInSystemd deploys yurthub in systemd
+func DeployYurthubInSystemd(hostControlPlaneAddr string, serverAddr string, yurthubBinary string, nodeName string) error {
+	// stop yurthub service at first
+	if err := StopYurthubService(); err != nil {
+		return err
+	}
+	// set and start yurthub service in systemd
+	if err := SetYurthubService(hostControlPlaneAddr, serverAddr, yurthubBinary, nodeName); err != nil {
+		return err
+	}
+	if err := EnableYurthubService(); err != nil {
+		return err
+	}
+	if err := StartYurthubService(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// StopYurthubService stop yurthub service
+func StopYurthubService() error {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return err
+	}
+	if ok := initSystem.ServiceIsActive("yurthub"); ok {
+		if err = initSystem.ServiceStop("yurthub"); err != nil {
+			return fmt.Errorf("stop yurthub service failed")
+		}
+	}
+
+	return nil
+}
+
+// SetYurthubService configure yurthub service.
+func SetYurthubService(hostControlPlaneAddr string, serverAddr string, yurthubBinary string, nodeName string) error {
+	klog.Info("Setting Yurthub service.")
+	yurthubServiceDir := filepath.Dir(constants.YurthubServiceFilepath)
+	if _, err := os.Stat(yurthubServiceDir); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(yurthubServiceDir, os.ModePerm); err != nil {
+				klog.Errorf("Create dir %s fail: %v", yurthubServiceDir, err)
+				return err
+			}
+		} else {
+			klog.Errorf("Describe dir %s fail: %v", yurthubServiceDir, err)
+			return err
+		}
+	}
+	// copy yurthub binary to /usr/bin
+	cmd := exec.Command("cp", yurthubBinary, "/usr/bin")
+	if err := cmd.Run(); err != nil {
+		klog.Errorf("Copy yurthub binary to /usr/bin fail: %v", err)
+		return err
+	}
+	klog.Info("yurthub binary is in /usr/bin.")
+
+	// yurthub.default contains the environment variables that yurthub needs
+	yurthubSyetmdServiceEnvironmentFileContent := fmt.Sprintf(`
+WORKINGMODE=local
+NODENAME=%s
+SERVERADDR=%s
+HOSTCONTROLPLANEADDRESS=%s
+`, nodeName, serverAddr, hostControlPlaneAddr)
+
+	if err := os.WriteFile(constants.YurthubEnvironmentFilePath, []byte(yurthubSyetmdServiceEnvironmentFileContent), 0644); err != nil {
+		klog.Errorf("Write file %s fail: %v", constants.YurthubEnvironmentFilePath, err)
+		return err
+	}
+
+	// yurthub.service contains the configuration of yurthub service
+	if err := os.WriteFile(constants.YurthubServiceFilepath, []byte(constants.YurthubSyetmdServiceContent), 0644); err != nil {
+		klog.Errorf("Write file %s fail: %v", constants.YurthubServiceFilepath, err)
+		return err
+	}
+	return nil
+}
+
+// EnableYurthubService enable yurthub service
+func EnableYurthubService() error {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return err
+	}
+
+	if !initSystem.ServiceIsEnabled("yurthub") {
+		if err = initSystem.ServiceEnable("yurthub"); err != nil {
+			return fmt.Errorf("enable yurthub service failed")
+		}
+	}
+	return nil
+}
+
+// StartYurthubService start yurthub service
+func StartYurthubService() error {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return err
+	}
+	if err = initSystem.ServiceStart("yurthub"); err != nil {
+		return fmt.Errorf("start yurthub service failed")
+	}
+	return nil
+}
+
+// CheckYurthubStatus check if yurthub is healthy.
+func CheckYurthubStatus() (bool, error) {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return false, err
+	}
+	if ok := initSystem.ServiceIsActive("yurthub"); !ok {
+		return false, fmt.Errorf("yurthub is not active. ")
+	}
+	return true, nil
+}
+
+// CheckIptablesChainAndRulesExists checks if the iptables chain and rules exist.
+func CheckIptablesChainAndRulesExists(table, chain string) (bool, error) {
+	ipt, err := iptables.New()
+	if err != nil {
+		klog.Errorf("Create iptables client failed: %v", err)
+		return false, err
+	}
+
+	// check if LBCHAIN exists
+	exists, err := ipt.ChainExists(table, chain)
+	if err != nil {
+		klog.Errorf("error checking if chain exists: %v", err)
+		return false, err
+	}
+	if !exists {
+		klog.Errorf("Chain %s does not exist in table %s", chain, table)
+		return false, nil
+	}
+
+	// List all rules in the chain
+	rules, err := ipt.List(table, chain)
+	if err != nil {
+		klog.Errorf("List rules in chain %s failed: %v", chain, err)
+		return false, err
+	}
+
+	// The first rule is always the chain creation command
+	// Valid rules start from the second entry
+	if len(rules) <= 1 {
+		klog.Errorf("Chain %s has no effective rules", chain)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// WaitForIptablesChainReady waits for the LBCHAIN and rules to be ready.
+func WaitForIptablesChainReady(table, chain string, iptablesDone chan<- bool) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		exists, err := CheckIptablesChainAndRulesExists(table, chain)
+		if err != nil {
+			klog.Errorf("CheckIptablesChainAndRulesExists fail: %v", err)
+			continue
+		}
+
+		if exists {
+			klog.Info("LBCHAIN and rules exist in nat table, continue to next step.")
+			iptablesDone <- true
+			return
+		}
+
+		klog.Info("LBCHAIN is not ready, retry after 10 second...")
+	}
+}

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -333,6 +333,14 @@ func (j *testData) YurtHubImage() string {
 	return ""
 }
 
+func (j *testData) YurtHubBinary() string {
+	return ""
+}
+
+func (j *testData) HostControlPlaneAddr() string {
+	return ""
+}
+
 func (j *testData) YurtHubServer() string {
 	return ""
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> /kind feature
> /kind question
#### What this PR does / why we need it:
#2124 
##### What is new:

1. Support deploying local mode yurthub in systemd, which list/watch endpoints to configure iptables rules for loadbalancing.
2. In yurtadm join, we first wait for local mode yurthub to be ready and iptables rules to be ready. Then we invoke `kubeadm join` join nodes to cluster, including kubelet bootstrap and so on. At last in the postcheck phase we modify kubelet.conf and set address to VIP then restart kubelet, so the traffic from kubelet to apiservers can be loadbalanced.

##### TODO and questions:

1. The implement of loadbalacing in yurtadm join relies on modifing kubelet.conf, which seems not elegant. The original idea is that we first do some preparation, then use `kubeadm join` to join the node. Because all apiservers' certificates are the same, invoking `kubeadm join` to join the cluster allows the node to do TLS bootstrap to obtain the kubelet certificate. Finally, modify kubelet.conf and restart kubelet, kubelet will do 4-layer load balancing and establish a TCP connection with one of the apiservers.
2. Yurtadm join is a one-time operation, so what will happen when kubelet rotate it's certificates, maybe loadbalance will be invalid. 
3. How do other components like kube-proxy, addons, pods access apiserver in loadbalance mode? Simply modifying yurtadm join seems to unable to afford these components for loadbalancing.
#### Special notes for your reviewer:
/assign @rambohe-ch 