### PR TITLE
fix add pod request into reconcile queue instead of node

### DIFF
--- a/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtcoordinator/podbinding/pod_binding_controller_test.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/openyurtio/openyurt/pkg/projectinfo"
 )
 
 func podIndexer(rawObj client.Object) []string {
@@ -90,6 +92,9 @@ func TestReconcile(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
+					Labels: map[string]string{
+						projectinfo.GetEdgeWorkerLabelKey(): "true",
+					},
 					Annotations: map[string]string{
 						"node.openyurt.io/autonomy-duration": "100s",
 					},
@@ -151,6 +156,9 @@ func TestReconcile(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
+					Labels: map[string]string{
+						projectinfo.GetEdgeWorkerLabelKey(): "true",
+					},
 					Annotations: map[string]string{
 						"node.openyurt.io/autonomy-duration": "0s",
 					},
@@ -214,6 +222,9 @@ func TestReconcile(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node1",
+					Labels: map[string]string{
+						projectinfo.GetEdgeWorkerLabelKey(): "true",
+					},
 				},
 			},
 			resultPod: &corev1.Pod{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind bug

#### What this PR does / why we need it:
improve pod binding controller as following:
1. only process edge nodes and pods which run on edge nodes.
2. add pod request into reconcile queue instead of adding node request.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
