### PR TITLE
fix: move notFoundError to notExistError

### DIFF
--- a/pkg/yurtmanager/webhook/util/writer/certwriter.go
+++ b/pkg/yurtmanager/webhook/util/writer/certwriter.go
@@ -77,7 +77,11 @@ func updateIfNotExists(ch certReadWriter) (*generator.Artifacts, bool, error) {
 	certs, err := ch.read()
 	if isNotExist(err) {
 		// Create if not exists
-		certs, err = ch.overwrite(certs.ResourceVersion)
+		var resourceVersion string
+		if certs != nil {
+			resourceVersion = certs.ResourceVersion
+		}
+		certs, err = ch.overwrite(resourceVersion)
 		return certs, true, err
 	}
 	return certs, false, err

--- a/pkg/yurtmanager/webhook/util/writer/error.go
+++ b/pkg/yurtmanager/webhook/util/writer/error.go
@@ -16,14 +16,6 @@ limitations under the License.
 
 package writer
 
-type notFoundError struct {
-	err error
-}
-
-func (e notFoundError) Error() string {
-	return e.err.Error()
-}
-
 type alreadyExistError struct {
 	err error
 }

--- a/pkg/yurtmanager/webhook/util/writer/fs.go
+++ b/pkg/yurtmanager/webhook/util/writer/fs.go
@@ -188,7 +188,7 @@ func ensureExist(dir string) error {
 		case err == nil:
 			continue
 		case os.IsNotExist(err):
-			return notFoundError{err}
+			return notExistError{err}
 		default:
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:

If the user set `WEBHOOK_HOST` environment variable, the webhook certs will be written to filesystem (`/tmp/yurt-manager-webhook-certs` by default), and the code has a type confusion of `notExistError` and `notFoundError`.

This PR also fix a null pointer dereference in `updateIfNotExists`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
