### PR TITLE
feat: add node autonomy duration to lifecycle controller

### DIFF
--- a/pkg/projectinfo/projectinfo.go
+++ b/pkg/projectinfo/projectinfo.go
@@ -101,6 +101,11 @@ func GetAutonomyAnnotation() string {
 	return fmt.Sprintf("node.beta.%s/autonomy", labelPrefix)
 }
 
+// GetNodeAutonomyDurationAnnotation returns annotation key for node autonomy duration
+func GetNodeAutonomyDurationAnnotation() string {
+	return fmt.Sprintf("node.%s/autonomy-duration", labelPrefix)
+}
+
 // normalizeGitCommit reserve 7 characters for gitCommit
 func normalizeGitCommit(commit string) string {
 	if len(commit) > 7 {

--- a/pkg/yurtmanager/controller/util/node/controller_utils.go
+++ b/pkg/yurtmanager/controller/util/node/controller_utils.go
@@ -447,12 +447,18 @@ func addOrUpdateLabelsOnNode(kubeClient clientset.Interface, nodeName string, la
 	})
 }
 
+// IsPodBoundenToNode checks if the pod is bound to the node based on annotations.
+// If the pod is bound to the node, it will return true; otherwise, it will return false.
+// The pod is bound to the node if the pod has the following annotations:
+// - apps.openyurt.io/binding: "true"
+// - openyurt.beta.io/autonomy: "true"
+// - openyurt.io/autonomy-duration: "duration"
 func IsPodBoundenToNode(node *v1.Node) bool {
-	if node.Annotations != nil &&
-		(node.Annotations[projectinfo.GetAutonomyAnnotation()] == "true" ||
-			node.Annotations[PodBindingAnnotation] == "true") {
-		return true
+	if node.Annotations == nil {
+		return false
 	}
 
-	return false
+	return node.Annotations[PodBindingAnnotation] == "true" ||
+		node.Annotations[projectinfo.GetAutonomyAnnotation()] == "true" ||
+		node.Annotations[projectinfo.GetNodeAutonomyDurationAnnotation()] != ""
 }

--- a/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller.go
+++ b/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller.go
@@ -19,6 +19,7 @@ package podbinding
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,12 +35,12 @@ import (
 	yurtClient "github.com/openyurtio/openyurt/cmd/yurt-manager/app/client"
 	appconfig "github.com/openyurtio/openyurt/cmd/yurt-manager/app/config"
 	"github.com/openyurtio/openyurt/cmd/yurt-manager/names"
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
 	nodeutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
 )
 
 var (
-	controllerKind           = appsv1.SchemeGroupVersion.WithKind("Node")
-	defaultTolerationSeconds = 300
+	controllerKind = appsv1.SchemeGroupVersion.WithKind("Node")
 
 	notReadyToleration = corev1.Toleration{
 		Key:      corev1.TaintNodeNotReady,
@@ -149,12 +150,8 @@ func (r *ReconcilePodBinding) processNode(node *corev1.Node) error {
 
 		// pod binding takes precedence against node autonomy
 		if nodeutil.IsPodBoundenToNode(node) {
-			if err := r.configureTolerationForPod(pod, nil); err != nil {
-				klog.Errorf(Format("could not configure toleration of pod, %v", err))
-			}
-		} else {
-			tolerationSeconds := int64(defaultTolerationSeconds)
-			if err := r.configureTolerationForPod(pod, &tolerationSeconds); err != nil {
+			durationSeconds := getPodTolerationSeconds(node)
+			if err := r.configureTolerationForPod(pod, durationSeconds); err != nil {
 				klog.Errorf(Format("could not configure toleration of pod, %v", err))
 			}
 		}
@@ -246,4 +243,37 @@ func addOrUpdateTolerationInPodSpec(spec *corev1.PodSpec, toleration *corev1.Tol
 
 	spec.Tolerations = newTolerations
 	return true
+}
+
+// getPodTolerationSeconds returns the tolerationSeconds for the pod on the node.
+// The tolerationSeconds is calculated based on the following rules:
+// 1. If the pod is bound to the node, the tolerationSeconds is nil.
+// 2. If the node has autonomy annotation, the tolerationSeconds is nil.
+// 3. If the node has node autonomy duration annotation, the tolerationSeconds is the duration.
+// 4. If the autonomy duration is parsed as 0, the tolerationSeconds is nil which means the pod will not be evicted.
+func getPodTolerationSeconds(node *corev1.Node) *int64 {
+	if node.Annotations == nil {
+		return nil
+	}
+
+	// Pod binding takes precedence against node autonomy
+	if node.Annotations[nodeutil.PodBindingAnnotation] == "true" ||
+		node.Annotations[projectinfo.GetAutonomyAnnotation()] == "true" {
+		return nil
+	}
+
+	// Node autonomy duration has the least precedence
+	duration := node.Annotations[projectinfo.GetNodeAutonomyDurationAnnotation()]
+	durationTime, err := time.ParseDuration(duration)
+	if err != nil {
+		klog.Errorf(Format("could not parse duration %s, %v", duration, err))
+		return nil
+	}
+
+	if durationTime == 0 {
+		return nil
+	}
+
+	tolerationSeconds := int64(durationTime.Seconds())
+	return &tolerationSeconds
 }

--- a/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller_test.go
@@ -61,6 +61,30 @@ func prepareNodes() []client.Object {
 				},
 			},
 		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node4",
+				Annotations: map[string]string{
+					"node.openyurt.io/autonomy-duration": "0",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node5",
+				Annotations: map[string]string{
+					"node.openyurt.io/autonomy-duration": "2h",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node6",
+				Annotations: map[string]string{
+					"node.openyurt.io/autonomy-duration": "",
+				},
+			},
+		},
 	}
 	return nodes
 }
@@ -403,11 +427,74 @@ func TestIsPodBoundenToNode(t *testing.T) {
 			node: nodes[2].(*corev1.Node),
 			want: true,
 		},
+		{
+			name: "node4",
+			node: nodes[3].(*corev1.Node),
+			want: true,
+		},
+		{
+			name: "node5",
+			node: nodes[4].(*corev1.Node),
+			want: true,
+		},
+		{
+			name: "node6",
+			node: nodes[5].(*corev1.Node),
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := nodeutil.IsPodBoundenToNode(tt.node); got != tt.want {
 				t.Errorf("IsPodBoundenToNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPodTolerationSeconds(t *testing.T) {
+	expectedToleration := int64(7200)
+	nodes := prepareNodes()
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want *int64
+	}{
+		{
+			name: "node1",
+			node: nodes[0].(*corev1.Node),
+			want: nil,
+		},
+		{
+			name: "node2",
+			node: nodes[1].(*corev1.Node),
+			want: nil,
+		},
+		{
+			name: "node3",
+			node: nodes[2].(*corev1.Node),
+			want: nil,
+		},
+		{
+			name: "node4",
+			node: nodes[3].(*corev1.Node),
+			want: nil,
+		},
+		{
+			name: "node5",
+			node: nodes[4].(*corev1.Node),
+			want: &expectedToleration,
+		},
+		{
+			name: "node6",
+			node: nodes[5].(*corev1.Node),
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getPodTolerationSeconds(tt.node); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPodTolerationSeconds() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller_test.go
@@ -85,6 +85,20 @@ func prepareNodes() []client.Object {
 				},
 			},
 		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "node7",
+				Annotations: map[string]string{},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node8",
+				Annotations: map[string]string{
+					"other.annotation": "true",
+				},
+			},
+		},
 	}
 	return nodes
 }
@@ -442,6 +456,16 @@ func TestIsPodBoundenToNode(t *testing.T) {
 			node: nodes[5].(*corev1.Node),
 			want: false,
 		},
+		{
+			name: "node7",
+			node: nodes[6].(*corev1.Node),
+			want: false,
+		},
+		{
+			name: "node8",
+			node: nodes[7].(*corev1.Node),
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -454,6 +478,7 @@ func TestIsPodBoundenToNode(t *testing.T) {
 
 func TestGetPodTolerationSeconds(t *testing.T) {
 	expectedToleration := int64(7200)
+	defaultTolerationSeconds := int64(300)
 	nodes := prepareNodes()
 	tests := []struct {
 		name string
@@ -463,7 +488,7 @@ func TestGetPodTolerationSeconds(t *testing.T) {
 		{
 			name: "node1",
 			node: nodes[0].(*corev1.Node),
-			want: nil,
+			want: &defaultTolerationSeconds,
 		},
 		{
 			name: "node2",
@@ -489,6 +514,16 @@ func TestGetPodTolerationSeconds(t *testing.T) {
 			name: "node6",
 			node: nodes[5].(*corev1.Node),
 			want: nil,
+		},
+		{
+			name: "node7",
+			node: nodes[6].(*corev1.Node),
+			want: &defaultTolerationSeconds,
+		},
+		{
+			name: "node8",
+			node: nodes[7].(*corev1.Node),
+			want: &defaultTolerationSeconds,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Resolves https://github.com/openyurtio/openyurt/issues/2196

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/openyurtio/openyurt/issues/2196

#### Special notes for your reviewer:
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
```release-note
Adds a new node annotation node.openyurt.io/autonomy-duration which maps to pod tolerationSeconds to ensure pods are evicted during node failures.
```

#### other Note
```bash
# Label edge node 
k get nodes vagrant -o yaml
apiVersion: v1
kind: Node
metadata:
  annotations:
    node.openyurt.io/autonomy-duration: 30s

# Schedule workload
k get pods -o wide
NAME                               READY   STATUS    RESTARTS   AGE     IP               NODE                                NOMINATED NODE   READINESS GATES
netutils-6f94558c58-kvcwq          1/1     Running   0          3m50s   10.244.1.41      vagrant                             <none>           <none>
netutils-6f94558c58-pz9cp          1/1     Running   0          3m50s   10.244.1.248     vagrant                             <none>           <none>

# Show tolerationSeconds on pod
k get pods netutils-6f94558c58-kvcwq -o yaml
...
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 30
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 30

# Down network on edge
$ iptables -A INPUT -i eth0 -j DROP

# After 30 seconds
k get pods -o wide
NAME                               READY   STATUS        RESTARTS   AGE     IP               NODE                                NOMINATED NODE   
# Pod is terminating + 2 pending scheduled
netutils-6f94558c58-hsqv4          0/1     Pending       0          11s     <none>           <none>                              <none>           <none>
netutils-6f94558c58-kvcwq          1/1     Terminating   0          6m27s   10.244.1.41      vagrant                             <none>           <none>
netutils-6f94558c58-m88n7          0/1     Pending       0          11s     <none>           <none>                              <none>           <none>
netutils-6f94558c58-pz9cp          1/1     Terminating   0          6m27s   10.244.1.248     vagrant                             <none>           <none>

# Restore the node
k get nodes
NAME                                STATUS   ROLES    AGE    VERSION
vagrant                             Ready    <none>   16m    v1.29.9

# Check pods
$ k get po -o wide
NAME                               READY   STATUS    RESTARTS            AGE    IP               NODE                                NOMINATED NODE   READINESS GATES
netutils-6f94558c58-hsqv4          1/1     Running   0                   3m1s   10.244.1.16      vagrant                             <none>           <none>
netutils-6f94558c58-m88n7          1/1     Running   0                   3m1s   10.244.1.143     vagrant                             <none>           <none>

# On edge - the hash matches desired state
root@vagrant:/home/vagrant# c ps
CONTAINER           IMAGE               CREATED                  STATE               NAME                                     ATTEMPT             POD ID              POD
35a02917e7019       c7b1228ff9eb8       54 seconds ago           Running             netutils                                 0                   989e75d06e97f       netutils-6f94558c58-hsqv4
6d33ebc02a5f3       c7b1228ff9eb8       56 seconds ago           Running             netutils                                 0                   8eed0a481574b       netutils-6f94558c58-m88n7
```

