### PR TITLE
feat: add endpoints webhook for node autonomy

### DIFF
--- a/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
+++ b/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
@@ -1421,6 +1421,25 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
+  clientConfig:
+    service:
+      name: yurt-manager-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-core-openyurt-io-v1-endpoints
+  failurePolicy: Ignore
+  name: mutate.core.v1.endpoints.openyurt.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    resources:
+    - endpoints
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:

--- a/pkg/yurtmanager/controller/util/pod/pod_util.go
+++ b/pkg/yurtmanager/controller/util/pod/pod_util.go
@@ -58,6 +58,16 @@ func IsPodReadyConditionTrue(status v1.PodStatus) bool {
 	return condition != nil && condition.Status == v1.ConditionTrue
 }
 
+// IsPodCrashLoopBackOff returns true if a pod is in CrashLoopBackOff state; false otherwise.
+func IsPodCrashLoopBackOff(status v1.PodStatus) bool {
+	for _, c := range status.ContainerStatuses {
+		if c.State.Waiting != nil && c.State.Waiting.Reason == "CrashLoopBackOff" {
+			return true
+		}
+	}
+	return false
+}
+
 // GetPodReadyCondition extracts the pod ready condition from the given status and returns that.
 // Returns nil if the condition is not present.
 func GetPodReadyCondition(status v1.PodStatus) *v1.PodCondition {

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
@@ -33,7 +33,7 @@ import (
 func (webhook *EndpointsHandler) Default(ctx context.Context, obj runtime.Object) error {
 	endpoints, ok := obj.(*corev1.Endpoints)
 	if !ok {
-		return fmt.Errorf("expected an Endpoints object but got %T", obj)
+		apierrors.NewBadRequest(fmt.Sprintf("expected an Endpoints object but got %T", obj))
 	}
 
 	return remapAutonomyEndpoints(ctx, webhook.Client, endpoints)

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"fmt"
 
-	nodeutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
-	podutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/pod"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nodeutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
+	podutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/pod"
 )
 
 // Default satisfies the defaulting webhook interface.

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1
 
 import (

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default.go
@@ -1,0 +1,113 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	nodeutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
+	podutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/pod"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Default satisfies the defaulting webhook interface.
+func (webhook *EndpointsHandler) Default(ctx context.Context, obj runtime.Object) error {
+	endpoints, ok := obj.(*corev1.Endpoints)
+	if !ok {
+		return fmt.Errorf("expected an Endpoints object but got %T", obj)
+	}
+
+	return remapAutonomyEndpoints(ctx, webhook.Client, endpoints)
+}
+
+// isNodeAutonomous checks if the node has autonomy annotations
+// and returns true if it does, false otherwise.
+func isNodeAutonomous(ctx context.Context, c client.Client, nodeName string) (bool, error) {
+	node := &corev1.Node{}
+	err := c.Get(ctx, client.ObjectKey{Name: nodeName}, node)
+	if err != nil {
+		// If node doesn't exist, it doesn't have autonomy
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return nodeutil.IsPodBoundenToNode(node), nil
+}
+
+// isPodCrashLoopBackOff checks if the pod is crashloopbackoff
+// and returns true if it is, false otherwise.
+func isPodCrashLoopBackOff(ctx context.Context, c client.Client, podName, namespace string) (bool, error) {
+	pod := &corev1.Pod{}
+	err := c.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return podutil.IsPodCrashLoopBackOff(pod.Status), nil
+}
+
+// remapAutonomyEndpoints remaps the notReadyAddresses to the readyAddresses
+// for the subsets scheduled to nodes that have autonomy annotations.
+// The function checks the pod status and if the pod is not in crashloopbackoff,
+// it remaps the address to readyAddresses.
+func remapAutonomyEndpoints(ctx context.Context, client client.Client, endpoints *corev1.Endpoints) error {
+	// Track nodes with autonomy to avoid repeated checks
+	nodesWithAutonomy := make(map[string]bool)
+
+	// Get all the notReadyAddresses for subsets
+	for i, s := range endpoints.Subsets {
+		// Create a zero-length slice with the same underlying array
+		newNotReadyAddresses := s.NotReadyAddresses[:0]
+
+		for _, a := range s.NotReadyAddresses {
+			if a.NodeName == nil || a.TargetRef == nil {
+				newNotReadyAddresses = append(newNotReadyAddresses, a)
+				continue
+			}
+
+			// Get the node and check autonomy annotations
+			hasAutonomy, ok := nodesWithAutonomy[*a.NodeName]
+			if !ok {
+				isAutonomous, err := isNodeAutonomous(ctx, client, *a.NodeName)
+				if err != nil {
+					return err
+				}
+				// Store autonomy status for future checks
+				nodesWithAutonomy[*a.NodeName] = isAutonomous
+				hasAutonomy = isAutonomous
+			}
+
+			// If the node doesn't have autonomy, skip
+			if !hasAutonomy {
+				newNotReadyAddresses = append(newNotReadyAddresses, a)
+				continue
+			}
+
+			// Get the pod
+			isPodCrashLoopBackOff, err := isPodCrashLoopBackOff(ctx, client, a.TargetRef.Name, a.TargetRef.Namespace)
+			if err != nil {
+				return err
+			}
+
+			if isPodCrashLoopBackOff {
+				newNotReadyAddresses = append(newNotReadyAddresses, a)
+				continue
+			}
+
+			// Move the address to the ready addresses in the subset
+			endpoints.Subsets[i].Addresses = append(endpoints.Subsets[i].Addresses, *a.DeepCopy())
+		}
+
+		// Update the subset with the new notReadyAddresses
+		endpoints.Subsets[i].NotReadyAddresses = newNotReadyAddresses
+	}
+
+	return nil
+}

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default_test.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1_test
 
 import (

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default_test.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default_test.go
@@ -1,0 +1,568 @@
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openyurtio/openyurt/pkg/apis"
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	nodeutils "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
+	v1 "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpoints/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDefault_AutonomyAnnotations(t *testing.T) {
+	endpoint1 := corev1.EndpointAddress{
+		IP:       "10.0.0.1",
+		NodeName: ptr.To("node1"),
+		TargetRef: &corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod1",
+			Namespace: "default",
+		},
+	}
+
+	// Endpoint2 is mapped to pod2 which is always ready
+	endpoint2 := corev1.EndpointAddress{
+		IP:       "10.0.0.2",
+		NodeName: ptr.To("node1"),
+		TargetRef: &corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod2",
+			Namespace: "default",
+		},
+	}
+
+	// Fix the pod to ready for the test
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	// Test cases for Default
+	// endpoint2 should either be remapped or not
+	tests := []struct {
+		name              string
+		endpoints         *corev1.Endpoints
+		node              *corev1.Node
+		expectedEndpoints *corev1.Endpoints
+		expectErr         bool
+	}{
+		{
+			name: "Node autonomy duration annotation",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "10m",
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							endpoint1,
+							endpoint2, // endpoint2 moved to readyAddresses
+						},
+						NotReadyAddresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Node autonomy duration annotation empty",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "", // empty
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2}, // not moved to ready
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Autonomy annotation true",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetAutonomyAnnotation(): "true",
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							endpoint1,
+							endpoint2,
+						}, // endpoint2 moved to readyAddresses
+						NotReadyAddresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Autonomy annotation false",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetAutonomyAnnotation(): "false",
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2}, // not moved to ready
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod binding annotation true",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						nodeutils.PodBindingAnnotation: "true",
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							endpoint1,
+							endpoint2,
+						}, // endpoint2 moved to readyAddresses
+						NotReadyAddresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod binding annotation false",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						nodeutils.PodBindingAnnotation: "false",
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2}, // not moved to ready
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Node has no annotations",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "node1",
+					Annotations: map[string]string{}, // Nothing
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Other node",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node3", // Other
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "10m",
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			err := clientgoscheme.AddToScheme(scheme)
+			require.NoError(t, err, "Fail to add kubernetes clint-go custom resource")
+
+			apis.AddToScheme(scheme)
+
+			// Build client
+			clientBuilder := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pod)
+			if tc.node != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.node)
+			}
+
+			// Invoke Default
+			w := &v1.EndpointsHandler{Client: clientBuilder.Build()}
+			err = w.Default(context.TODO(), tc.endpoints)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Check the result
+			require.Equal(t, tc.expectedEndpoints, tc.endpoints)
+		})
+	}
+}
+
+func TestDefault_PodCrashLoopBack(t *testing.T) {
+	endpoint1 := corev1.EndpointAddress{
+		IP:       "10.0.0.1",
+		NodeName: ptr.To("node1"),
+		TargetRef: &corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod1",
+			Namespace: "default",
+		},
+	}
+
+	endpoint2 := corev1.EndpointAddress{
+		IP:       "10.0.0.2",
+		NodeName: ptr.To("node1"),
+		TargetRef: &corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod2",
+			Namespace: "default",
+		},
+	}
+
+	// Fix the node annotation to autonomy duration
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				projectinfo.GetNodeAutonomyDurationAnnotation(): "10m",
+			},
+		},
+	}
+
+	// Test cases for Default
+	// endpoint2 should either be remapped or not
+	tests := []struct {
+		name              string
+		endpoints         *corev1.Endpoints
+		pod               *corev1.Pod
+		expectedEndpoints *corev1.Endpoints
+		expectErr         bool
+	}{
+		{
+			name: "Pod not crashloopback",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							endpoint1,
+							endpoint2, // endpoint2 moved to readyAddresses
+						},
+						NotReadyAddresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod is crashloopbackoff",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "CrashLoopBackOff",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2}, // not moved to ready
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod no container states",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1, endpoint2},
+						NotReadyAddresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod multiple container statuses",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+						},
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "CrashLoopBackOff",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2}, // not moved to ready
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod is empty",
+			endpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses:         []corev1.EndpointAddress{endpoint1},
+						NotReadyAddresses: []corev1.EndpointAddress{endpoint2},
+					},
+				},
+			},
+			pod: &corev1.Pod{}, // Empty pod
+			expectedEndpoints: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							endpoint1,
+							endpoint2,
+						}, // endpoint2 moved to readyAddresses
+						NotReadyAddresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			err := clientgoscheme.AddToScheme(scheme)
+			require.NoError(t, err, "Fail to add kubernetes clint-go custom resource")
+
+			apis.AddToScheme(scheme)
+
+			// Build client
+			clientBuilder := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(node)
+
+			// Pod
+			if tc.pod != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.pod)
+			}
+
+			// Invoke Default
+			w := &v1.EndpointsHandler{Client: clientBuilder.Build()}
+			err = w.Default(context.TODO(), tc.endpoints)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Check the result
+			require.Equal(t, tc.expectedEndpoints, tc.endpoints)
+		})
+	}
+}

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default_test.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_default_test.go
@@ -20,10 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openyurtio/openyurt/pkg/apis"
-	"github.com/openyurtio/openyurt/pkg/projectinfo"
-	nodeutils "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
-	v1 "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpoints/v1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +27,11 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openyurtio/openyurt/pkg/apis"
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	nodeutils "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
+	v1 "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpoints/v1"
 )
 
 func TestDefault_AutonomyAnnotations(t *testing.T) {

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_handler.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_handler.go
@@ -17,13 +17,14 @@ limitations under the License.
 package v1
 
 import (
-	yurtClient "github.com/openyurtio/openyurt/cmd/yurt-manager/app/client"
-	"github.com/openyurtio/openyurt/cmd/yurt-manager/names"
-	"github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/util"
 	v1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	yurtClient "github.com/openyurtio/openyurt/cmd/yurt-manager/app/client"
+	"github.com/openyurtio/openyurt/cmd/yurt-manager/names"
+	"github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/util"
 )
 
 const (

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_handler.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_handler.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	yurtClient "github.com/openyurtio/openyurt/cmd/yurt-manager/app/client"
+	"github.com/openyurtio/openyurt/cmd/yurt-manager/names"
+	"github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/util"
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+const (
+	WebhookName = "endpoints"
+)
+
+// EndpointsHandler implements a defaulting webhook for Endpoints.
+type EndpointsHandler struct {
+	Client client.Client
+}
+
+// SetupWebhookWithManager sets up Endpoints webhooks.
+func (webhook *EndpointsHandler) SetupWebhookWithManager(mgr ctrl.Manager) (string, string, error) {
+	// init
+	webhook.Client = yurtClient.GetClientByControllerNameOrDie(mgr, names.NodeLifeCycleController)
+
+	return util.RegisterWebhook(mgr, &v1.Endpoints{}, webhook)
+}
+
+// +kubebuilder:webhook:path=/mutate-core-openyurt-io-v1-endpoints,mutating=true,failurePolicy=ignore,sideEffects=None,admissionReviewVersions=v1,groups="",resources=endpoints,verbs=update,versions=v1,name=mutate.core.v1.endpoints.openyurt.io
+
+var _ webhook.CustomDefaulter = &EndpointsHandler{}

--- a/pkg/yurtmanager/webhook/endpoints/v1/endpoints_handler.go
+++ b/pkg/yurtmanager/webhook/endpoints/v1/endpoints_handler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1
 
 import (

--- a/pkg/yurtmanager/webhook/server.go
+++ b/pkg/yurtmanager/webhook/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-manager/names"
 	controller "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/base"
 	v1alpha1deploymentrender "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/deploymentrender/v1alpha1"
+	v1endpoints "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpoints/v1"
 	v1beta1gateway "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/gateway/v1beta1"
 	v1node "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/node/v1"
 	v1beta1nodepool "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/nodepool/v1beta1"
@@ -82,6 +83,8 @@ func init() {
 
 	independentWebhooks[v1node.WebhookName] = &v1node.NodeHandler{}
 	independentWebhooks[v1alpha1pod.WebhookName] = &v1alpha1pod.PodHandler{}
+	independentWebhooks[v1endpoints.WebhookName] = &v1endpoints.EndpointsHandler{}
+
 }
 
 // Note !!! @kadisi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> /kind feature

#### What this PR does / why we need it:
Adds endpoint webhook for node autonomy feature. When the node lifecycle controller marks a pod not ready; the endpoints are removed. This webhook ensures those endpoints are still in the ready state when node autonomy feature is in use. 

#### Which issue(s) this PR fixes:
Fixes https://github.com/openyurtio/openyurt/issues/2197

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

#### other Note

#### Test Results

##### Yurt manager : Node lifecycle controller and platformadmins controller disabled.
```bash
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    meta.helm.sh/release-name: yurt-manager
    meta.helm.sh/release-namespace: kube-system
  creationTimestamp: "2024-12-01T22:26:12Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: yurt-manager
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: yurt-manager
    app.kubernetes.io/version: v1.5.0
    helm.sh/chart: yurt-manager-1.5.0
  name: yurt-manager
  namespace: kube-system
  resourceVersion: "23331"
  uid: 792f663e-7c8c-48b7-9a46-9f5bd7fd96b1
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/instance: yurt-manager
      app.kubernetes.io/name: yurt-manager
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: yurt-manager
        app.kubernetes.io/name: yurt-manager
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: yurt-control-plane
                operator: Exists
      containers:
      - args:
        - --metrics-addr=:10271
        - --health-probe-addr=:10272
        - --webhook-port=10273
        - --v=4
        - --working-namespace=kube-system
        - --leader-elect-resource-name=cloud-yurt-manager
        - --controllers=-platformadmin,-nodelifecycle,*
        command:
        - /usr/local/bin/yurt-manager
        image: tiensimon/yurt-manager:latest
        imagePullPolicy: IfNotPresent
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /healthz
            port: 10272
            scheme: HTTP
          initialDelaySeconds: 60
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 2
        name: yurt-manager
        ports:
        - containerPort: 10273
          name: webhook-server
          protocol: TCP
        - containerPort: 10271
          name: metrics
          protocol: TCP
        - containerPort: 10272
          name: health
          protocol: TCP
        readinessProbe:
          failureThreshold: 2
          httpGet:
            path: /readyz
            port: 10272
            scheme: HTTP
          initialDelaySeconds: 60
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 2
        resources:
          limits:
            cpu: "2"
            memory: 1Gi
          requests:
            cpu: 100m
            memory: 256Mi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: yurt-manager
      serviceAccountName: yurt-manager
      terminationGracePeriodSeconds: 30
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      - effect: NoSchedule
        key: node-role.kubernetes.io/control-plane
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2024-12-01T22:27:22Z"
    lastUpdateTime: "2024-12-01T22:27:22Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2024-12-01T22:26:12Z"
    lastUpdateTime: "2024-12-01T22:27:22Z"
    message: ReplicaSet "yurt-manager-587b4b8bd4" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 1
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
```

##### Nodes - node is ready and labelled with autonomy-duration
```bash
✗ k get nodes -o wide
NAME                                STATUS   ROLES    AGE     VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
vagrant                             Ready    <none>   9m19s   v1.29.9   172.16.201.2   <none>           Ubuntu 24.04 LTS     6.8.0-38-generic    containerd://1.7.12

✗ k get nodes vagrant -o yaml 
apiVersion: v1
kind: Node
metadata:
  annotations:
    node.openyurt.io/autonomy-duration: 3600s
```

##### Pods - pods are running
```bash
✗ k get pods -o wide
NAME                                READY   STATUS    RESTARTS            AGE     IP             NODE                                NOMINATED NODE   READINESS GATES
nginx-deployment-79b9cd8cc9-xcmnl   1/1     Running   0                   3m30s   10.244.1.195   vagrant                             <none>           <none>
nginx-deployment-79b9cd8cc9-z89hz   1/1     Running   0                   3m30s   10.244.1.182   vagrant                             <none>           <none>
```

#### Endpoints - endpoints are up and ready
```bash
✗ k get endpoints
NAME            ENDPOINTS                           AGE
nginx-service   10.244.1.182:80,10.244.1.195:80     7m45s
```

##### Node goes
```bash
$ k get nodes
NAME                                STATUS     ROLES    AGE    VERSION
vagrant                             NotReady   <none>   18m    v1.29.9
```

##### Pods - still running becomes not ready
```bash
✗ k get pods -o wide
NAME                                READY   STATUS    RESTARTS            AGE     IP             NODE                                NOMINATED NODE   READINESS GATES
nginx-deployment-79b9cd8cc9-xcmnl   1/1     Running   0                   6m57s   10.244.1.195   vagrant                             <none>           <none>
nginx-deployment-79b9cd8cc9-z89hz   1/1     Running   0                   6m57s   10.244.1.182   vagrant                             <none>           <none>

apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2024-12-01T22:39:16Z"
  generateName: nginx-deployment-79b9cd8cc9-
  labels:
    app: nginx
    pod-template-hash: 79b9cd8cc9
  name: nginx-deployment-79b9cd8cc9-xcmnl
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2024-12-01T22:42:28Z"
    status: "True"
    type: PodReadyToStartContainers
  - lastProbeTime: null
    lastTransitionTime: "2024-12-01T22:42:21Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2024-12-01T22:44:51Z"
    status: "False" 
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2024-12-01T22:42:28Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2024-12-01T22:42:21Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: containerd://571f958748de3f9db6281524f5f904857b761884efb594c5b479a165b1dcc171
    image: docker.io/library/nginx:latest
    imageID: docker.io/library/nginx@sha256:0c86dddac19f2ce4fd716ac58c0fd87bf69bfd4edabfd6971fb885bafd12a00b
    lastState: {}
    name: nginx
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2024-12-01T22:42:27Z"
  hostIP: 172.16.201.2
  hostIPs:
  - ip: 172.16.201.2
  phase: Running
  podIP: 10.244.1.195
  podIPs:
  - ip: 10.244.1.195
  qosClass: BestEffort
  startTime: "2024-12-01T22:42:21Z"
```

##### Endpoints - remain up, unchanged and ready.
```bash
✗ k get endpoints
NAME            ENDPOINTS                           AGE
nginx-service   10.244.1.182:80,10.244.1.195:80     10m
```