### PR TITLE
fix: ensure hub leader configmap is deleted with nodepool

### DIFF
--- a/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller.go
+++ b/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller.go
@@ -82,8 +82,7 @@ func Add(ctx context.Context, cfg *appconfig.CompletedConfig, mgr manager.Manage
 			return ok
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			_, ok := e.Object.(*appsv1beta2.NodePool)
-			return ok
+			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldPool, ok := e.ObjectOld.(*appsv1beta2.NodePool)

--- a/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller_test.go
+++ b/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller_test.go
@@ -95,6 +95,11 @@ func TestReconcile(t *testing.T) {
 					Labels: map[string]string{
 						projectinfo.GetHubLeaderConfigMapLabel(): "leader-hub-hangzhou",
 					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "hangzhou",
+						},
+					},
 				},
 				Data: map[string]string{
 					"leaders":                "node1/10.0.0.1",
@@ -152,6 +157,11 @@ func TestReconcile(t *testing.T) {
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
 						projectinfo.GetHubLeaderConfigMapLabel(): "leader-hub-shanghai",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "shanghai",
+						},
 					},
 				},
 				Data: map[string]string{
@@ -274,6 +284,11 @@ func TestReconcile(t *testing.T) {
 					Labels: map[string]string{
 						projectinfo.GetHubLeaderConfigMapLabel(): "leader-hub-beijing",
 					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "beijing",
+						},
+					},
 				},
 				Data: map[string]string{
 					"leaders":                "",
@@ -320,6 +335,11 @@ func TestReconcile(t *testing.T) {
 					Labels: map[string]string{
 						projectinfo.GetHubLeaderConfigMapLabel(): "leader-hub-beijing",
 					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "beijing",
+						},
+					},
 				},
 				Data: map[string]string{
 					"leaders":                "node1/10.0.0.1,node2/10.0.0.2",
@@ -365,6 +385,11 @@ func TestReconcile(t *testing.T) {
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
 						projectinfo.GetHubLeaderConfigMapLabel(): "leader-hub-beijing",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "beijing",
+						},
 					},
 				},
 				Data: map[string]string{

--- a/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller_test.go
+++ b/pkg/yurtmanager/controller/hubleaderconfig/hubleaderconfig_controller_test.go
@@ -220,6 +220,11 @@ func TestReconcile(t *testing.T) {
 					Labels: map[string]string{
 						projectinfo.GetHubLeaderConfigMapLabel(): "leader-hub-shanghai",
 					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "shanghai",
+						},
+					},
 				},
 				Data: map[string]string{
 					"leaders":                "node1/10.0.0.1",
@@ -234,6 +239,11 @@ func TestReconcile(t *testing.T) {
 					Namespace: metav1.NamespaceSystem,
 					Labels: map[string]string{
 						projectinfo.GetHubLeaderConfigMapLabel(): "leader-hub-shanghai",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name: "shanghai",
+						},
 					},
 				},
 				Data: map[string]string{

--- a/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default.go
+++ b/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default.go
@@ -94,8 +94,5 @@ func (webhook *NodePoolHandler) Default(ctx context.Context, obj runtime.Object)
 		}
 	}
 
-	// Set default enable leader election to false
-	np.Spec.EnableLeaderElection = false
-
 	return nil
 }

--- a/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default_test.go
+++ b/pkg/yurtmanager/webhook/nodepool/v1beta2/nodepool_default_test.go
@@ -612,6 +612,68 @@ func TestDefault(t *testing.T) {
 				},
 			},
 		},
+		"nodepool has enable leader election enabled": {
+			obj: &v1beta2.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: v1beta2.NodePoolSpec{
+					HostNetwork:            true,
+					Type:                   v1beta2.Cloud,
+					LeaderElectionStrategy: string(v1beta2.ElectionStrategyMark),
+					LeaderReplicas:         3,
+					EnableLeaderElection:   true,
+					PoolScopeMetadata: []metav1.GroupVersionResource{
+						{
+							Group:    "discovery.k8s.io",
+							Version:  "v1",
+							Resource: "Endpoints",
+						},
+					},
+				},
+			},
+			wantedNodePool: &v1beta2.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":                       "bar",
+						"nodepool.openyurt.io/type": "cloud",
+					},
+				},
+				Spec: v1beta2.NodePoolSpec{
+					HostNetwork:            true,
+					Type:                   v1beta2.Cloud,
+					LeaderElectionStrategy: string(v1beta2.ElectionStrategyMark),
+					LeaderReplicas:         3,
+					EnableLeaderElection:   true,
+					PoolScopeMetadata: []metav1.GroupVersionResource{
+						{
+							Group:    "discovery.k8s.io",
+							Version:  "v1",
+							Resource: "Endpoints",
+						},
+						{
+							Group:    "",
+							Version:  "v1",
+							Resource: "services",
+						},
+						{
+							Group:    "discovery.k8s.io",
+							Version:  "v1",
+							Resource: "endpointslices",
+						},
+					},
+				},
+				Status: v1beta2.NodePoolStatus{
+					ReadyNodeNum:   0,
+					UnreadyNodeNum: 0,
+					Nodes:          []string{},
+				},
+			},
+		},
 	}
 
 	for k, tc := range testcases {

--- a/test/e2e/yurt/hubleader.go
+++ b/test/e2e/yurt/hubleader.go
@@ -19,6 +19,7 @@ package yurt
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -89,23 +90,6 @@ var _ = Describe("Test hubleader elections", Serial, func() {
 		})
 
 		return expectedLeaders
-	}
-
-	// getExpectedLeaderConfig returns the expected leader config map data
-	getExpectedLeaderConfig := func(leaders []v1beta2.Leader) map[string]string {
-		expectedLeaderConfig := make(map[string]string)
-
-		leaderEndpoints := make([]string, 0, len(leaders))
-		for _, leader := range leaders {
-			leaderEndpoints = append(leaderEndpoints, leader.NodeName+"/"+leader.Address)
-		}
-
-		expectedLeaderConfig["leaders"] = strings.Join(leaderEndpoints, ",")
-		expectedLeaderConfig["pool-scoped-metadata"] = "/v1/services,discovery.k8s.io/v1/endpointslices"
-		expectedLeaderConfig["interconnectivity"] = "true"
-		expectedLeaderConfig["enable-leader-election"] = "true"
-
-		return expectedLeaderConfig
 	}
 
 	getActualLeaders := func() []v1beta2.Leader {
@@ -254,3 +238,108 @@ var _ = Describe("Test hubleader elections", Serial, func() {
 		})
 	})
 })
