### PR TITLE
fix: update gvr for core.v1.services

### DIFF
--- a/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller_test.go
+++ b/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller_test.go
@@ -67,14 +67,14 @@ func TestReconcile(t *testing.T) {
 					EnableLeaderElection:   true,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
-							Resource: "Service",
+							Resource: "services",
 						},
 						{
 							Group:    "discovery.k8s.io",
 							Version:  "v1",
-							Resource: "EndpointSlice",
+							Resource: "endpointslices",
 						},
 					},
 				},
@@ -98,7 +98,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Data: map[string]string{
 					"leaders":                "node1/10.0.0.1",
-					"pool-scoped-metadata":   "core/v1/Service,discovery.k8s.io/v1/EndpointSlice",
+					"pool-scoped-metadata":   "/v1/services,discovery.k8s.io/v1/endpointslices",
 					"interconnectivity":      "true",
 					"enable-leader-election": "true",
 				},
@@ -121,14 +121,14 @@ func TestReconcile(t *testing.T) {
 					EnableLeaderElection:   true,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
-							Resource: "Service",
+							Resource: "services",
 						},
 						{
 							Group:    "discovery.k8s.io",
 							Version:  "v1",
-							Resource: "EndpointSlice",
+							Resource: "endpointslices",
 						},
 					},
 				},
@@ -156,7 +156,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Data: map[string]string{
 					"leaders":                "node1/10.0.0.1,node2/10.0.0.2",
-					"pool-scoped-metadata":   "core/v1/Service,discovery.k8s.io/v1/EndpointSlice",
+					"pool-scoped-metadata":   "/v1/services,discovery.k8s.io/v1/endpointslices",
 					"interconnectivity":      "true",
 					"enable-leader-election": "true",
 				},
@@ -179,14 +179,14 @@ func TestReconcile(t *testing.T) {
 					EnableLeaderElection:   true,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
-							Resource: "Service",
+							Resource: "services",
 						},
 						{
 							Group:    "discovery.k8s.io",
 							Version:  "v1",
-							Resource: "EndpointSlice",
+							Resource: "endpointslices",
 						},
 					},
 				},
@@ -213,7 +213,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Data: map[string]string{
 					"leaders":                "node1/10.0.0.1",
-					"pool-scoped-metadata":   "core/v1/Service",
+					"pool-scoped-metadata":   "/v1/services",
 					"interconnectivity":      "true",
 					"enable-leader-election": "false",
 				},
@@ -228,7 +228,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Data: map[string]string{
 					"leaders":                "node1/10.0.0.1,node2/10.0.0.2",
-					"pool-scoped-metadata":   "core/v1/Service,discovery.k8s.io/v1/EndpointSlice",
+					"pool-scoped-metadata":   "/v1/services,discovery.k8s.io/v1/endpointslices",
 					"interconnectivity":      "true",
 					"enable-leader-election": "true",
 				},
@@ -251,14 +251,14 @@ func TestReconcile(t *testing.T) {
 					EnableLeaderElection:   true,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
-							Resource: "Service",
+							Resource: "services",
 						},
 						{
 							Group:    "discovery.k8s.io",
 							Version:  "v1",
-							Resource: "EndpointSlice",
+							Resource: "endpointslices",
 						},
 					},
 				},
@@ -277,7 +277,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Data: map[string]string{
 					"leaders":                "",
-					"pool-scoped-metadata":   "core/v1/Service,discovery.k8s.io/v1/EndpointSlice",
+					"pool-scoped-metadata":   "/v1/services,discovery.k8s.io/v1/endpointslices",
 					"interconnectivity":      "true",
 					"enable-leader-election": "true",
 				},

--- a/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default.go
+++ b/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default.go
@@ -69,7 +69,7 @@ func (webhook *NodePoolHandler) Default(ctx context.Context, obj runtime.Object)
 	// Set default PoolScopeMetadata
 	defaultPoolScopeMetadata := []v1.GroupVersionResource{
 		{
-			Group:    "core",
+			Group:    "",
 			Version:  "v1",
 			Resource: "services",
 		},

--- a/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default_test.go
+++ b/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default_test.go
@@ -63,7 +63,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         3,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -110,7 +110,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         3,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -158,7 +158,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         3,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -206,7 +206,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         3,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -254,7 +254,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         3,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -314,7 +314,7 @@ func TestDefault(t *testing.T) {
 							Resource: "Endpoints",
 						},
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -347,7 +347,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         3,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -369,7 +369,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         3,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -429,7 +429,7 @@ func TestDefault(t *testing.T) {
 							Resource: "endpointslices",
 						},
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -472,7 +472,7 @@ func TestDefault(t *testing.T) {
 					LeaderReplicas:         2,
 					PoolScopeMetadata: []metav1.GroupVersionResource{
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -510,7 +510,7 @@ func TestDefault(t *testing.T) {
 							Resource: "endpointslices",
 						},
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -537,7 +537,7 @@ func TestDefault(t *testing.T) {
 							Resource: "endpointslices",
 						},
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},
@@ -594,7 +594,7 @@ func TestDefault(t *testing.T) {
 							Resource: "Endpoints",
 						},
 						{
-							Group:    "core",
+							Group:    "",
 							Version:  "v1",
 							Resource: "services",
 						},

--- a/test/e2e/yurt/hubleader.go
+++ b/test/e2e/yurt/hubleader.go
@@ -101,7 +101,7 @@ var _ = Describe("Test hubleader elections", Serial, func() {
 		}
 
 		expectedLeaderConfig["leaders"] = strings.Join(leaderEndpoints, ",")
-		expectedLeaderConfig["pool-scoped-metadata"] = "core/v1/services,discovery.k8s.io/v1/endpointslices"
+		expectedLeaderConfig["pool-scoped-metadata"] = "/v1/services,discovery.k8s.io/v1/endpointslices"
 		expectedLeaderConfig["interconnectivity"] = "true"
 		expectedLeaderConfig["enable-leader-election"] = "true"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When moving from GVK to GVR in poolscoped metadata, the core.v1.services was left with group. We need to remove group from GVR for v1.services.

#### Which issue(s) this PR fixes:
Fixes https://github.com/openyurtio/openyurt/issues/2317

#### Special notes for your reviewer:
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
