### PR TITLE
upgrade kind cluster to 1.30 for e2e.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.22.3'
   GOLANGCI_VERSION: 'v1.55.2'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
@@ -132,8 +132,8 @@ jobs:
 #          restore-keys: ${{ runner.os }}-go-
       - name: Install Required Commands
         run: |
-          go install sigs.k8s.io/kind@v0.22.0
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.28.7/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
+          go install sigs.k8s.io/kind@v0.25.0
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.30.1/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
       - name: Build Images
         run: make docker-build
       - name: Local Up Openyurt Cluster With Kind

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBERNETESVERSION ?=v1.28
+KUBERNETESVERSION ?=v1.30
 GOLANGCILINT_VERSION ?= v1.55.2
 GLOBAL_GOLANGCILINT := $(shell which golangci-lint)
 GOBIN := $(shell go env GOPATH)/bin
@@ -64,7 +64,7 @@ KUSTOMIZE_VERSION ?= v4.5.7
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 
-KUBECTL_VERSION ?= v1.28.7
+KUBECTL_VERSION ?= v1.30.1
 KUBECTL ?= $(LOCALBIN)/kubectl
 
 YQ_VERSION := 4.13.2

--- a/hack/make-rules/local-up-openyurt.sh
+++ b/hack/make-rules/local-up-openyurt.sh
@@ -62,14 +62,14 @@ readonly REQUIRED_IMAGES=(
 readonly LOCAL_ARCH=$(go env GOHOSTARCH)
 readonly LOCAL_OS=$(go env GOHOSTOS)
 readonly CLUSTER_NAME="openyurt-e2e-test"
-readonly KUBERNETESVERSION=${KUBERNETESVERSION:-"v1.28"}
+readonly KUBERNETESVERSION=${KUBERNETESVERSION:-"v1.30"}
 readonly NODES_NUM=${NODES_NUM:-3}
 readonly KIND_KUBECONFIG=${KIND_KUBECONFIG:-${HOME}/.kube/config}
 readonly DISABLE_DEFAULT_CNI=${DISABLE_DEFAULT_CNI:-"false"}
 
 function install_kind {
     echo "Begin to install kind"
-    GO111MODULE="on" go install sigs.k8s.io/kind@v0.22.0
+    GO111MODULE="on" go install sigs.k8s.io/kind@v0.25.0
 }
 
 function install_docker {

--- a/test/e2e/cmd/init/init.go
+++ b/test/e2e/cmd/init/init.go
@@ -65,11 +65,13 @@ var (
 		"v1.27",
 		"v1.28",
 		"v1.29",
+		"v1.30",
 	}
 	validKindVersions = []string{
 		"v0.11.1",
 		"v0.12.0",
 		"v0.22.0",
+		"v0.25.0",
 	}
 	AllValidOpenYurtVersions = append(projectinfo.Get().AllVersions, "latest")
 
@@ -98,6 +100,14 @@ var (
 			"v1.27": "kindest/node:v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843",
 			"v1.28": "kindest/node:v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58",
 			"v1.29": "kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245",
+		},
+		"v0.25.0": {
+			"v1.31": "kindest/node:v1.31.2@sha256:18fbefc20a7113353c7b75b5c869d7145a6abd6269154825872dc59c1329912e",
+			"v1.30": "kindest/node:v1.30.6@sha256:b6d08db72079ba5ae1f4a88a09025c0a904af3b52387643c285442afb05ab994",
+			"v1.29": "kindest/node:v1.29.10@sha256:3b2d8c31753e6c8069d4fc4517264cd20e86fd36220671fb7d0a5855103aa84b",
+			"v1.28": "kindest/node:v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251",
+			"v1.27": "kindest/node:v1.27.16@sha256:2d21a61643eafc439905e18705b8186f3296384750a835ad7a005dceb9546d20",
+			"v1.26": "kindest/node:v1.26.15@sha256:c79602a44b4056d7e48dc20f7504350f1e87530fe953428b792def00bc1076dd",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

> /kind feature

#### What this PR does / why we need it:

OpenYurt supports Kubernetes clusters version 1.30, and the e2e test kind cluster needs to be upgraded to 1.30.


-->
```release-note
none
```