+
+var _ = Describe("Hub leader config owner cleanup", func() {
+	ctx := context.Background()
+	var k8sClient client.Client
+
+	BeforeEach(func() {
+		k8sClient = ycfg.YurtE2eCfg.RuntimeClient
+	})
+
+	AfterEach(func() {})
+
+	It("Should delete hub leader config when nodepool is deleted", func() {
+		npName := fmt.Sprintf("test-%d", time.Now().Unix())
+		pool := util.TestNodePool{
+			NodePool: v1beta2.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: npName,
+				},
+				Spec: v1beta2.NodePoolSpec{
+					EnableLeaderElection: true,
+					InterConnectivity:    true,
+					Type:                 v1beta2.Edge,
+				},
+			},
+		}
+
+		By("Creating a new empty nodepool")
+		Eventually(
+			func() error {
+				return util.InitTestNodePool(ctx, k8sClient, pool)
+			},
+			time.Second*5, time.Millisecond*500).Should(BeNil())
+
+		By("Nodepool should be created")
+		Eventually(
+			func() error {
+				_, err := util.GetNodepool(ctx, k8sClient, pool.NodePool.Name)
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			time.Second*5, time.Millisecond*500).Should(BeNil())
+
+		By("Leader config map should be created")
+		Eventually(
+			getActualLeaderConfig,
+			time.Second*5,
+			time.Millisecond*500,
+		).WithArguments(ctx, k8sClient, npName).Should(Equal(getExpectedLeaderConfig([]v1beta2.Leader{})))
+
+		By("Delete the nodepool")
+		Eventually(
+			func() error {
+				return util.DeleteNodePool(ctx, k8sClient, npName)
+			},
+			time.Second*5, time.Millisecond*500).Should(BeNil())
+
+		By("Leader config map should be not found")
+		Eventually(
+			func() error {
+				err := k8sClient.Get(
+					ctx,
+					client.ObjectKey{Name: "leader-hub-" + npName, Namespace: metav1.NamespaceSystem},
+					&v1.ConfigMap{},
+				)
+				if err != nil && client.IgnoreNotFound(err) != nil {
+					return err
+				}
+				return nil
+			},
+			time.Second*5, time.Millisecond*500).Should(BeNil())
+	})
+})
+
+// getActualLeaderConfig returns the actual leader config map data
+func getActualLeaderConfig(ctx context.Context, k8sClient client.Client, nodePoolName string) map[string]string {
+	configMap := v1.ConfigMap{}
+	err := k8sClient.Get(
+		ctx,
+		client.ObjectKey{Name: "leader-hub-" + nodePoolName, Namespace: metav1.NamespaceSystem},
+		&configMap,
+	)
+	if err != nil {
+		return nil
+	}
+	return configMap.Data
+}
+
+// getExpectedLeaderConfig returns the expected leader config map data
+func getExpectedLeaderConfig(leaders []v1beta2.Leader) map[string]string {
+	expectedLeaderConfig := make(map[string]string)
+
+	leaderEndpoints := make([]string, 0, len(leaders))
+	for _, leader := range leaders {
+		leaderEndpoints = append(leaderEndpoints, leader.NodeName+"/"+leader.Address)
+	}
+
+	expectedLeaderConfig["leaders"] = strings.Join(leaderEndpoints, ",")
+	expectedLeaderConfig["pool-scoped-metadata"] = "/v1/services,discovery.k8s.io/v1/endpointslices"
+	expectedLeaderConfig["interconnectivity"] = "true"
+	expectedLeaderConfig["enable-leader-election"] = "true"
+
+	return expectedLeaderConfig
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Hub leader config should be deleted when nodepool is deleted

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/openyurtio/openyurt/issues/2323

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
/assign @rambohe-ch 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
None
```

#### other Note
* Removed set enableLeaderElection = false from defaulting webhook. Should not set this default. 
* Created e2e scenario for hub leader config clean up