### PR TITLE
Add endpointslice webhook for node autonomy

### DIFF
--- a/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
+++ b/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
@@ -1440,6 +1440,25 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
+  clientConfig:
+    service:
+      name: yurt-manager-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-core-openyurt-io-v1-endpointslice
+  failurePolicy: Ignore
+  name: mutate.core.v1.endpointslice.openyurt.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    resources:
+    - endpointslices
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:

--- a/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default.go
+++ b/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nodeutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
+	podutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/pod"
+)
+
+// Default satisfies the defaulting webhook interface.
+func (webhook *EndpointSliceHandler) Default(ctx context.Context, obj runtime.Object) error {
+	endpoints, ok := obj.(*discovery.EndpointSlice)
+	if !ok {
+		apierrors.NewBadRequest(fmt.Sprintf("expected an EndpointSlice object but got %T", obj))
+	}
+
+	return remapAutonomyEndpoints(ctx, webhook.Client, endpoints)
+}
+
+// isNodeAutonomous checks if the node has autonomy annotations
+// and returns true if it does, false otherwise.
+func isNodeAutonomous(ctx context.Context, c client.Client, nodeName string) (bool, error) {
+	node := &corev1.Node{}
+	err := c.Get(ctx, client.ObjectKey{Name: nodeName}, node)
+	if err != nil {
+		// If node doesn't exist, it doesn't have autonomy
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return nodeutil.IsPodBoundenToNode(node), nil
+}
+
+// isPodCrashLoopBackOff checks if the pod is crashloopbackoff
+// and returns true if it is, false otherwise.
+func isPodCrashLoopBackOff(ctx context.Context, c client.Client, podName, namespace string) (bool, error) {
+	pod := &corev1.Pod{}
+	err := c.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return podutil.IsPodCrashLoopBackOff(pod.Status), nil
+}
+
+func remapAutonomyEndpoints(ctx context.Context, client client.Client, slice *discovery.EndpointSlice) error {
+	if slice == nil || len(slice.Endpoints) == 0 {
+		return nil
+	}
+
+	for _, e := range slice.Endpoints {
+		// If the endpoint is ready, skip
+		if e.Conditions.Ready != nil && *e.Conditions.Ready {
+			continue
+		}
+
+		// If the endpoint doesn't have a node name or target ref, skip
+		if e.NodeName == nil || *e.NodeName == "" || e.TargetRef == nil {
+			continue
+		}
+
+		isAutonomous, err := isNodeAutonomous(ctx, client, *e.NodeName)
+		if err != nil {
+			return err
+		}
+
+		// If the node doesn't have autonomy, skip
+		if !isAutonomous {
+			continue
+		}
+
+		isPodCrashLoopBackOff, err := isPodCrashLoopBackOff(ctx, client, e.TargetRef.Name, e.TargetRef.Namespace)
+		if err != nil {
+			return err
+		}
+
+		// If the pod is in crashloopbackoff, skip
+		if isPodCrashLoopBackOff {
+			continue
+		}
+
+		// Set not ready addresses to ready
+		*e.Conditions.Ready = true
+	}
+
+	return nil
+}

--- a/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default_test.go
+++ b/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default_test.go
@@ -1,0 +1,506 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openyurtio/openyurt/pkg/apis"
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	nodeutils "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
+	v1 "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpointslice/v1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDefault_AutonomyAnnotations(t *testing.T) {
+	// Fix the pod to ready for the test
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	// Test cases for Default
+	tests := []struct {
+		name        string
+		node        *corev1.Node
+		inputObj    runtime.Object
+		expectedObj *discovery.EndpointSlice
+		expectErr   bool
+	}{
+		{
+			name: "Node autonomy duration annotation",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "10m",
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2(true)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Node autonomy duration annotation empty",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "", // empty
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)}, // not updated to Ready
+			},
+			expectErr: false,
+		},
+		{
+			name: "Autonomy annotation true",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetAutonomyAnnotation(): "true",
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2(true)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Autonomy annotation false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						projectinfo.GetAutonomyAnnotation(): "false",
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2(false)}, // not updated to Ready
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod binding annotation true",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						nodeutils.PodBindingAnnotation: "true",
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2(true)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod binding annotation false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						nodeutils.PodBindingAnnotation: "false",
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)}, // not updated to Ready
+			},
+			expectErr: false,
+		},
+		{
+			name: "Node has no annotations",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "node1",
+					Annotations: map[string]string{}, // Nothing
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Other node",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node3", // Other
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "10m",
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Node name is empty",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "",
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "", // empty
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2(false)}, // not updated to Ready
+			},
+			expectErr: false,
+		},
+		{
+			name: "Node name and target ref nil",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "", // empty
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"172.16.0.17", "172.16.0.18"},
+					Conditions: discovery.EndpointConditions{
+						Ready: ptr.To(false),
+					},
+				}},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"172.16.0.17", "172.16.0.18"},
+					Conditions: discovery.EndpointConditions{
+						Ready: ptr.To(false),
+					},
+				}}, // not updated to Ready
+			},
+			expectErr: false,
+		},
+		{
+			name: "Endpoint slice is empty",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						projectinfo.GetNodeAutonomyDurationAnnotation(): "", // empty
+					},
+				},
+			},
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			err := clientgoscheme.AddToScheme(scheme)
+			require.NoError(t, err, "Fail to add kubernetes clint-go custom resource")
+
+			apis.AddToScheme(scheme)
+
+			// Build client
+			clientBuilder := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pod)
+			if tc.node != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.node)
+			}
+
+			// Invoke Default
+			w := &v1.EndpointSliceHandler{Client: clientBuilder.Build()}
+			err = w.Default(context.TODO(), tc.inputObj)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Check the result
+			require.Equal(t, tc.expectedObj, tc.inputObj)
+		})
+	}
+}
+
+func TestDefault_PodCrashLoopBack(t *testing.T) {
+	// Fix the node annotation to autonomy duration
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				projectinfo.GetNodeAutonomyDurationAnnotation(): "10m",
+			},
+		},
+	}
+
+	// Test cases for Default
+	tests := []struct {
+		name        string
+		inputObj    runtime.Object
+		pod         *corev1.Pod
+		expectedObj *discovery.EndpointSlice
+		expectErr   bool
+	}{
+		{
+			name: "Pod not crashloopback",
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2Pod2(false)},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+						},
+					},
+				},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2Pod2(true)}, /// updates regardless of matching pod
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod is crashloopbackoff",
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint2Pod2(false)},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "CrashLoopBackOff",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint2Pod2(false)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod no container states",
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false)},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod multiple container statuses",
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2Pod2(false)},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+						},
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "CrashLoopBackOff",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2Pod2(false)},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Pod is empty",
+			inputObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(false), endpoint2Pod2(false)},
+			},
+			pod: &corev1.Pod{}, // Empty pod
+			expectedObj: &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{endpoint1(true), endpoint2Pod2(true)},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			err := clientgoscheme.AddToScheme(scheme)
+			require.NoError(t, err, "Fail to add kubernetes clint-go custom resource")
+
+			apis.AddToScheme(scheme)
+
+			// Build client
+			clientBuilder := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(node)
+
+			// Pod
+			if tc.pod != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.pod)
+			}
+
+			// Invoke Default
+			w := &v1.EndpointSliceHandler{Client: clientBuilder.Build()}
+			err = w.Default(context.TODO(), tc.inputObj)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Check the result
+			require.Equal(t, tc.expectedObj, tc.inputObj)
+		})
+	}
+}
+
+func endpoint1(ready bool) discovery.Endpoint {
+	return discovery.Endpoint{
+		Addresses: []string{"172.16.0.17", "172.16.0.18"},
+		Conditions: discovery.EndpointConditions{
+			Ready: ptr.To(ready),
+		},
+		NodeName: ptr.To("node1"),
+		TargetRef: &corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod1",
+			Namespace: "default",
+		},
+	}
+}
+
+func endpoint2(ready bool) discovery.Endpoint {
+	return discovery.Endpoint{
+		Addresses: []string{"10.244.1.2", "10.244.1.3"},
+		Conditions: discovery.EndpointConditions{
+			Ready: ptr.To(ready),
+		},
+		NodeName: ptr.To("node1"),
+		TargetRef: &corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod1",
+			Namespace: "default",
+		},
+	}
+}
+
+func endpoint2Pod2(ready bool) discovery.Endpoint {
+	return discovery.Endpoint{
+		Addresses: []string{"10.244.1.2", "10.244.1.3"},
+		Conditions: discovery.EndpointConditions{
+			Ready: ptr.To(ready),
+		},
+		NodeName: ptr.To("node1"),
+		TargetRef: &corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod2",
+			Namespace: "default",
+		},
+	}
+}

