### PR TITLE
fix: endpointslices belongs to discovery.k8s.io group

### DIFF
--- a/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
+++ b/charts/yurt-manager/templates/yurt-manager-auto-generated.yaml
@@ -1444,12 +1444,12 @@ webhooks:
     service:
       name: yurt-manager-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /mutate-core-openyurt-io-v1-endpointslice
+      path: /mutate-discovery-k8s-io-v1-endpointslice
   failurePolicy: Ignore
-  name: mutate.core.v1.endpointslice.openyurt.io
+  name: mutate.discovery.v1.endpointslice.k8s.io
   rules:
   - apiGroups:
-    - ""
+    - discovery.k8s.io
     apiVersions:
     - v1
     operations:

--- a/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default.go
+++ b/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_default.go
@@ -77,7 +77,8 @@ func remapAutonomyEndpoints(ctx context.Context, client client.Client, slice *di
 		return nil
 	}
 
-	for _, e := range slice.Endpoints {
+	readyServing := true
+	for i, e := range slice.Endpoints {
 		// If the endpoint is ready, skip
 		if e.Conditions.Ready != nil && *e.Conditions.Ready {
 			continue
@@ -115,10 +116,10 @@ func remapAutonomyEndpoints(ctx context.Context, client client.Client, slice *di
 
 		// Set not ready addresses to ready & serving
 		if e.Conditions.Ready != nil {
-			*e.Conditions.Ready = true
+			slice.Endpoints[i].Conditions.Ready = &readyServing
 		}
 		if e.Conditions.Serving != nil {
-			*e.Conditions.Serving = true
+			slice.Endpoints[i].Conditions.Serving = &readyServing
 		}
 	}
 

--- a/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_handler.go
+++ b/pkg/yurtmanager/webhook/endpointslice/v1/endpointslice_handler.go
@@ -44,6 +44,6 @@ func (webhook *EndpointSliceHandler) SetupWebhookWithManager(mgr ctrl.Manager) (
 	return util.RegisterWebhook(mgr, &v1.EndpointSlice{}, webhook)
 }
 
-// +kubebuilder:webhook:path=/mutate-core-openyurt-io-v1-endpointslice,mutating=true,failurePolicy=ignore,sideEffects=None,admissionReviewVersions=v1,groups="",resources=endpointslices,verbs=update,versions=v1,name=mutate.core.v1.endpointslice.openyurt.io
+// +kubebuilder:webhook:path=/mutate-discovery-k8s-io-v1-endpointslice,mutating=true,failurePolicy=ignore,sideEffects=None,admissionReviewVersions=v1,groups="discovery.k8s.io",resources=endpointslices,verbs=update,versions=v1,name=mutate.discovery.v1.endpointslice.k8s.io
 
 var _ webhook.CustomDefaulter = &EndpointSliceHandler{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:
1. Endpointslices resource belongs to `discovery.k8s.io` group instead of core group. so we need to adapt webhook settings according to group `discovery.k8s.io`.
2. fix some miss of mutating endpointslices

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
