### PR TITLE
feat: support yurtadm local mode for joining IDC node in K8s-on-K8s cluster

### DIFF
--- a/pkg/yurtadm/cmd/join/joindata/data.go
+++ b/pkg/yurtadm/cmd/join/joindata/data.go
@@ -36,6 +36,8 @@ type YurtJoinData interface {
 	JoinToken() string
 	PauseImage() string
 	YurtHubImage() string
+	YurtHubBinaryUrl() string
+	HostControlPlaneAddr() string
 	YurtHubServer() string
 	YurtHubTemplate() string
 	YurtHubManifest() string

--- a/pkg/yurtadm/cmd/join/phases/postcheck.go
+++ b/pkg/yurtadm/cmd/join/phases/postcheck.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/kubernetes"
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
@@ -32,16 +33,19 @@ func RunPostCheck(data joindata.YurtJoinData) error {
 	}
 	klog.V(1).Infof("kubelet service is active")
 
-	klog.V(1).Infof("waiting hub agent ready.")
-	if err := yurthub.CheckYurthubHealthz(data.YurtHubServer()); err != nil {
-		return err
-	}
-	klog.V(1).Infof("hub agent is ready")
+	// check staticpod yurthub for edge node and cloud node
+	if data.NodeRegistration().WorkingMode != constants.LocalNode {
+		klog.V(1).Infof("waiting hub agent ready.")
+		if err := yurthub.CheckYurthubHealthz(data.YurtHubServer()); err != nil {
+			return err
+		}
+		klog.V(1).Infof("hub agent is ready")
 
-	if err := yurthub.CleanHubBootstrapConfig(); err != nil {
-		return err
+		if err := yurthub.CleanHubBootstrapConfig(); err != nil {
+			return err
+		}
+		klog.V(1).Infof("clean yurthub bootstrap config file success")
 	}
-	klog.V(1).Infof("clean yurthub bootstrap config file success")
 
 	return nil
 }

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -35,8 +35,11 @@ const (
 	PauseImagePath                = "registry.cn-hangzhou.aliyuncs.com/google_containers/pause:3.2"
 	DefaultCertificatesDir        = "/etc/kubernetes/pki"
 	DefaultDockerCRISocket        = "/var/run/dockershim.sock"
+	YurthubServiceFilepath        = "/etc/systemd/system/yurthub.service"
+	YurthubEnvironmentFilePath    = "/etc/systemd/system/yurthub.default"
 	YurthubYamlName               = "yurthub.yaml"
 	YurthubStaticPodManifest      = "yurthub"
+	YurthubTmpDir                 = "/tmp/yurthub"
 	YurthubNamespace              = "kube-system"
 	YurthubYurtStaticSetName      = "yurt-hub"
 	YurthubCloudYurtStaticSetName = "yurt-hub-cloud"
@@ -72,6 +75,7 @@ const (
 
 	EdgeNode  = "edge"
 	CloudNode = "cloud"
+	LocalNode = "local"
 
 	// CertificatesDir
 	CertificatesDir = "cert-dir"
@@ -107,6 +111,10 @@ const (
 	Namespace = "namespace"
 	// YurtHubImage flag sets the yurthub image for worker node.
 	YurtHubImage = "yurthub-image"
+	// YurtHubBinaryUrl flag sets the yurthub Binary for worker node.
+	YurtHubBinaryUrl = "yurthub-binary-url"
+	// HostControlPlaneAddr flag sets the address of host kubernetes cluster
+	HostControlPlaneAddr = "host-control-plane-addr"
 	// YurtHubServerAddr flag set the address of yurthub server (not proxy server!)
 	YurtHubServerAddr = "yurthub-server-addr"
 	// ServerAddr flag set the address of kubernetes kube-apiserver
@@ -145,7 +153,7 @@ WantedBy=multi-user.target`
 
 	KubeletUnitConfig = `
 [Service]
-Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_KUBECONFIG_ARGS={{- if .bootstrapKubeconfig}}{{.bootstrapKubeconfig}} {{end}}{{.kubeconfig}}"
 Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
 EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 EnvironmentFile=-/etc/default/kubelet
@@ -180,14 +188,18 @@ discovery:
 nodeRegistration:
   criSocket: {{.criSocket}}
   name: {{.name}}
+  {{- if .ignorePreflightErrors}}
   ignorePreflightErrors:
     {{- range $index, $value := .ignorePreflightErrors}}
     - {{$value}}
     {{- end}}
+  {{- end}}
   kubeletExtraArgs:
-    rotate-certificates: "false"
+    rotate-certificates: "{{.rotateCertificates}}"
     pod-infra-container-image: {{.podInfraContainerImage}}
+	{{- if .nodeLabels}}
     node-labels: {{.nodeLabels}}
+    {{- end}}
     {{- if .networkPlugin}}
     network-plugin: {{.networkPlugin}}
     {{end}}
@@ -272,5 +284,21 @@ spec:
   hostNetwork: true
   priorityClassName: system-node-critical
   priority: 2000001000
+`
+
+	YurthubSyetmdServiceContent = `
+[Unit]
+Description=local mode yurthub is deployed in systemd
+Documentation=https://github.com/openyurtio/openyurt/pull/2124
+
+[Service]
+EnvironmentFile=/etc/systemd/system/yurthub.default
+ExecStart=/usr/bin/yurthub --working-mode ${WORKINGMODE} --node-name ${NODENAME} --server-addr ${SERVERADDR} --host-control-plane-address ${HOSTCONTROLPLANEADDRESS}
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
 `
 )

--- a/pkg/yurtadm/util/initsystem/initsystem.go
+++ b/pkg/yurtadm/util/initsystem/initsystem.go
@@ -27,4 +27,10 @@ type InitSystem interface {
 
 	// ServiceIsActive ensures the service is running, or attempting to run. (crash looping in the case of kubelet)
 	ServiceIsActive(service string) bool
+
+	// ServiceToStart tries to start a specific service
+	ServiceStart(service string) error
+
+	// ServiceStop tries to stop a specific service
+	ServiceStop(service string) error
 }

--- a/pkg/yurtadm/util/initsystem/initsystem_unix.go
+++ b/pkg/yurtadm/util/initsystem/initsystem_unix.go
@@ -52,6 +52,18 @@ func (openrc OpenRCInitSystem) ServiceIsActive(service string) bool {
 	return !strings.Contains(outStr, "stopped") && !strings.Contains(outStr, "does not exist")
 }
 
+// ServiceStart tries to start a specific service
+func (openrc OpenRCInitSystem) ServiceStart(service string) error {
+	args := []string{service, "start"}
+	return exec.Command("rc-service", args...).Run()
+}
+
+// ServiceStop tries to stop a specific service
+func (openrc OpenRCInitSystem) ServiceStop(service string) error {
+	args := []string{service, "stop"}
+	return exec.Command("rc-service", args...).Run()
+}
+
 // SystemdInitSystem defines systemd
 type SystemdInitSystem struct{}
 
@@ -92,6 +104,22 @@ func (sysd SystemdInitSystem) ServiceIsActive(service string) bool {
 		return true
 	}
 	return false
+}
+
+// ServiceStart tries to start a specific service
+func (sysd SystemdInitSystem) ServiceStart(service string) error {
+	// Before we try to start any service, make sure that systemd is ready
+	if err := sysd.reloadSystemd(); err != nil {
+		return err
+	}
+	args := []string{"start", service}
+	return exec.Command("systemctl", args...).Run()
+}
+
+// ServiceStop tries to stop a specific service
+func (sysd SystemdInitSystem) ServiceStop(service string) error {
+	args := []string{"stop", service}
+	return exec.Command("systemctl", args...).Run()
 }
 
 // GetInitSystem returns an InitSystem for the current system, or nil

--- a/pkg/yurtadm/util/initsystem/initsystem_unix_test.go
+++ b/pkg/yurtadm/util/initsystem/initsystem_unix_test.go
@@ -1,0 +1,185 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2022 The OpenYurt Authors.
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initsystem
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// setupFakeCommand is a helper function that dynamically creates fake 'systemctl' and 'rc-service'
+// executables for testing purposes.
+func setupFakeCommand(t *testing.T) {
+	t.Helper()
+
+	// 1. The source code for our smarter fake command. It can decide its behavior based on arguments.
+	const fakeCommandSource = `
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	// Read an environment variable that tells us which specific command should fail.
+	failureTarget := os.Getenv("SIMULATE_FAILURE_FOR")
+
+	// Get the command's own name (e.g., "systemctl") and its arguments.
+	commandName := strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+	args := os.Args[1:]
+	argString := strings.Join(args, " ")
+
+	// Construct the full command string, e.g., "systemctl daemon-reload".
+	fullCmd := commandName + " " + argString
+
+	// Check if the currently invoked command is the one we're supposed to fail.
+	if failureTarget == fullCmd {
+		fmt.Fprintf(os.Stderr, "simulating failure for: %s", fullCmd)
+		os.Exit(1) // Return a non-zero exit code to indicate failure.
+	}
+
+	// If it's not the target for failure, simulate success.
+	fmt.Fprintf(os.Stdout, "successfully executed: %s", fullCmd)
+	os.Exit(0)
+}
+`
+	tempDir := t.TempDir()
+	sourceFilePath := filepath.Join(tempDir, "fake_cmd.go")
+	if err := os.WriteFile(sourceFilePath, []byte(fakeCommandSource), 0644); err != nil {
+		t.Fatalf("Failed to write fake command source: %v", err)
+	}
+
+	// Compile the source code into two different executables.
+	for _, cmdName := range []string{"systemctl", "rc-service"} {
+		fakeCmdPath := filepath.Join(tempDir, cmdName)
+		cmd := exec.Command("go", "build", "-o", fakeCmdPath, sourceFilePath)
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to build fake command '%s': %v", cmdName, err)
+		}
+	}
+
+	// Prepend the temporary directory to the PATH.
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", fmt.Sprintf("%s%c%s", tempDir, os.PathListSeparator, originalPath))
+}
+
+func TestSystemdInitSystem(t *testing.T) {
+	setupFakeCommand(t)
+	sysd := SystemdInitSystem{}
+	serviceName := "kubelet"
+
+	t.Run("ServiceStart", func(t *testing.T) {
+		t.Run("should succeed when both reload and start succeed", func(t *testing.T) {
+			// Set SIMULATE_FAILURE_FOR to a value that will never match, ensuring all commands succeed.
+			t.Setenv("SIMULATE_FAILURE_FOR", "none")
+			err := sysd.ServiceStart(serviceName)
+			if err != nil {
+				t.Errorf("expected no error, but got: %v", err)
+			}
+		})
+
+		t.Run("should fail if reloadSystemd fails", func(t *testing.T) {
+			// Precisely tell the fake command to fail only when it is 'daemon-reload'.
+			t.Setenv("SIMULATE_FAILURE_FOR", "systemctl daemon-reload")
+			err := sysd.ServiceStart(serviceName)
+			if err == nil {
+				t.Error("expected an error for reload failure, but got nil")
+			}
+		})
+
+		t.Run("should fail if the final start command fails", func(t *testing.T) {
+			// Precisely tell the fake command to fail only when it is 'start kubelet'.
+			// The 'daemon-reload' call will succeed because it doesn't match.
+			t.Setenv("SIMULATE_FAILURE_FOR", fmt.Sprintf("systemctl start %s", serviceName))
+			err := sysd.ServiceStart(serviceName)
+			if err == nil {
+				t.Error("expected an error for start failure, but got nil")
+			}
+		})
+	})
+
+	t.Run("ServiceStop", func(t *testing.T) {
+		t.Run("should succeed", func(t *testing.T) {
+			t.Setenv("SIMULATE_FAILURE_FOR", "none")
+			err := sysd.ServiceStop(serviceName)
+			if err != nil {
+				t.Errorf("expected no error, but got: %v", err)
+			}
+		})
+
+		t.Run("should fail when stop command fails", func(t *testing.T) {
+			t.Setenv("SIMULATE_FAILURE_FOR", fmt.Sprintf("systemctl stop %s", serviceName))
+			err := sysd.ServiceStop(serviceName)
+			if err == nil {
+				t.Error("expected an error, but got nil")
+			}
+		})
+	})
+}
+
+func TestOpenRCInitSystem(t *testing.T) {
+	setupFakeCommand(t)
+	openrc := OpenRCInitSystem{}
+	serviceName := "kubelet"
+
+	t.Run("ServiceStart", func(t *testing.T) {
+		t.Run("should succeed", func(t *testing.T) {
+			t.Setenv("SIMULATE_FAILURE_FOR", "none")
+			err := openrc.ServiceStart(serviceName)
+			if err != nil {
+				t.Errorf("expected no error, but got: %v", err)
+			}
+		})
+
+		t.Run("should fail when start command fails", func(t *testing.T) {
+			t.Setenv("SIMULATE_FAILURE_FOR", fmt.Sprintf("rc-service %s start", serviceName))
+			err := openrc.ServiceStart(serviceName)
+			if err == nil {
+				t.Error("expected an error, but got nil")
+			}
+		})
+	})
+
+	t.Run("ServiceStop", func(t *testing.T) {
+		t.Run("should succeed", func(t *testing.T) {
+			t.Setenv("SIMULATE_FAILURE_FOR", "none")
+			err := openrc.ServiceStop(serviceName)
+			if err != nil {
+				t.Errorf("expected no error, but got: %v", err)
+			}
+		})
+
+		t.Run("should fail when stop command fails", func(t *testing.T) {
+			t.Setenv("SIMULATE_FAILURE_FOR", fmt.Sprintf("rc-service %s stop", serviceName))
+			err := openrc.ServiceStop(serviceName)
+			if err == nil {
+				t.Error("expected an error, but got nil")
+			}
+		})
+	})
+}

--- a/pkg/yurtadm/util/initsystem/initsystem_windows.go
+++ b/pkg/yurtadm/util/initsystem/initsystem_windows.go
@@ -22,13 +22,143 @@ package initsystem
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
 // WindowsInitSystem is the windows implementation of InitSystem
 type WindowsInitSystem struct{}
+
+// ServiceStart tries to start a specific service
+// Following Windows documentation: https://docs.microsoft.com/en-us/windows/desktop/Services/starting-a-service
+func (sysd WindowsInitSystem) ServiceStart(service string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(service)
+	if err != nil {
+		return errors.Wrapf(err, "could not access service %s", service)
+	}
+	defer s.Close()
+
+	// Check if service is already started
+	status, err := s.Query()
+	if err != nil {
+		return errors.Wrapf(err, "could not query service %s", service)
+	}
+
+	if status.State != svc.Stopped && status.State != svc.StopPending {
+		return nil
+	}
+
+	timeout := time.Now().Add(10 * time.Second)
+	for status.State != svc.Stopped {
+		if timeout.Before(time.Now()) {
+			return errors.Errorf("timeout waiting for %s service to stop", service)
+		}
+		time.Sleep(300 * time.Millisecond)
+		status, err = s.Query()
+		if err != nil {
+			return errors.Wrapf(err, "could not retrieve %s service status", service)
+		}
+	}
+
+	// Start the service
+	err = s.Start("is", "manual-started")
+	if err != nil {
+		return errors.Wrapf(err, "could not start service %s", service)
+	}
+
+	// Check that the start was successful
+	status, err = s.Query()
+	if err != nil {
+		return errors.Wrapf(err, "could not query service %s", service)
+	}
+	timeout = time.Now().Add(10 * time.Second)
+	for status.State != svc.Running {
+		if timeout.Before(time.Now()) {
+			return errors.Errorf("timeout waiting for %s service to start", service)
+		}
+		time.Sleep(300 * time.Millisecond)
+		status, err = s.Query()
+		if err != nil {
+			return errors.Wrapf(err, "could not retrieve %s service status", service)
+		}
+	}
+	return nil
+}
+
+// ServiceStop tries to stop a specific service
+// Following Windows documentation: https://docs.microsoft.com/en-us/windows/desktop/Services/stopping-a-service
+func (sysd WindowsInitSystem) ServiceStop(service string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(service)
+	if err != nil {
+		return errors.Wrapf(err, "could not access service %s", service)
+	}
+	defer s.Close()
+
+	// Check if service is already stopped
+	status, err := s.Query()
+	if err != nil {
+		return errors.Wrapf(err, "could not query service %s", service)
+	}
+
+	if status.State == svc.Stopped {
+		return nil
+	}
+
+	// If StopPending, check that service eventually stops
+	if status.State == svc.StopPending {
+		timeout := time.Now().Add(10 * time.Second)
+		for status.State != svc.Stopped {
+			if timeout.Before(time.Now()) {
+				return errors.Errorf("timeout waiting for %s service to stop", service)
+			}
+			time.Sleep(300 * time.Millisecond)
+			status, err = s.Query()
+			if err != nil {
+				return errors.Wrapf(err, "could not retrieve %s service status", service)
+			}
+		}
+		return nil
+	}
+
+	// Stop the service
+	status, err = s.Control(svc.Stop)
+	if err != nil {
+		return errors.Wrapf(err, "could not stop service %s", service)
+	}
+
+	// Check that the stop was successful
+	status, err = s.Query()
+	if err != nil {
+		return errors.Wrapf(err, "could not query service %s", service)
+	}
+	timeout := time.Now().Add(10 * time.Second)
+	for status.State != svc.Stopped {
+		if timeout.Before(time.Now()) {
+			return errors.Errorf("timeout waiting for %s service to stop", service)
+		}
+		time.Sleep(300 * time.Millisecond)
+		status, err = s.Query()
+		if err != nil {
+			return errors.Wrapf(err, "could not retrieve %s service status", service)
+		}
+	}
+	return nil
+}
 
 // ServiceIsEnabled ensures the service is enabled to start on each boot.
 func (sysd WindowsInitSystem) ServiceIsEnabled(service string) bool {

--- a/pkg/yurtadm/util/kubernetes/kubernetes_test.go
+++ b/pkg/yurtadm/util/kubernetes/kubernetes_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// --- TestIsValidBootstrapToken tests the BootstrapTokenRegexp regex pattern ---
+func TestIsValidBootstrapToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{
+			name:  "Valid_Token",
+			token: "abcdef.1234567890abcdef", // 6-char prefix.16-char suffix
+			want:  true,
+		},
+		{
+			name:  "Invalid_Length_Prefix",
+			token: "abc.1234567890abcdef", // Prefix length < 6
+			want:  false,
+		},
+		{
+			name:  "Invalid_Length_Suffix",
+			token: "abcdef.123", // Suffix length < 16
+			want:  false,
+		},
+		{
+			name:  "Invalid_Separator",
+			token: "abcdef-1234567890abcdef", // Separator is not a dot
+			want:  false,
+		},
+		{
+			name:  "Empty_Token",
+			token: "",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidBootstrapToken(tt.token); got != tt.want {
+				t.Errorf("IsValidBootstrapToken(%q) = %v, want %v", tt.token, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- TestConstructNodeLabels tests the logic for creating node labels string ---
+func TestConstructNodeLabels(t *testing.T) {
+	// Define a constant Edge Worker label for reference
+	const edgeWorkerLabel = "apps.openyurt.io/is-edge-worker"
+
+	tests := []struct {
+		name        string
+		inputLabels map[string]string
+		workingMode string
+		expectedMap map[string]string
+	}{
+		{
+			name:        "Cloud_Mode_No_Existing_Label",
+			inputLabels: map[string]string{"foo": "bar", "env": "prod"},
+			workingMode: "cloud",
+			expectedMap: map[string]string{
+				"foo":           "bar",
+				"env":           "prod",
+				edgeWorkerLabel: "false", // Should be automatically added as false
+			},
+		},
+		{
+			name:        "Edge_Mode_No_Existing_Label",
+			inputLabels: map[string]string{"foo": "bar"},
+			workingMode: "edge",
+			expectedMap: map[string]string{
+				"foo":           "bar",
+				edgeWorkerLabel: "true", // Should be automatically added as true
+			},
+		},
+		{
+			name:        "Existing_Label_Not_Overwritten",
+			inputLabels: map[string]string{edgeWorkerLabel: "custom-value", "zone": "shanghai"},
+			workingMode: "cloud", // Existing label should be preserved regardless of workingMode
+			expectedMap: map[string]string{
+				edgeWorkerLabel: "custom-value",
+				"zone":          "shanghai",
+			},
+		},
+		{
+			name:        "Empty_Input_Edge_Mode",
+			inputLabels: nil,
+			workingMode: "edge",
+			expectedMap: map[string]string{
+				edgeWorkerLabel: "true",
+			},
+		},
+		{
+			name:        "Empty_Input_Cloud_Mode",
+			inputLabels: map[string]string{},
+			workingMode: "cloud",
+			expectedMap: map[string]string{
+				edgeWorkerLabel: "false",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resultStr := constructNodeLabels(tt.inputLabels, tt.workingMode, edgeWorkerLabel)
+
+			// Parse the result string back to a Map for reliable comparison (due to Map iteration order)
+			resultMap := make(map[string]string)
+			parts := strings.Split(resultStr, ",")
+			for _, part := range parts {
+				kv := strings.Split(part, "=")
+				if len(kv) == 2 {
+					resultMap[kv[0]] = kv[1]
+				}
+			}
+
+			if !reflect.DeepEqual(resultMap, tt.expectedMap) {
+				t.Errorf("constructNodeLabels() result mismatch.\nExpected Map: %v\nActual Map: %v\nActual String: %s",
+					tt.expectedMap, resultMap, resultStr)
+			}
+		})
+	}
+}

--- a/pkg/yurtadm/util/localnode/localnode.go
+++ b/pkg/yurtadm/util/localnode/localnode.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2025 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localnode
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/go-iptables/iptables"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/util"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/util/edgenode"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/util/initsystem"
+)
+
+// iptablesInterface defines an interface for mocking the iptables client.
+type iptablesInterface interface {
+	ChainExists(table, chain string) (bool, error)
+	List(table, chain string) ([]string, error)
+}
+
+// Replace direct function calls with package-level variables to allow monkey patching in tests.
+var (
+	// os functions
+	osMkdirAll   = os.MkdirAll
+	osRemoveAll  = os.RemoveAll
+	filepathWalk = filepath.Walk
+
+	// util functions
+	utilDownloadFile = util.DownloadFile
+	utilUntar        = util.Untar
+	edgenodeCopyFile = edgenode.CopyFile
+
+	// factory functions
+	newIptables = func() (iptablesInterface, error) {
+		return iptables.New()
+	}
+
+	// internal function calls
+	checkChainFunc = CheckIptablesChainAndRulesExists
+
+	// Convert constant to variable for testing.
+	yurthubTmpDir = constants.YurthubTmpDir
+)
+
+// DownloadAndDeployYurthubInSystemd downloads yurthub binary and deploys yurthub in systemd
+func DownloadAndDeployYurthubInSystemd(hostControlPlaneAddr string, serverAddr string, yurthubBinaryUrl string, nodeName string) error {
+	// download yurthub (tar.gz) from yurthubBinaryUrl and install it to /usr/bin/yurthub
+	if err := DownloadAndInstallYurthub(yurthubBinaryUrl); err != nil {
+		return err
+	}
+	// stop yurthub service at first
+	if err := StopYurthubService(); err != nil {
+		return err
+	}
+	// set and start yurthub service in systemd
+	if err := SetYurthubService(hostControlPlaneAddr, serverAddr, nodeName); err != nil {
+		return err
+	}
+	if err := EnableYurthubService(); err != nil {
+		return err
+	}
+	if err := StartYurthubService(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DownloadAndInstallYurthub gets yurthub binary from URL and saves to /usr/bin/yurthub
+func DownloadAndInstallYurthub(yurthubBinaryUrl string) error {
+	//download yurthub (format: tar.gz) from yurthubBinaryUrl
+	originalFileName := path.Base(yurthubBinaryUrl)
+	if err := osMkdirAll(yurthubTmpDir, 0755); err != nil {
+		return err
+	}
+	defer osRemoveAll(yurthubTmpDir)
+	savePath := fmt.Sprintf("%s/%s", yurthubTmpDir, originalFileName)
+	klog.V(1).Infof("Download yurthub from: %s", yurthubBinaryUrl)
+	if err := utilDownloadFile(yurthubBinaryUrl, savePath, 3); err != nil {
+		return fmt.Errorf("download yurthub fail: %w", err)
+	}
+	// untar the tar.gz file to YurthubTmpDir
+	if err := utilUntar(savePath, yurthubTmpDir); err != nil {
+		return err
+	}
+
+	// look for a binary file named "yurthub" in the untared directory
+	var foundBinaryPath string
+	binaryToFind := "yurthub"
+
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err // if an error occurs during the traversal, the error is returned directly
+		}
+		// we only care about the file, and the file name must be "yurthub"
+		if !info.IsDir() && info.Name() == binaryToFind {
+			foundBinaryPath = path // found it and record its full path
+			return io.EOF          // io.EOF is a special signal that tells the Walk function to stop traversing.
+		}
+		return nil // continue traversing
+	}
+
+	// start traversal search from the root of the untared directory
+	if err := filepathWalk(yurthubTmpDir, walkFn); err != nil && err != io.EOF {
+		return fmt.Errorf("error looking up %s: %w", binaryToFind, err)
+	}
+
+	// check if the file was found
+	if foundBinaryPath == "" {
+		return fmt.Errorf("no binary file named '%s' found in the archive", binaryToFind)
+	}
+	klog.V(1).Infof("binary file found: %s", foundBinaryPath)
+
+	// copy the found binary files to the final destination
+	klog.V(1).Infof("copying %s to %s", foundBinaryPath, "/usr/bin/yurthub")
+	if err := edgenodeCopyFile(foundBinaryPath, "/usr/bin/yurthub", constants.DirMode); err != nil {
+		return err
+	}
+	return nil
+}
+
+// StopYurthubService stop yurthub service
+func StopYurthubService() error {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return err
+	}
+	if ok := initSystem.ServiceIsActive("yurthub"); ok {
+		if err = initSystem.ServiceStop("yurthub"); err != nil {
+			return fmt.Errorf("stop yurthub service failed")
+		}
+	}
+
+	return nil
+}
+
+// SetYurthubService configure yurthub service.
+func SetYurthubService(hostControlPlaneAddr string, serverAddr string, nodeName string) error {
+	klog.Info("Setting Yurthub service.")
+	yurthubServiceDir := filepath.Dir(constants.YurthubServiceFilepath)
+	if _, err := os.Stat(yurthubServiceDir); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(yurthubServiceDir, os.ModePerm); err != nil {
+				klog.Errorf("Create dir %s fail: %v", yurthubServiceDir, err)
+				return err
+			}
+		} else {
+			klog.Errorf("Describe dir %s fail: %v", yurthubServiceDir, err)
+			return err
+		}
+	}
+
+	// yurthub.default contains the environment variables that yurthub needs
+	yurthubSyetmdServiceEnvironmentFileContent := fmt.Sprintf(`
+WORKINGMODE=local
+NODENAME=%s
+SERVERADDR=%s
+HOSTCONTROLPLANEADDRESS=%s
+`, nodeName, serverAddr, hostControlPlaneAddr)
+
+	if err := os.WriteFile(constants.YurthubEnvironmentFilePath, []byte(yurthubSyetmdServiceEnvironmentFileContent), 0644); err != nil {
+		klog.Errorf("Write file %s fail: %v", constants.YurthubEnvironmentFilePath, err)
+		return err
+	}
+
+	// yurthub.service contains the configuration of yurthub service
+	if err := os.WriteFile(constants.YurthubServiceFilepath, []byte(constants.YurthubSyetmdServiceContent), 0644); err != nil {
+		klog.Errorf("Write file %s fail: %v", constants.YurthubServiceFilepath, err)
+		return err
+	}
+	return nil
+}
+
+// EnableYurthubService enable yurthub service
+func EnableYurthubService() error {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return err
+	}
+
+	if !initSystem.ServiceIsEnabled("yurthub") {
+		if err = initSystem.ServiceEnable("yurthub"); err != nil {
+			return fmt.Errorf("enable yurthub service failed")
+		}
+	}
+	return nil
+}
+
+// StartYurthubService start yurthub service
+func StartYurthubService() error {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return err
+	}
+	if err = initSystem.ServiceStart("yurthub"); err != nil {
+		return fmt.Errorf("start yurthub service failed")
+	}
+	return nil
+}
+
+// CheckYurthubStatus check if yurthub is healthy.
+func CheckYurthubStatus() (bool, error) {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return false, err
+	}
+	if ok := initSystem.ServiceIsActive("yurthub"); !ok {
+		return false, fmt.Errorf("yurthub is not active. ")
+	}
+	return true, nil
+}
+
+// CheckIptablesChainAndRulesExists checks if the iptables chain and rules exist.
+func CheckIptablesChainAndRulesExists(table, chain string) (bool, error) {
+	ipt, err := newIptables()
+	if err != nil {
+		klog.Errorf("Create iptables client failed: %v", err)
+		return false, err
+	}
+
+	// check if LBCHAIN exists
+	exists, err := ipt.ChainExists(table, chain)
+	if err != nil {
+		klog.Errorf("error checking if chain exists: %v", err)
+		return false, err
+	}
+	if !exists {
+		klog.Errorf("Chain %s does not exist in table %s", chain, table)
+		return false, nil
+	}
+
+	// List all rules in the chain
+	rules, err := ipt.List(table, chain)
+	if err != nil {
+		klog.Errorf("List rules in chain %s failed: %v", chain, err)
+		return false, err
+	}
+
+	// The first rule is always the chain creation command
+	// Valid rules start from the second entry
+	if len(rules) <= 1 {
+		klog.Errorf("Chain %s has no effective rules", chain)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// WaitForIptablesChainReadyWithTimeout waits for the iptables chain and its rules to be ready within a specified timeout.
+func WaitForIptablesChainReadyWithTimeout(table, chain string, interval, timeout time.Duration) error {
+	// Create a context that will be canceled automatically after the timeout duration.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Create a ticker to check periodically.
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	klog.Infof("Waiting for iptables chain '%s' in table '%s' to be ready (timeout: %s)...", chain, table, timeout)
+
+	// Loop and use a 'select' statement to wait for either the ticker or the timeout.
+	for {
+		select {
+		// This case is triggered when the context's timeout is exceeded.
+		case <-ctx.Done():
+			return fmt.Errorf("timed out after %s waiting for iptables chain '%s' in table '%s'", timeout, chain, table)
+
+		// This case is triggered at each interval defined by the ticker.
+		case <-ticker.C:
+			exists, err := checkChainFunc(table, chain)
+			if err != nil {
+				// An error occurred during the check; log it and retry on the next tick.
+				klog.Errorf("CheckIptablesChainAndRulesExists failed: %v, retrying...", err)
+				continue
+			}
+
+			if exists {
+				// The condition is met; log success and return nil (no error).
+				klog.Infof("iptables chain '%s' in table '%s' is ready.", chain, table)
+				return nil
+			}
+
+			// The chain is not ready yet; log and wait for the next tick.
+			klog.Infof("Chain '%s' is not ready yet, retrying in %s...", chain, interval)
+		}
+	}
+}

--- a/pkg/yurtadm/util/localnode/localnode_test.go
+++ b/pkg/yurtadm/util/localnode/localnode_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2025 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localnode
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockIptables is a mock implementation of the iptablesInterface.
+type mockIptables struct {
+	// key format is "table/chain"
+	chains map[string][]string
+	// fields for simulating errors
+	chainExistsErr error
+	listErr        error
+}
+
+func (m *mockIptables) ChainExists(table, chain string) (bool, error) {
+	if m.chainExistsErr != nil {
+		return false, m.chainExistsErr
+	}
+	_, exists := m.chains[table+"/"+chain]
+	return exists, nil
+}
+func (m *mockIptables) List(table, chain string) ([]string, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	rules, exists := m.chains[table+"/"+chain]
+	if !exists {
+		return nil, fmt.Errorf("chain %s does not exist", chain)
+	}
+	return rules, nil
+}
+
+// TestDownloadAndInstallYurthub tests the download and installation logic.
+func TestDownloadAndInstallYurthub(t *testing.T) {
+	// --- Mock all external function calls ---
+	originalDownload := utilDownloadFile
+	originalUntar := utilUntar
+	originalCopy := edgenodeCopyFile
+	originalRemoveAll := osRemoveAll
+	t.Cleanup(func() { // Ensure original functions are restored after the test.
+		utilDownloadFile = originalDownload
+		utilUntar = originalUntar
+		edgenodeCopyFile = originalCopy
+		osRemoveAll = originalRemoveAll
+	})
+
+	// Default mock behavior: all operations succeed.
+	utilDownloadFile = func(url, savePath string, retries int) error { return nil }
+	edgenodeCopyFile = func(src, dst string, perm os.FileMode) error { return nil }
+	// In tests, we don't want to actually delete the directory, so replace it with an empty function.
+	osRemoveAll = func(path string) error { return nil }
+
+	t.Run("should find and install binary successfully", func(t *testing.T) {
+		// Create an independent temporary directory for each subtest.
+		tmpDir := t.TempDir()
+		originalYurthubTmpDir := yurthubTmpDir
+		yurthubTmpDir = tmpDir
+		t.Cleanup(func() {
+			yurthubTmpDir = originalYurthubTmpDir
+		})
+
+		var copySrc, copyDst string
+		// Mock untar to create a fake yurthub binary inside a subdirectory.
+		utilUntar = func(src, dst string) error {
+			subDir := filepath.Join(dst, "yurthub-v1.0")
+			if err := os.Mkdir(subDir, 0755); err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Join(subDir, "yurthub"), []byte("fake binary"), 0755)
+		}
+		// Mock file copy to record the source and destination paths.
+		edgenodeCopyFile = func(src, dst string, perm os.FileMode) error {
+			copySrc = src
+			copyDst = dst
+			return nil
+		}
+
+		err := DownloadAndInstallYurthub("http://fake.url/yurthub.tar.gz")
+
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(tmpDir, "yurthub-v1.0", "yurthub"), copySrc, "Source path for copy is incorrect")
+		assert.Equal(t, "/usr/bin/yurthub", copyDst, "Destination path for copy is incorrect")
+	})
+
+	t.Run("should return an error when download fails", func(t *testing.T) {
+		// Create an independent temporary directory for each subtest.
+		tmpDir := t.TempDir()
+		originalYurthubTmpDir := yurthubTmpDir
+		yurthubTmpDir = tmpDir
+		t.Cleanup(func() {
+			yurthubTmpDir = originalYurthubTmpDir
+		})
+
+		expectedErr := errors.New("network error")
+		utilDownloadFile = func(url, savePath string, retries int) error {
+			return expectedErr
+		}
+
+		err := DownloadAndInstallYurthub("http://fake.url/yurthub.tar.gz")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error(), "Error message should contain the underlying download error")
+	})
+
+	t.Run("should return an error when binary is not found after untar", func(t *testing.T) {
+		// Create an independent temporary directory for each subtest.
+		tmpDir := t.TempDir()
+		originalYurthubTmpDir := yurthubTmpDir
+		yurthubTmpDir = tmpDir
+		t.Cleanup(func() {
+			yurthubTmpDir = originalYurthubTmpDir
+		})
+
+		// Restore successful download behavior.
+		utilDownloadFile = func(url, savePath string, retries int) error { return nil }
+		// Mock successful untar, but without a yurthub file inside.
+		utilUntar = func(src, dst string) error {
+			// Write an unrelated file in the clean directory.
+			return os.WriteFile(filepath.Join(dst, "not-yurthub"), []byte("fake binary"), 0755)
+		}
+
+		err := DownloadAndInstallYurthub("http://fake.url/yurthub.tar.gz")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no binary file named 'yurthub' found")
+	})
+}
+
+// TestCheckIptablesChainAndRulesExists tests the iptables chain check function.
+func TestCheckIptablesChainAndRulesExists(t *testing.T) {
+	// Save the original function and restore it after the test.
+	originalNewIptables := newIptables
+	t.Cleanup(func() { newIptables = originalNewIptables })
+
+	t.Run("should return true when chain exists and has rules", func(t *testing.T) {
+		mock := &mockIptables{chains: map[string][]string{
+			"nat/TEST-CHAIN": {"-N TEST-CHAIN", "-A TEST-CHAIN ..."}, // exists and has rules
+		}}
+		newIptables = func() (iptablesInterface, error) { return mock, nil }
+
+		exists, err := CheckIptablesChainAndRulesExists("nat", "TEST-CHAIN")
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("should return false when chain exists but has no rules", func(t *testing.T) {
+		mock := &mockIptables{chains: map[string][]string{
+			"nat/NO-RULES": {"-N NO-RULES"}, // exists but only has the definition, no effective rules
+		}}
+		newIptables = func() (iptablesInterface, error) { return mock, nil }
+
+		exists, err := CheckIptablesChainAndRulesExists("nat", "NO-RULES")
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("should return false when chain does not exist", func(t *testing.T) {
+		mock := &mockIptables{chains: map[string][]string{}}
+		newIptables = func() (iptablesInterface, error) { return mock, nil }
+
+		exists, err := CheckIptablesChainAndRulesExists("nat", "NON-EXISTENT-CHAIN")
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
+}
+
+// TestWaitForIptablesChainReadyWithTimeout tests the wait-with-timeout function.
+func TestWaitForIptablesChainReadyWithTimeout(t *testing.T) {
+	// Save the original function and restore it after the test.
+	originalCheckFunc := checkChainFunc
+	t.Cleanup(func() { checkChainFunc = originalCheckFunc })
+
+	t.Run("should return successfully when ready before timeout", func(t *testing.T) {
+		callCount := 0
+		// Mock the check function: returns false for the first two calls, then true.
+		mockCheck := func(table, chain string) (bool, error) {
+			callCount++
+			if callCount < 3 {
+				return false, nil
+			}
+			return true, nil
+		}
+		checkChainFunc = mockCheck // perform monkey patch
+
+		// Use very short intervals to make the test run quickly.
+		err := WaitForIptablesChainReadyWithTimeout("nat", "test", 10*time.Millisecond, 100*time.Millisecond)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return a timeout error when not ready after timeout", func(t *testing.T) {
+		// Mock a check function that always returns false.
+		mockCheck := func(table, chain string) (bool, error) {
+			return false, nil
+		}
+		checkChainFunc = mockCheck // perform monkey patch
+
+		err := WaitForIptablesChainReadyWithTimeout("nat", "test", 10*time.Millisecond, 50*time.Millisecond)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out", "Error message should contain 'timed out'")
+	})
+}
+
+// TestStopYurthubService tests the stop service function.
+func TestStopYurthubService(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+	}{
+		{
+			"normal",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := StopYurthubService()
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestSetYurthubService tests the set service function.
+func TestSetYurthubService(t *testing.T) {
+	tests := []struct {
+		name                 string
+		hostControlPlaneAddr string
+		serverAddr           string
+		nodeName             string
+		expectErr            bool
+	}{
+		{
+			"normal",
+			"192.168.0.1:8443",
+			"192.168.0.1:12345",
+			"node",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SetYurthubService(tt.hostControlPlaneAddr, tt.serverAddr, tt.nodeName)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestEnableYurthubService tests the enable service function.
+func TestEnableYurthubService(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+	}{
+		{
+			"normal",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := EnableYurthubService()
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestStartYurthubService tests the start service function.
+func TestStartYurthubService(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+	}{
+		{
+			"normal",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := StartYurthubService()
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCheckYurthubStatus tests the check service status function.
+func TestCheckYurthubStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+	}{
+		{
+			"normal",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := CheckYurthubStatus()
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDownloadAndDeployYurthubInSystemd(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+	}{
+		{
+			"normal",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DownloadAndDeployYurthubInSystemd("192.168.0.1:8443", "192.168.0.1:12345", "https://yurthub.com/yurthub.tar.gz", "node")
+			if tt.expectErr {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/pkg/yurtadm/util/util_test.go
+++ b/pkg/yurtadm/util/util_test.go
@@ -17,38 +17,180 @@ limitations under the License.
 package util
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_DownloadFile(t *testing.T) {
-	testCase := []struct {
-		name     string
-		url      string
-		retry    int
-		expected bool
-	}{
-		{"invalid download url", "http://1.2.3.4", 2, false},
-	}
+	// 1. Test successful download
+	t.Run("download successfully", func(t *testing.T) {
+		// Create a mock server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "file content")
+		}))
+		defer server.Close()
 
-	for _, tc := range testCase {
-		err := DownloadFile(tc.url, "", tc.retry)
-		assert.Equal(t, tc.expected, err == nil)
+		// Use a temporary directory for the downloaded file
+		tempDir := t.TempDir()
+		savePath := filepath.Join(tempDir, "testfile.txt")
+
+		err := DownloadFile(server.URL, savePath, 3)
+		assert.NoError(t, err, "Download should succeed")
+
+		// Verify the file content
+		content, err := os.ReadFile(savePath)
+		assert.NoError(t, err)
+		assert.Equal(t, "file content", string(content))
+	})
+
+	// 2. Test server returns an error
+	t.Run("server returns non-200 status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		tempDir := t.TempDir()
+		savePath := filepath.Join(tempDir, "testfile.txt")
+
+		err := DownloadFile(server.URL, savePath, 2)
+		assert.Error(t, err, "Download should fail with non-200 status")
+
+		// Verify the file was not created
+		_, err = os.Stat(savePath)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	// 3. Test the retry mechanism
+	t.Run("download successfully after retry", func(t *testing.T) {
+		var requestCount int32 = 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Fail on the first request, succeed on the second
+			if atomic.AddInt32(&requestCount, 1) == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "success after retry")
+		}))
+		defer server.Close()
+
+		tempDir := t.TempDir()
+		savePath := filepath.Join(tempDir, "testfile.txt")
+
+		err := DownloadFile(server.URL, savePath, 3)
+		assert.NoError(t, err, "Download should succeed after retry")
+
+		content, err := os.ReadFile(savePath)
+		assert.NoError(t, err)
+		assert.Equal(t, "success after retry", string(content))
+		assert.Equal(t, int32(2), atomic.LoadInt32(&requestCount), "Should have been called twice")
+	})
+
+	// 4. Test invalid URL
+	t.Run("invalid download url", func(t *testing.T) {
+		// Use a URL that will fail to resolve
+		err := DownloadFile("http://invalid-url-that-does-not-exist.local", "/tmp/test", 2)
+		assert.Error(t, err, "Download should fail for invalid URL")
+	})
+}
+
+// createTestTarGz is a helper function to create a .tar.gz file for testing.
+// files: a map where the key is the filename and the value is the file content.
+func createTestTarGz(t *testing.T, files map[string]string) string {
+	tarPath := filepath.Join(t.TempDir(), "test.tar.gz")
+	tarFile, err := os.Create(tarPath)
+	assert.NoError(t, err)
+	defer tarFile.Close()
+
+	gw := gzip.NewWriter(tarFile)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0600,
+			Size: int64(len(content)),
+		}
+		err := tw.WriteHeader(hdr)
+		assert.NoError(t, err)
+		_, err = io.WriteString(tw, content)
+		assert.NoError(t, err)
 	}
+	return tarPath
 }
 
 func Test_Untar(t *testing.T) {
-	testCase := []struct {
-		name     string
-		filePath string
-		expected bool
-	}{
-		{"invalid tar file", "/tmp", false},
-	}
+	// 1. Test successful untar
+	t.Run("untar successfully", func(t *testing.T) {
+		// Prepare test files
+		files := map[string]string{
+			"file1.txt":      "content1",
+			"dir1/file2.txt": "content2",
+		}
+		tarPath := createTestTarGz(t, files)
+		destDir := t.TempDir()
 
-	for _, tc := range testCase {
-		err := Untar(tc.name, "")
-		assert.Equal(t, tc.expected, err == nil)
-	}
+		err := Untar(tarPath, destDir)
+		assert.NoError(t, err, "Untar should be successful")
+
+		// Verify extracted files
+		content1, err := os.ReadFile(filepath.Join(destDir, "file1.txt"))
+		assert.NoError(t, err)
+		assert.Equal(t, "content1", string(content1))
+
+		content2, err := os.ReadFile(filepath.Join(destDir, "dir1/file2.txt"))
+		assert.NoError(t, err)
+		assert.Equal(t, "content2", string(content2))
+	})
+
+	// 2. Test for path traversal vulnerability
+	t.Run("should prevent path traversal", func(t *testing.T) {
+		files := map[string]string{
+			"../../evil.txt": "you are hacked",
+		}
+		tarPath := createTestTarGz(t, files)
+		destDir := t.TempDir()
+
+		err := Untar(tarPath, destDir)
+		assert.Error(t, err, "Untar should fail on path traversal")
+		assert.Contains(t, err.Error(), "illegal file path", "Error message should indicate security issue")
+
+		// Ensure the malicious file was not created outside the destination
+		evilPath := filepath.Join(destDir, "../../evil.txt")
+		_, err = os.Stat(evilPath)
+		assert.True(t, os.IsNotExist(err), "Malicious file should not be created")
+	})
+
+	// 3. Test when the tar file does not exist
+	t.Run("tar file does not exist", func(t *testing.T) {
+		err := Untar("/path/to/nonexistent/file.tar.gz", t.TempDir())
+		assert.Error(t, err, "Untar should fail if source file does not exist")
+	})
+
+	// 4. Test invalid tar file format
+	t.Run("invalid tar file format", func(t *testing.T) {
+		// Create a plain text file, not a tar.gz
+		invalidFile := filepath.Join(t.TempDir(), "invalid.txt")
+		err := os.WriteFile(invalidFile, []byte("this is not a tar.gz file"), 0644)
+		assert.NoError(t, err)
+
+		err = Untar(invalidFile, t.TempDir())
+		assert.Error(t, err, "Untar should fail for invalid file format")
+		assert.Contains(t, err.Error(), "gzip: invalid header")
+	})
 }

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -333,6 +333,14 @@ func (j *testData) YurtHubImage() string {
 	return ""
 }
 
+func (j *testData) YurtHubBinaryUrl() string {
+	return ""
+}
+
+func (j *testData) HostControlPlaneAddr() string {
+	return ""
+}
+
 func (j *testData) YurtHubServer() string {
 	return ""
 }


### PR DESCRIPTION
#### What type of PR is this?
> /kind feature

#### What this PR does / why we need it:
we can use yurtadm to join a node in K8s-on-K8s cluster by:

`./yurtadm join <YOUR-TENANT-APISERVER-SERVICE-ADDRESS> --node-type=local --yurthub-binary-url=<YOUR-YURTHUB-BINARY-URL> --host-control-plane-addr=<YOUR-HOST-K8S-APISERVER-ADDRESS> --token=<BOOTSTRAP-TOKEN> --discovery-token-unsafe-skip-ca-verification --v=5`

in which 10.96.100.1:6443 is service address for tenant-K8s's apiservers, used for loadbalancing.

#### Relavant PRs:
#2124 
#2157 
#2452 
#2454 