--- a/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default_test.go
+++ b/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default_test.go
@@ -20,20 +20,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openyurtio/openyurt/pkg/apis"
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
 	nodeutils "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
 	v1 "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpointslice/v1"
-	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestDefault_AutonomyAnnotations(t *testing.T) {

--- a/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_handler.go
+++ b/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_handler.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	v1 "k8s.io/api/discovery/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	yurtClient "github.com/openyurtio/openyurt/cmd/yurt-manager/app/client"
+	"github.com/openyurtio/openyurt/cmd/yurt-manager/names"
+	"github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/util"
+)
+
+const (
+	WebhookName = "endpointslice"
+)
+
+// EndpointSliceHandler implements a defaulting webhook for EndpointSlice.
+type EndpointSliceHandler struct {
+	Client client.Client
+}
+
+// SetupWebhookWithManager sets up EndpointSlice webhooks.
+func (webhook *EndpointSliceHandler) SetupWebhookWithManager(mgr ctrl.Manager) (string, string, error) {
+	// init
+	webhook.Client = yurtClient.GetClientByControllerNameOrDie(mgr, names.NodeLifeCycleController)
+
+	return util.RegisterWebhook(mgr, &v1.EndpointSlice{}, webhook)
+}
+
+// +kubebuilder:webhook:path=/mutate-core-openyurt-io-v1-endpointslice,mutating=true,failurePolicy=ignore,sideEffects=None,admissionReviewVersions=v1,groups="",resources=endpointslices,verbs=update,versions=v1,name=mutate.core.v1.endpointslice.openyurt.io
+
+var _ webhook.CustomDefaulter = &EndpointSliceHandler{}

