### PR TITLE
clean up meaningless code

### DIFF
--- a/cmd/yurt-manager/yurt-manager.go
+++ b/cmd/yurt-manager/yurt-manager.go
@@ -17,10 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	_ "net/http/pprof"
 	"os"
-	"time"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/component-base/logs"
@@ -30,9 +28,6 @@ import (
 )
 
 func main() {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	newRand.Seed(time.Now().UnixNano())
-
 	command := app.NewYurtManagerCommand()
 
 	// TODO: once we switch everything over to Cobra commands, we can go back to calling

--- a/cmd/yurt-node-servant/node-servant.go
+++ b/cmd/yurt-node-servant/node-servant.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -35,9 +33,6 @@ import (
 // running on specific node, do convert/revert job
 // node-servant convert/revert join/reset, yurtcluster operator shall start a k8s job to run this.
 func main() {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	newRand.Seed(time.Now().UnixNano())
-
 	version := fmt.Sprintf("%#v", projectinfo.Get())
 	rootCmd := &cobra.Command{
 		Use:     "node-servant",

--- a/cmd/yurthub/yurthub.go
+++ b/cmd/yurthub/yurthub.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"flag"
-	"math/rand"
-	"time"
 
 	"k8s.io/apiserver/pkg/server"
 
@@ -27,9 +25,6 @@ import (
 )
 
 func main() {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	newRand.Seed(time.Now().UnixNano())
-
 	cmd := app.NewCmdStartYurtHub(server.SetupSignalContext())
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
after package global method `rand.Seed()` has been deprecated, there is no need to call top-level `Seed` at main(), the top-level `globalRandGenerator` will auto get seed when runtime start

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

/kind enhancement

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