--- a/pkg/yurtmanager/webhook/server.go
+++ b/pkg/yurtmanager/webhook/server.go
@@ -32,6 +32,7 @@ import (
 	controller "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/base"
 	v1alpha1deploymentrender "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/deploymentrender/v1alpha1"
 	v1endpoints "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpoints/v1"
+	v1endpointslice "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/endpointslice/v1"
 	v1beta1gateway "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/gateway/v1beta1"
 	v1node "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/node/v1"
 	v1beta1nodepool "github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/nodepool/v1beta1"
@@ -84,7 +85,7 @@ func init() {
 	independentWebhooks[v1node.WebhookName] = &v1node.NodeHandler{}
 	independentWebhooks[v1alpha1pod.WebhookName] = &v1alpha1pod.PodHandler{}
 	independentWebhooks[v1endpoints.WebhookName] = &v1endpoints.EndpointsHandler{}
-
+	independentWebhooks[v1endpointslice.WebhookName] = &v1endpointslice.EndpointSliceHandler{}
 }
 
 // Note !!! @kadisi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:
This change adds a webhook in yurt-manager that updates endpoints within endpointslice resource from "not ready" to "ready" when the node has node autonomy configuration(node.openyurt.io/autonomy-duration). We don't want endpoints to be removed from endpointslice if node autonomy duration is configured.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/openyurtio/openyurt/issues/2198

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->

Testing results:
```
// deployed yurt-manager with PR change
$ k get pod yurt-manager-85cd6cb579-lkfjj -n kube-system -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2024-12-09T23:29:28Z"
  generateName: yurt-manager-85cd6cb579-
  labels:
    app.kubernetes.io/instance: yurt-manager
    app.kubernetes.io/name: yurt-manager
    pod-template-hash: 85cd6cb579
  name: yurt-manager-85cd6cb579-lkfjj
  namespace: kube-system
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: ReplicaSet
    name: yurt-manager-85cd6cb579
    uid: 4d42f136-ad8b-4457-803b-a8ad125dfe70
  resourceVersion: "1892455"
  uid: 6b8d5938-13bd-4b43-9956-4f17b76f49a3
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: yurt-control-plane
            operator: Exists
  containers:
  - args:
    - --metrics-addr=:10271
    - --health-probe-addr=:10272
    - --webhook-port=10273
    - --v=4
    - --working-namespace=kube-system
    - --leader-elect-resource-name=cloud-yurt-manager
    - --controllers=-platformadmin,-nodelifecycle,*
    command:
    - /usr/local/bin/yurt-manager
    env:
    - name: KUBERNETES_SERVICE_HOST
      value: jwangaks-jwangrg-8ecadf-xhtdvfvh.hcp.eastus2.azmk8s.io
    - name: KUBERNETES_PORT
      value: tcp://jwangaks-jwangrg-8ecadf-xhtdvfvh.hcp.eastus2.azmk8s.io:443
    - name: KUBERNETES_PORT_443_TCP
      value: tcp://jwangaks-jwangrg-8ecadf-xhtdvfvh.hcp.eastus2.azmk8s.io:443
    - name: KUBERNETES_PORT_443_TCP_ADDR
      value: jwangaks-jwangrg-8ecadf-xhtdvfvh.hcp.eastus2.azmk8s.io
    image: jessie1/openyurt:yurtmanager-latest
    imagePullPolicy: IfNotPresent
    livenessProbe:
      failureThreshold: 3
      httpGet:
        path: /healthz
        port: 10272
        scheme: HTTP
      initialDelaySeconds: 60
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 2
    name: yurt-manager
    ports:
    - containerPort: 10273
      name: webhook-server
      protocol: TCP
    - containerPort: 10271
      name: metrics
      protocol: TCP
    - containerPort: 10272
      name: health
      protocol: TCP
   ...


// Edge node with node autonomy annotation
$ k get nodes jwang1-virtual-machine -o yaml
apiVersion: v1
kind: Node
metadata:
  annotations:
    csi.volume.kubernetes.io/nodeid: '{"disk.csi.azure.com":"jwang1-virtual-machine","file.csi.azure.com":"jwang1-virtual-machine"}'
    node.alpha.kubernetes.io/ttl: "0"
    node.beta.openyurt.io/autonomy: "true"
    node.beta.openyurt.io/autonomy-duration: 10m
    volumes.kubernetes.io/controller-managed-attach-detach: "true"
  creationTimestamp: "2024-12-05T11:43:03Z"
  labels:
    beta.kubernetes.io/arch: amd64
    beta.kubernetes.io/os: linux
    kubernetes.azure.com/agentpool: nodepool2
    kubernetes.azure.com/cluster: MC_jwangrg_jwangaks_eastus2
    kubernetes.azure.com/managed: "false"
    kubernetes.azure.com/mode: user
    kubernetes.azure.com/role: agent
    kubernetes.azure.com/stretch: "true"
    kubernetes.io/arch: amd64
    kubernetes.io/hostname: jwang1-virtual-machine
    kubernetes.io/os: linux
    node.kubernetes.io/exclude-from-external-load-balancers: "true"
    openyurt.io/is-edge-worker: "true"
    topology.disk.csi.azure.com/zone: ""
  name: jwang1-virtual-machine
  resourceVersion: "1471294"
  uid: 3cbf99ad-4f2f-40cd-ab8a-c34ba7a4a5f7
...

// Workload deployed
$ k get pods -A  -o wide
NAMESPACE     NAME                                                READY   STATUS    RESTARTS        AGE     IP             NODE
default       nginx-daemonset-2z97h                               1/1     Running   0               54s     10.244.1.16    jwang1-virtual-machine
default       nginx-daemonset-lcj7r                               1/1     Running   0               54s     10.244.0.176   aks-nodepool1-40510526-vmss000000

$ k get service -n default
NAMESPACE     NAME                           TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
default       nginx-service                  ClusterIP   10.245.2.50    <none>        80/TCP              63s


// Endpointslice is up and ready
$ k get endpointslice | grep nginx
nginx-service-pj85p   IPv4          80      10.244.1.16,10.244.0.176   45s


// kubelet is stopped on VM - node becomes not ready
$ k get nodes -o wide | grep virtual-machine
jwang1-virtual-machine              NotReady   <none>   3d11h   v1.29.9   192.168.1.33   <none>          Ubuntu 22.04.5 LTS   6.8.0-1018-azure    containerd://1.6.36-1

// workload pods continue to run
$ k get pods -A  -o wide | grep nginx
default       nginx-daemonset-2z97h                               1/1     Running   0                16h     10.244.1.16    jwang1-virtual-machine              <none>           <none>
default       nginx-daemonset-lcj7r                               1/1     Running   0                16h     10.244.0.176   aks-nodepool1-40510526-vmss000000   <none>           <none>

$ k get pod nginx-daemonset-2z97h -n default -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2024-12-08T06:52:35Z"
  generateName: nginx-daemonset-
  labels:
    app: nginx
    controller-revision-hash: 7c79c4bf97
    pod-template-generation: "1"
  name: nginx-daemonset-2z97h
  namespace: default
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: DaemonSet
    name: nginx-daemonset
    uid: 7bbc9bcb-7a29-4f44-a05c-03ae3085bd56
  resourceVersion: "1894854"
  uid: 8b524af3-a4ae-4c6b-a5f1-ab49ef588b6f
...
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2024-12-08T06:52:51Z"
    status: "True"
    type: PodReadyToStartContainers
  - lastProbeTime: null
    lastTransitionTime: "2024-12-08T06:52:35Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2024-12-09T23:37:27Z"
    status: "False" <-- **Not ready**
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2024-12-08T06:52:51Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2024-12-08T06:52:35Z"
    status: "True"
    type: PodScheduled
...

// endpoints remain ready and unchanged
$ k get endpointslice | grep nginx
nginx-service-pj85p   IPv4          80      10.244.1.16,10.244.0.176   40h
```
