### PR TITLE
fix logic error: SetDiscoveryConfig should be called in both local mode and non-local mode

### DIFF
--- a/pkg/yurtadm/cmd/join/phases/prepare.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare.go
@@ -29,65 +29,174 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
 
+// SystemManager abstracts all system-level operations and external dependencies
+type SystemManager interface {
+	// File system operations
+	RemoveAll(path string) error
+
+	// System configuration operations
+	SetIpv4Forward() error
+	SetBridgeSetting() error
+	SetSELinux() error
+
+	// Kubernetes component operations
+	CheckAndInstallKubelet(server, version string) error
+	CheckAndInstallKubeadm(server, version string) error
+	CheckAndInstallKubernetesCni(reuseCNIBin bool) error
+	SetKubeletService() error
+	EnableKubeletService() error
+	SetKubeletUnitConfig(data joindata.YurtJoinData) error
+	SetKubeletConfigForNode() error
+	SetDiscoveryConfig(data joindata.YurtJoinData) error
+	SetKubeadmJoinConfig(data joindata.YurtJoinData) error
+
+	// YurtHub operations
+	SetHubBootstrapConfig(serverAddr, joinToken string, caCertHashes []string) error
+	CheckAndInstallYurthub(version string) error
+	CreateYurthubSystemdService(data joindata.YurtJoinData) error
+}
+
+// ProductionSystemManager is the production implementation of SystemManager
+type ProductionSystemManager struct{}
+
+// NewProductionSystemManager creates a new production system manager
+func NewProductionSystemManager() SystemManager {
+	return &ProductionSystemManager{}
+}
+
+// File system operations
+func (p *ProductionSystemManager) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+// System configuration operations
+func (p *ProductionSystemManager) SetIpv4Forward() error {
+	return system.SetIpv4Forward()
+}
+
+func (p *ProductionSystemManager) SetBridgeSetting() error {
+	return system.SetBridgeSetting()
+}
+
+func (p *ProductionSystemManager) SetSELinux() error {
+	return system.SetSELinux()
+}
+
+// Kubernetes component operations
+func (p *ProductionSystemManager) CheckAndInstallKubelet(server, version string) error {
+	return yurtadmutil.CheckAndInstallKubelet(server, version)
+}
+
+func (p *ProductionSystemManager) CheckAndInstallKubeadm(server, version string) error {
+	return yurtadmutil.CheckAndInstallKubeadm(server, version)
+}
+
+func (p *ProductionSystemManager) CheckAndInstallKubernetesCni(reuseCNIBin bool) error {
+	return yurtadmutil.CheckAndInstallKubernetesCni(reuseCNIBin)
+}
+
+func (p *ProductionSystemManager) SetKubeletService() error {
+	return yurtadmutil.SetKubeletService()
+}
+
+func (p *ProductionSystemManager) EnableKubeletService() error {
+	return yurtadmutil.EnableKubeletService()
+}
+
+func (p *ProductionSystemManager) SetKubeletUnitConfig(data joindata.YurtJoinData) error {
+	return yurtadmutil.SetKubeletUnitConfig(data)
+}
+
+func (p *ProductionSystemManager) SetKubeletConfigForNode() error {
+	return yurtadmutil.SetKubeletConfigForNode()
+}
+
+func (p *ProductionSystemManager) SetDiscoveryConfig(data joindata.YurtJoinData) error {
+	return yurtadmutil.SetDiscoveryConfig(data)
+}
+
+func (p *ProductionSystemManager) SetKubeadmJoinConfig(data joindata.YurtJoinData) error {
+	return yurtadmutil.SetKubeadmJoinConfig(data)
+}
+
+// YurtHub operations
+func (p *ProductionSystemManager) SetHubBootstrapConfig(serverAddr, joinToken string, caCertHashes []string) error {
+	return yurthub.SetHubBootstrapConfig(serverAddr, joinToken, caCertHashes)
+}
+
+func (p *ProductionSystemManager) CheckAndInstallYurthub(version string) error {
+	return yurthub.CheckAndInstallYurthub(version)
+}
+
+func (p *ProductionSystemManager) CreateYurthubSystemdService(data joindata.YurtJoinData) error {
+	return yurthub.CreateYurthubSystemdService(data)
+}
+
 // RunPrepare executes the node initialization process.
+// Maintains the original function signature, uses the new interface internally
 func RunPrepare(data joindata.YurtJoinData) error {
+	return RunPrepareWithManager(data, NewProductionSystemManager())
+}
+
+// RunPrepareWithManager executes the node initialization process using the specified SystemManager
+func RunPrepareWithManager(data joindata.YurtJoinData, manager SystemManager) error {
 	// cleanup at first
 	if data.NodeRegistration().WorkingMode != constants.LocalNode {
 		staticPodsPath := filepath.Join(constants.KubeletConfigureDir, constants.ManifestsSubDirName)
-		if err := os.RemoveAll(staticPodsPath); err != nil {
+		if err := manager.RemoveAll(staticPodsPath); err != nil {
 			klog.Warningf("remove %s: %v", staticPodsPath, err)
 		}
 	}
 
-	if err := system.SetIpv4Forward(); err != nil {
+	if err := manager.SetIpv4Forward(); err != nil {
 		return err
 	}
-	if err := system.SetBridgeSetting(); err != nil {
+	if err := manager.SetBridgeSetting(); err != nil {
 		return err
 	}
-	if err := system.SetSELinux(); err != nil {
+	if err := manager.SetSELinux(); err != nil {
 		return err
 	}
-	if err := yurtadmutil.CheckAndInstallKubelet(data.KubernetesResourceServer(), data.KubernetesVersion()); err != nil {
+	if err := manager.CheckAndInstallKubelet(data.KubernetesResourceServer(), data.KubernetesVersion()); err != nil {
 		return err
 	}
-	if err := yurtadmutil.CheckAndInstallKubeadm(data.KubernetesResourceServer(), data.KubernetesVersion()); err != nil {
+	if err := manager.CheckAndInstallKubeadm(data.KubernetesResourceServer(), data.KubernetesVersion()); err != nil {
 		return err
 	}
 	if data.NodeRegistration().WorkingMode != constants.LocalNode {
-		if err := yurtadmutil.CheckAndInstallKubernetesCni(data.ReuseCNIBin()); err != nil {
+		if err := manager.CheckAndInstallKubernetesCni(data.ReuseCNIBin()); err != nil {
 			return err
 		}
 	}
-	if err := yurtadmutil.SetKubeletService(); err != nil {
+	if err := manager.SetKubeletService(); err != nil {
 		return err
 	}
-	if err := yurtadmutil.EnableKubeletService(); err != nil {
+	if err := manager.EnableKubeletService(); err != nil {
 		return err
 	}
-	if err := yurtadmutil.SetKubeletUnitConfig(data); err != nil {
+	if err := manager.SetKubeletUnitConfig(data); err != nil {
 		return err
 	}
 
 	if data.NodeRegistration().WorkingMode != constants.LocalNode {
-		if err := yurtadmutil.SetKubeletConfigForNode(); err != nil {
+		if err := manager.SetKubeletConfigForNode(); err != nil {
 			return err
 		}
-		if err := yurthub.SetHubBootstrapConfig(data.ServerAddr(), data.JoinToken(), data.CaCertHashes()); err != nil {
+		if err := manager.SetHubBootstrapConfig(data.ServerAddr(), data.JoinToken(), data.CaCertHashes()); err != nil {
 			return err
 		}
-		if err := yurthub.CheckAndInstallYurthub(constants.YurthubVersion); err != nil {
+		if err := manager.CheckAndInstallYurthub(constants.YurthubVersion); err != nil {
 			return err
 		}
-		if err := yurthub.CreateYurthubSystemdService(data); err != nil {
+		if err := manager.CreateYurthubSystemdService(data); err != nil {
 			return err
 		}
 	}
-	if err := yurtadmutil.SetDiscoveryConfig(data); err != nil {
+	if err := manager.SetDiscoveryConfig(data); err != nil {
 		return err
 	}
 	if data.CfgPath() == "" {
-		if err := yurtadmutil.SetKubeadmJoinConfig(data); err != nil {
+		if err := manager.SetKubeadmJoinConfig(data); err != nil {
 			return err
 		}
 	}

--- a/pkg/yurtadm/cmd/join/phases/prepare_test.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare_test.go
@@ -1,0 +1,1201 @@
+/*
+Copyright 2025 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
+)
+
+// MockYurtJoinData implements YurtJoinData interface for testing
+type MockYurtJoinData struct {
+	cfgPath                  string
+	serverAddr               string
+	joinToken                string
+	pauseImage               string
+	yurtHubImage             string
+	yurtHubBinaryUrl         string
+	hostControlPlaneAddr     string
+	yurtHubServer            string
+	yurtHubTemplate          string
+	yurtHubManifest          string
+	kubernetesVersion        string
+	tlsBootstrapCfg          *clientcmdapi.Config
+	bootstrapClient          *clientset.Clientset
+	nodeRegistration         *joindata.NodeRegistration
+	caCertHashes             []string
+	nodeLabels               map[string]string
+	ignorePreflightErrors    sets.Set[string]
+	kubernetesResourceServer string
+	reuseCNIBin              bool
+	namespace                string
+	staticPodTemplateList    []string
+	staticPodManifestList    []string
+}
+
+func (m *MockYurtJoinData) CfgPath() string                              { return m.cfgPath }
+func (m *MockYurtJoinData) ServerAddr() string                           { return m.serverAddr }
+func (m *MockYurtJoinData) JoinToken() string                            { return m.joinToken }
+func (m *MockYurtJoinData) PauseImage() string                           { return m.pauseImage }
+func (m *MockYurtJoinData) YurtHubImage() string                         { return m.yurtHubImage }
+func (m *MockYurtJoinData) YurtHubBinaryUrl() string                     { return m.yurtHubBinaryUrl }
+func (m *MockYurtJoinData) HostControlPlaneAddr() string                 { return m.hostControlPlaneAddr }
+func (m *MockYurtJoinData) YurtHubServer() string                        { return m.yurtHubServer }
+func (m *MockYurtJoinData) YurtHubTemplate() string                      { return m.yurtHubTemplate }
+func (m *MockYurtJoinData) YurtHubManifest() string                      { return m.yurtHubManifest }
+func (m *MockYurtJoinData) KubernetesVersion() string                    { return m.kubernetesVersion }
+func (m *MockYurtJoinData) TLSBootstrapCfg() *clientcmdapi.Config        { return m.tlsBootstrapCfg }
+func (m *MockYurtJoinData) BootstrapClient() *clientset.Clientset        { return m.bootstrapClient }
+func (m *MockYurtJoinData) NodeRegistration() *joindata.NodeRegistration { return m.nodeRegistration }
+func (m *MockYurtJoinData) CaCertHashes() []string                       { return m.caCertHashes }
+func (m *MockYurtJoinData) NodeLabels() map[string]string                { return m.nodeLabels }
+func (m *MockYurtJoinData) IgnorePreflightErrors() sets.Set[string]      { return m.ignorePreflightErrors }
+func (m *MockYurtJoinData) KubernetesResourceServer() string             { return m.kubernetesResourceServer }
+func (m *MockYurtJoinData) ReuseCNIBin() bool                            { return m.reuseCNIBin }
+func (m *MockYurtJoinData) Namespace() string                            { return m.namespace }
+func (m *MockYurtJoinData) StaticPodTemplateList() []string              { return m.staticPodTemplateList }
+func (m *MockYurtJoinData) StaticPodManifestList() []string              { return m.staticPodManifestList }
+
+// MockSystemManager is the test implementation of SystemManager
+type MockSystemManager struct {
+	// Behavior control flags
+	ShouldFailOnRemoveAll                    bool
+	ShouldFailOnSetIpv4Forward               bool
+	ShouldFailOnSetBridgeSetting             bool
+	ShouldFailOnSetSELinux                   bool
+	ShouldFailOnCheckAndInstallKubelet       bool
+	ShouldFailOnCheckAndInstallKubeadm       bool
+	ShouldFailOnCheckAndInstallKubernetesCni bool
+	ShouldFailOnSetKubeletService            bool
+	ShouldFailOnEnableKubeletService         bool
+	ShouldFailOnSetKubeletUnitConfig         bool
+	ShouldFailOnSetKubeletConfigForNode      bool
+	ShouldFailOnSetDiscoveryConfig           bool
+	ShouldFailOnSetKubeadmJoinConfig         bool
+	ShouldFailOnSetHubBootstrapConfig        bool
+	ShouldFailOnCheckAndInstallYurthub       bool
+	ShouldFailOnCreateYurthubSystemdService  bool
+
+	// Call counters and parameter records
+	CallCounts                        map[string]int
+	RemoveAllPaths                    []string
+	CheckAndInstallKubeletCalls       []KubeletCall
+	CheckAndInstallKubeadmCalls       []KubeadmCall
+	CheckAndInstallKubernetesCniCalls []bool
+	SetKubeletUnitConfigCalls         []joindata.YurtJoinData
+	SetKubeletConfigForNodeCalls      []bool
+	SetDiscoveryConfigCalls           []joindata.YurtJoinData
+	SetKubeadmJoinConfigCalls         []joindata.YurtJoinData
+	SetHubBootstrapConfigCalls        []HubBootstrapCall
+	CheckAndInstallYurthubCalls       []string
+	CreateYurthubSystemdServiceCalls  []joindata.YurtJoinData
+}
+
+// KubeletCall records CheckAndInstallKubelet call parameters
+type KubeletCall struct {
+	Server  string
+	Version string
+}
+
+// KubeadmCall records CheckAndInstallKubeadm call parameters
+type KubeadmCall struct {
+	Server  string
+	Version string
+}
+
+// HubBootstrapCall records SetHubBootstrapConfig call parameters
+type HubBootstrapCall struct {
+	ServerAddr   string
+	JoinToken    string
+	CaCertHashes []string
+}
+
+// NewMockSystemManager creates a new mock system manager
+func NewMockSystemManager() *MockSystemManager {
+	return &MockSystemManager{
+		CallCounts: make(map[string]int),
+	}
+}
+
+// File system operations
+func (m *MockSystemManager) RemoveAll(path string) error {
+	m.CallCounts["RemoveAll"]++
+	m.RemoveAllPaths = append(m.RemoveAllPaths, path)
+
+	if m.ShouldFailOnRemoveAll {
+		return fmt.Errorf("mock RemoveAll failed")
+	}
+	return nil
+}
+
+// System configuration operations
+func (m *MockSystemManager) SetIpv4Forward() error {
+	m.CallCounts["SetIpv4Forward"]++
+
+	if m.ShouldFailOnSetIpv4Forward {
+		return fmt.Errorf("mock SetIpv4Forward failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) SetBridgeSetting() error {
+	m.CallCounts["SetBridgeSetting"]++
+
+	if m.ShouldFailOnSetBridgeSetting {
+		return fmt.Errorf("mock SetBridgeSetting failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) SetSELinux() error {
+	m.CallCounts["SetSELinux"]++
+
+	if m.ShouldFailOnSetSELinux {
+		return fmt.Errorf("mock SetSELinux failed")
+	}
+	return nil
+}
+
+// Kubernetes component operations
+func (m *MockSystemManager) CheckAndInstallKubelet(server, version string) error {
+	m.CallCounts["CheckAndInstallKubelet"]++
+	m.CheckAndInstallKubeletCalls = append(m.CheckAndInstallKubeletCalls, KubeletCall{Server: server, Version: version})
+
+	if m.ShouldFailOnCheckAndInstallKubelet {
+		return fmt.Errorf("mock CheckAndInstallKubelet failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) CheckAndInstallKubeadm(server, version string) error {
+	m.CallCounts["CheckAndInstallKubeadm"]++
+	m.CheckAndInstallKubeadmCalls = append(m.CheckAndInstallKubeadmCalls, KubeadmCall{Server: server, Version: version})
+
+	if m.ShouldFailOnCheckAndInstallKubeadm {
+		return fmt.Errorf("mock CheckAndInstallKubeadm failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) CheckAndInstallKubernetesCni(reuseCNIBin bool) error {
+	m.CallCounts["CheckAndInstallKubernetesCni"]++
+	m.CheckAndInstallKubernetesCniCalls = append(m.CheckAndInstallKubernetesCniCalls, reuseCNIBin)
+
+	if m.ShouldFailOnCheckAndInstallKubernetesCni {
+		return fmt.Errorf("mock CheckAndInstallKubernetesCni failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) SetKubeletService() error {
+	m.CallCounts["SetKubeletService"]++
+
+	if m.ShouldFailOnSetKubeletService {
+		return fmt.Errorf("mock SetKubeletService failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) EnableKubeletService() error {
+	m.CallCounts["EnableKubeletService"]++
+
+	if m.ShouldFailOnEnableKubeletService {
+		return fmt.Errorf("mock EnableKubeletService failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) SetKubeletUnitConfig(data joindata.YurtJoinData) error {
+	m.CallCounts["SetKubeletUnitConfig"]++
+	m.SetKubeletUnitConfigCalls = append(m.SetKubeletUnitConfigCalls, data)
+
+	if m.ShouldFailOnSetKubeletUnitConfig {
+		return fmt.Errorf("mock SetKubeletUnitConfig failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) SetKubeletConfigForNode() error {
+	m.CallCounts["SetKubeletConfigForNode"]++
+	m.SetKubeletConfigForNodeCalls = append(m.SetKubeletConfigForNodeCalls, true)
+
+	if m.ShouldFailOnSetKubeletConfigForNode {
+		return fmt.Errorf("mock SetKubeletConfigForNode failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) SetDiscoveryConfig(data joindata.YurtJoinData) error {
+	m.CallCounts["SetDiscoveryConfig"]++
+	m.SetDiscoveryConfigCalls = append(m.SetDiscoveryConfigCalls, data)
+
+	if m.ShouldFailOnSetDiscoveryConfig {
+		return fmt.Errorf("mock SetDiscoveryConfig failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) SetKubeadmJoinConfig(data joindata.YurtJoinData) error {
+	m.CallCounts["SetKubeadmJoinConfig"]++
+	m.SetKubeadmJoinConfigCalls = append(m.SetKubeadmJoinConfigCalls, data)
+
+	if m.ShouldFailOnSetKubeadmJoinConfig {
+		return fmt.Errorf("mock SetKubeadmJoinConfig failed")
+	}
+	return nil
+}
+
+// YurtHub operations
+func (m *MockSystemManager) SetHubBootstrapConfig(serverAddr, joinToken string, caCertHashes []string) error {
+	m.CallCounts["SetHubBootstrapConfig"]++
+	m.SetHubBootstrapConfigCalls = append(m.SetHubBootstrapConfigCalls, HubBootstrapCall{
+		ServerAddr:   serverAddr,
+		JoinToken:    joinToken,
+		CaCertHashes: caCertHashes,
+	})
+
+	if m.ShouldFailOnSetHubBootstrapConfig {
+		return fmt.Errorf("mock SetHubBootstrapConfig failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) CheckAndInstallYurthub(version string) error {
+	m.CallCounts["CheckAndInstallYurthub"]++
+	m.CheckAndInstallYurthubCalls = append(m.CheckAndInstallYurthubCalls, version)
+
+	if m.ShouldFailOnCheckAndInstallYurthub {
+		return fmt.Errorf("mock CheckAndInstallYurthub failed")
+	}
+	return nil
+}
+
+func (m *MockSystemManager) CreateYurthubSystemdService(data joindata.YurtJoinData) error {
+	m.CallCounts["CreateYurthubSystemdService"]++
+	m.CreateYurthubSystemdServiceCalls = append(m.CreateYurthubSystemdServiceCalls, data)
+
+	if m.ShouldFailOnCreateYurthubSystemdService {
+		return fmt.Errorf("mock CreateYurthubSystemdService failed")
+	}
+	return nil
+}
+
+// Reset resets the mock state
+func (m *MockSystemManager) Reset() {
+	m.CallCounts = make(map[string]int)
+	m.RemoveAllPaths = []string{}
+	m.CheckAndInstallKubeletCalls = []KubeletCall{}
+	m.CheckAndInstallKubeadmCalls = []KubeadmCall{}
+	m.CheckAndInstallKubernetesCniCalls = []bool{}
+	m.SetKubeletUnitConfigCalls = []joindata.YurtJoinData{}
+	m.SetKubeletConfigForNodeCalls = []bool{}
+	m.SetDiscoveryConfigCalls = []joindata.YurtJoinData{}
+	m.SetKubeadmJoinConfigCalls = []joindata.YurtJoinData{}
+	m.SetHubBootstrapConfigCalls = []HubBootstrapCall{}
+	m.CheckAndInstallYurthubCalls = []string{}
+	m.CreateYurthubSystemdServiceCalls = []joindata.YurtJoinData{}
+
+	// Reset failure flags
+	m.ShouldFailOnRemoveAll = false
+	m.ShouldFailOnSetIpv4Forward = false
+	m.ShouldFailOnSetBridgeSetting = false
+	m.ShouldFailOnSetSELinux = false
+	m.ShouldFailOnCheckAndInstallKubelet = false
+	m.ShouldFailOnCheckAndInstallKubeadm = false
+	m.ShouldFailOnCheckAndInstallKubernetesCni = false
+	m.ShouldFailOnSetKubeletService = false
+	m.ShouldFailOnEnableKubeletService = false
+	m.ShouldFailOnSetKubeletUnitConfig = false
+	m.ShouldFailOnSetKubeletConfigForNode = false
+	m.ShouldFailOnSetDiscoveryConfig = false
+	m.ShouldFailOnSetKubeadmJoinConfig = false
+	m.ShouldFailOnSetHubBootstrapConfig = false
+	m.ShouldFailOnCheckAndInstallYurthub = false
+	m.ShouldFailOnCreateYurthubSystemdService = false
+}
+
+// TestRunPrepareWithManager_LocalNodeMode tests the LocalNode mode where certain operations should be skipped
+func TestRunPrepareWithManager_LocalNodeMode(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.LocalNode,
+		},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		cfgPath:                  "",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify operations that should not be executed in LocalNode mode
+	assert.Equal(t, 0, mockManager.CallCounts["CheckAndInstallKubernetesCni"])
+	assert.Equal(t, 0, mockManager.CallCounts["SetKubeletConfigForNode"])
+	assert.Equal(t, 0, mockManager.CallCounts["SetHubBootstrapConfig"])
+	assert.Equal(t, 0, mockManager.CallCounts["CheckAndInstallYurthub"])
+	assert.Equal(t, 0, mockManager.CallCounts["CreateYurthubSystemdService"])
+	assert.Equal(t, 0, mockManager.CallCounts["RemoveAll"])
+
+	// Verify operations that should be executed in LocalNode mode
+	assert.Equal(t, 1, mockManager.CallCounts["SetIpv4Forward"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetBridgeSetting"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetSELinux"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubelet"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubeadm"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeletService"])
+	assert.Equal(t, 1, mockManager.CallCounts["EnableKubeletService"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeletUnitConfig"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetDiscoveryConfig"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeadmJoinConfig"]) // Should execute when cfgPath is empty
+}
+
+// TestRunPrepareWithManager_EdgeNodeMode tests the EdgeNode mode where all operations should be executed
+func TestRunPrepareWithManager_EdgeNodeMode(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode,
+		},
+		serverAddr:               "https://127.0.0.1:6443",
+		joinToken:                "abcdef.0123456789abcdef",
+		caCertHashes:             []string{"sha256:1234567890abcdef"},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		reuseCNIBin:              false,
+		cfgPath:                  "",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify all operations that should be executed in EdgeNode mode
+	assert.Equal(t, 1, mockManager.CallCounts["RemoveAll"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetIpv4Forward"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetBridgeSetting"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetSELinux"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubelet"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubeadm"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubernetesCni"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeletService"])
+	assert.Equal(t, 1, mockManager.CallCounts["EnableKubeletService"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeletUnitConfig"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeletConfigForNode"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetHubBootstrapConfig"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallYurthub"])
+	assert.Equal(t, 1, mockManager.CallCounts["CreateYurthubSystemdService"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetDiscoveryConfig"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeadmJoinConfig"]) // Should execute when cfgPath is empty
+
+	// Verify parameter passing correctness
+	assert.Equal(t, 1, len(mockManager.RemoveAllPaths))
+	assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeletCalls))
+	assert.Equal(t, "dl.k8s.io", mockManager.CheckAndInstallKubeletCalls[0].Server)
+	assert.Equal(t, "v1.20.0", mockManager.CheckAndInstallKubeletCalls[0].Version)
+	assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeadmCalls))
+	assert.Equal(t, "dl.k8s.io", mockManager.CheckAndInstallKubeadmCalls[0].Server)
+	assert.Equal(t, "v1.20.0", mockManager.CheckAndInstallKubeadmCalls[0].Version)
+	assert.Equal(t, 1, len(mockManager.CheckAndInstallKubernetesCniCalls))
+	assert.Equal(t, false, mockManager.CheckAndInstallKubernetesCniCalls[0])
+	assert.Equal(t, 1, len(mockManager.SetHubBootstrapConfigCalls))
+	assert.Equal(t, "https://127.0.0.1:6443", mockManager.SetHubBootstrapConfigCalls[0].ServerAddr)
+	assert.Equal(t, "abcdef.0123456789abcdef", mockManager.SetHubBootstrapConfigCalls[0].JoinToken)
+	assert.Equal(t, []string{"sha256:1234567890abcdef"}, mockManager.SetHubBootstrapConfigCalls[0].CaCertHashes)
+}
+
+// TestRunPrepareWithManager_WithCfgPath tests the case where cfgPath is set (should skip SetKubeadmJoinConfig)
+func TestRunPrepareWithManager_WithCfgPath(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.LocalNode,
+		},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		cfgPath:                  "/path/to/config",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify that SetKubeadmJoinConfig should not be called when cfgPath is not empty
+	assert.Equal(t, 0, mockManager.CallCounts["SetKubeadmJoinConfig"])
+
+	// Verify other operations execute normally
+	assert.Equal(t, 1, mockManager.CallCounts["SetDiscoveryConfig"])
+}
+
+// TestRunPrepareWithManager_ErrorCases tests various error scenarios
+func TestRunPrepareWithManager_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		setFailure    func(*MockSystemManager)
+		expectedError string
+	}{
+		{
+			name: "SetIpv4Forward fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetIpv4Forward = true
+			},
+			expectedError: "mock SetIpv4Forward failed",
+		},
+		{
+			name: "SetBridgeSetting fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetBridgeSetting = true
+			},
+			expectedError: "mock SetBridgeSetting failed",
+		},
+		{
+			name: "SetSELinux fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetSELinux = true
+			},
+			expectedError: "mock SetSELinux failed",
+		},
+		{
+			name: "CheckAndInstallKubelet fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnCheckAndInstallKubelet = true
+			},
+			expectedError: "mock CheckAndInstallKubelet failed",
+		},
+		{
+			name: "CheckAndInstallKubeadm fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnCheckAndInstallKubeadm = true
+			},
+			expectedError: "mock CheckAndInstallKubeadm failed",
+		},
+		{
+			name: "SetKubeletService fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetKubeletService = true
+			},
+			expectedError: "mock SetKubeletService failed",
+		},
+		{
+			name: "EnableKubeletService fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnEnableKubeletService = true
+			},
+			expectedError: "mock EnableKubeletService failed",
+		},
+		{
+			name: "SetKubeletUnitConfig fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetKubeletUnitConfig = true
+			},
+			expectedError: "mock SetKubeletUnitConfig failed",
+		},
+		{
+			name: "SetDiscoveryConfig fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetDiscoveryConfig = true
+			},
+			expectedError: "mock SetDiscoveryConfig failed",
+		},
+		{
+			name: "SetKubeadmJoinConfig fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetKubeadmJoinConfig = true
+			},
+			expectedError: "mock SetKubeadmJoinConfig failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := NewMockSystemManager()
+			tt.setFailure(mockManager)
+
+			data := &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.LocalNode,
+				},
+				kubernetesVersion:        "v1.20.0",
+				kubernetesResourceServer: "dl.k8s.io",
+				cfgPath:                  "",
+			}
+
+			err := RunPrepareWithManager(data, mockManager)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+// TestRunPrepareWithManager_EdgeNodeErrorCases tests error scenarios for EdgeNode mode
+func TestRunPrepareWithManager_EdgeNodeErrorCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		setFailure    func(*MockSystemManager)
+		expectedError string
+	}{
+		{
+			name: "CheckAndInstallKubernetesCni fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnCheckAndInstallKubernetesCni = true
+			},
+			expectedError: "mock CheckAndInstallKubernetesCni failed",
+		},
+		{
+			name: "SetKubeletConfigForNode fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetKubeletConfigForNode = true
+			},
+			expectedError: "mock SetKubeletConfigForNode failed",
+		},
+		{
+			name: "SetHubBootstrapConfig fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnSetHubBootstrapConfig = true
+			},
+			expectedError: "mock SetHubBootstrapConfig failed",
+		},
+		{
+			name: "CheckAndInstallYurthub fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnCheckAndInstallYurthub = true
+			},
+			expectedError: "mock CheckAndInstallYurthub failed",
+		},
+		{
+			name: "CreateYurthubSystemdService fails",
+			setFailure: func(m *MockSystemManager) {
+				m.ShouldFailOnCreateYurthubSystemdService = true
+			},
+			expectedError: "mock CreateYurthubSystemdService failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := NewMockSystemManager()
+			tt.setFailure(mockManager)
+
+			data := &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.EdgeNode,
+				},
+				serverAddr:               "https://127.0.0.1:6443",
+				joinToken:                "abcdef.0123456789abcdef",
+				caCertHashes:             []string{"sha256:1234567890abcdef"},
+				kubernetesVersion:        "v1.20.0",
+				kubernetesResourceServer: "dl.k8s.io",
+				reuseCNIBin:              false,
+				cfgPath:                  "",
+			}
+
+			err := RunPrepareWithManager(data, mockManager)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+// TestRunPrepareWithManager_BoundaryConditions tests boundary conditions
+func TestRunPrepareWithManager_BoundaryConditions(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      *MockYurtJoinData
+		setupMock func(*MockSystemManager)
+	}{
+		{
+			name: "EdgeNode with reuseCNIBin=true",
+			data: &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.EdgeNode,
+				},
+				serverAddr:               "https://127.0.0.1:6443",
+				joinToken:                "abcdef.0123456789abcdef",
+				caCertHashes:             []string{"sha256:1234567890abcdef"},
+				kubernetesVersion:        "v1.20.0",
+				kubernetesResourceServer: "dl.k8s.io",
+				reuseCNIBin:              true, // Test case with reuseCNIBin = true
+				cfgPath:                  "",
+			},
+		},
+		{
+			name: "LocalNode with non-empty cfgPath",
+			data: &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.LocalNode,
+				},
+				kubernetesVersion:        "v1.20.0",
+				kubernetesResourceServer: "dl.k8s.io",
+				cfgPath:                  "/path/to/config", // Test case with non-empty cfgPath
+			},
+		},
+		{
+			name: "EdgeNode with non-empty cfgPath",
+			data: &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.EdgeNode,
+				},
+				serverAddr:               "https://127.0.0.1:6443",
+				joinToken:                "abcdef.0123456789abcdef",
+				caCertHashes:             []string{"sha256:1234567890abcdef"},
+				kubernetesVersion:        "v1.20.0",
+				kubernetesResourceServer: "dl.k8s.io",
+				reuseCNIBin:              true,
+				cfgPath:                  "/path/to/config", // Test case with non-empty cfgPath
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := NewMockSystemManager()
+			if tt.setupMock != nil {
+				tt.setupMock(mockManager)
+			}
+
+			err := RunPrepareWithManager(tt.data, mockManager)
+			assert.NoError(t, err)
+
+			// Verify reuseCNIBin parameter is passed correctly
+			if tt.data.reuseCNIBin {
+				assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubernetesCni"])
+				assert.Equal(t, 1, len(mockManager.CheckAndInstallKubernetesCniCalls))
+				assert.Equal(t, true, mockManager.CheckAndInstallKubernetesCniCalls[0])
+			}
+
+			// Verify cfgPath parameter is handled correctly
+			if tt.data.CfgPath() != "" {
+				assert.Equal(t, 0, mockManager.CallCounts["SetKubeadmJoinConfig"])
+			} else {
+				assert.Equal(t, 1, mockManager.CallCounts["SetKubeadmJoinConfig"])
+			}
+		})
+	}
+}
+
+// TestRunPrepare_Integration tests the original RunPrepare function with production manager
+func TestRunPrepare_Integration(t *testing.T) {
+	// This test verifies the integration of the original RunPrepare function with ProductionSystemManager
+	// Note: This test may fail because it attempts to execute real system operations
+	// In a real environment, this test may need to be skipped or use a special environment
+
+	t.Skip("Skipping integration test that requires real system operations")
+
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.LocalNode,
+		},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		cfgPath:                  "",
+	}
+
+	// This call will use ProductionSystemManager
+	err := RunPrepare(data)
+	// In a real environment, this may fail, but we can verify that the function can be called normally
+	// In CI/CD environments, this test should be skipped
+	_ = err
+}
+
+// TestRunPrepare tests the RunPrepare function with mock system manager
+func TestRunPrepare(t *testing.T) {
+	// Test that RunPrepare correctly creates and uses ProductionSystemManager
+	// We'll use a mock approach by testing the function flow
+	mockManager := NewMockSystemManager()
+
+	// Create a test data
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.LocalNode,
+		},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		cfgPath:                  "",
+	}
+
+	// Test with a custom manager to verify the function works correctly
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify all expected operations were called
+	assert.Equal(t, 1, mockManager.CallCounts["SetIpv4Forward"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetBridgeSetting"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetSELinux"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubelet"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubeadm"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeletService"])
+	assert.Equal(t, 1, mockManager.CallCounts["EnableKubeletService"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeletUnitConfig"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetDiscoveryConfig"])
+	assert.Equal(t, 1, mockManager.CallCounts["SetKubeadmJoinConfig"])
+}
+
+// TestProductionSystemManager tests the ProductionSystemManager implementation
+func TestProductionSystemManager(t *testing.T) {
+	manager := NewProductionSystemManager()
+
+	// Verify it returns the correct type
+	_, ok := manager.(*ProductionSystemManager)
+	assert.True(t, ok, "NewProductionSystemManager should return *ProductionSystemManager")
+}
+
+// TestRunPrepareWithManager_RemoveAllWarning tests the warning case when RemoveAll fails
+func TestRunPrepareWithManager_RemoveAllWarning(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode, // Not LocalNode, so RemoveAll will be called
+		},
+		serverAddr:               "https://127.0.0.1:6443",
+		joinToken:                "abcdef.0123456789abcdef",
+		caCertHashes:             []string{"sha256:1234567890abcdef"},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		reuseCNIBin:              false,
+		cfgPath:                  "",
+	}
+
+	// Set RemoveAll to fail, but the function should continue and log a warning
+	mockManager.ShouldFailOnRemoveAll = true
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err) // Should not return error even if RemoveAll fails
+
+	// Verify RemoveAll was called
+	assert.Equal(t, 1, mockManager.CallCounts["RemoveAll"])
+
+	// Verify other operations still executed
+	assert.Equal(t, 1, mockManager.CallCounts["SetIpv4Forward"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubelet"])
+}
+
+// TestRunPrepareWithManager_YurthubVersion tests that YurthubVersion constant is used
+func TestRunPrepareWithManager_YurthubVersion(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode,
+		},
+		serverAddr:               "https://127.0.0.1:6443",
+		joinToken:                "abcdef.0123456789abcdef",
+		caCertHashes:             []string{"sha256:1234567890abcdef"},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		reuseCNIBin:              false,
+		cfgPath:                  "",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify CheckAndInstallYurthub was called
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallYurthub"])
+	assert.Equal(t, 1, len(mockManager.CheckAndInstallYurthubCalls))
+	// The version should be the constant from the package
+	assert.Equal(t, constants.YurthubVersion, mockManager.CheckAndInstallYurthubCalls[0])
+}
+
+// TestRunPrepareWithManager_CompleteFlow tests the complete flow with all parameters
+func TestRunPrepareWithManager_CompleteFlow(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode,
+		},
+		serverAddr:               "https://test-server:6443",
+		joinToken:                "test-token.1234567890abcdef",
+		caCertHashes:             []string{"sha256:abcdef1234567890"},
+		kubernetesVersion:        "v1.28.0",
+		kubernetesResourceServer: "custom.k8s.io",
+		reuseCNIBin:              true,
+		cfgPath:                  "",
+		pauseImage:               "custom-pause:latest",
+		yurtHubImage:             "custom-yurthub:latest",
+		yurtHubBinaryUrl:         "https://custom.url/yurthub",
+		hostControlPlaneAddr:     "https://custom-host:6443",
+		yurtHubServer:            "custom-yurthub-server",
+		yurtHubTemplate:          "custom-template",
+		yurtHubManifest:          "custom-manifest",
+		namespace:                "custom-namespace",
+		staticPodTemplateList:    []string{"template1", "template2"},
+		staticPodManifestList:    []string{"manifest1", "manifest2"},
+		nodeLabels:               map[string]string{"label1": "value1", "label2": "value2"},
+		ignorePreflightErrors:    sets.New[string]("error1", "error2"),
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify all operations were called with correct parameters
+	assert.Equal(t, 1, mockManager.CallCounts["RemoveAll"])
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubelet"])
+	assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeletCalls))
+	assert.Equal(t, "custom.k8s.io", mockManager.CheckAndInstallKubeletCalls[0].Server)
+	assert.Equal(t, "v1.28.0", mockManager.CheckAndInstallKubeletCalls[0].Version)
+
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubeadm"])
+	assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeadmCalls))
+	assert.Equal(t, "custom.k8s.io", mockManager.CheckAndInstallKubeadmCalls[0].Server)
+	assert.Equal(t, "v1.28.0", mockManager.CheckAndInstallKubeadmCalls[0].Version)
+
+	assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubernetesCni"])
+	assert.Equal(t, 1, len(mockManager.CheckAndInstallKubernetesCniCalls))
+	assert.Equal(t, true, mockManager.CheckAndInstallKubernetesCniCalls[0]) // reuseCNIBin = true
+
+	assert.Equal(t, 1, mockManager.CallCounts["SetHubBootstrapConfig"])
+	assert.Equal(t, 1, len(mockManager.SetHubBootstrapConfigCalls))
+	assert.Equal(t, "https://test-server:6443", mockManager.SetHubBootstrapConfigCalls[0].ServerAddr)
+	assert.Equal(t, "test-token.1234567890abcdef", mockManager.SetHubBootstrapConfigCalls[0].JoinToken)
+	assert.Equal(t, []string{"sha256:abcdef1234567890"}, mockManager.SetHubBootstrapConfigCalls[0].CaCertHashes)
+}
+
+// TestRunPrepareWithManager_EmptyCaCertHashes tests with empty caCertHashes
+func TestRunPrepareWithManager_EmptyCaCertHashes(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode,
+		},
+		serverAddr:               "https://127.0.0.1:6443",
+		joinToken:                "abcdef.0123456789abcdef",
+		caCertHashes:             []string{}, // Empty caCertHashes
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		reuseCNIBin:              false,
+		cfgPath:                  "",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify SetHubBootstrapConfig was called with empty caCertHashes
+	assert.Equal(t, 1, mockManager.CallCounts["SetHubBootstrapConfig"])
+	assert.Equal(t, 1, len(mockManager.SetHubBootstrapConfigCalls))
+	assert.Equal(t, []string{}, mockManager.SetHubBootstrapConfigCalls[0].CaCertHashes)
+}
+
+// TestRunPrepareWithManager_NilCaCertHashes tests with nil caCertHashes
+func TestRunPrepareWithManager_NilCaCertHashes(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode,
+		},
+		serverAddr:               "https://127.0.0.1:6443",
+		joinToken:                "abcdef.0123456789abcdef",
+		caCertHashes:             nil, // Nil caCertHashes
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		reuseCNIBin:              false,
+		cfgPath:                  "",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify SetHubBootstrapConfig was called with nil caCertHashes
+	assert.Equal(t, 1, mockManager.CallCounts["SetHubBootstrapConfig"])
+	assert.Equal(t, 1, len(mockManager.SetHubBootstrapConfigCalls))
+	assert.Nil(t, mockManager.SetHubBootstrapConfigCalls[0].CaCertHashes)
+}
+
+// TestRunPrepareWithManager_MultipleCaCertHashes tests with multiple caCertHashes
+func TestRunPrepareWithManager_MultipleCaCertHashes(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode,
+		},
+		serverAddr:               "https://127.0.0.1:6443",
+		joinToken:                "abcdef.0123456789abcdef",
+		caCertHashes:             []string{"sha256:hash1", "sha256:hash2", "sha256:hash3"}, // Multiple hashes
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		reuseCNIBin:              false,
+		cfgPath:                  "",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify SetHubBootstrapConfig was called with multiple caCertHashes
+	assert.Equal(t, 1, mockManager.CallCounts["SetHubBootstrapConfig"])
+	assert.Equal(t, 1, len(mockManager.SetHubBootstrapConfigCalls))
+	assert.Equal(t, []string{"sha256:hash1", "sha256:hash2", "sha256:hash3"}, mockManager.SetHubBootstrapConfigCalls[0].CaCertHashes)
+}
+
+// TestRunPrepareWithManager_SpecialCharactersInToken tests with special characters in join token
+func TestRunPrepareWithManager_SpecialCharactersInToken(t *testing.T) {
+	mockManager := NewMockSystemManager()
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.EdgeNode,
+		},
+		serverAddr:               "https://127.0.0.1:6443",
+		joinToken:                "token.with.special-chars_123.456", // Token with special characters
+		caCertHashes:             []string{"sha256:1234567890abcdef"},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		reuseCNIBin:              false,
+		cfgPath:                  "",
+	}
+
+	err := RunPrepareWithManager(data, mockManager)
+	assert.NoError(t, err)
+
+	// Verify SetHubBootstrapConfig was called with the special character token
+	assert.Equal(t, 1, mockManager.CallCounts["SetHubBootstrapConfig"])
+	assert.Equal(t, 1, len(mockManager.SetHubBootstrapConfigCalls))
+	assert.Equal(t, "token.with.special-chars_123.456", mockManager.SetHubBootstrapConfigCalls[0].JoinToken)
+}
+
+// TestRunPrepareWithManager_DifferentServerAddresses tests with different server address formats
+func TestRunPrepareWithManager_DifferentServerAddresses(t *testing.T) {
+	testCases := []struct {
+		name       string
+		serverAddr string
+	}{
+		{"IPv4 address", "https://192.168.1.100:6443"},
+		{"IPv6 address", "https://[2001:db8::1]:6443"},
+		{"DNS name", "https://kubernetes.example.com:6443"},
+		{"Localhost", "https://localhost:6443"},
+		{"With path", "https://example.com:6443/api"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockManager := NewMockSystemManager()
+			data := &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.EdgeNode,
+				},
+				serverAddr:               tc.serverAddr,
+				joinToken:                "abcdef.0123456789abcdef",
+				caCertHashes:             []string{"sha256:1234567890abcdef"},
+				kubernetesVersion:        "v1.20.0",
+				kubernetesResourceServer: "dl.k8s.io",
+				reuseCNIBin:              false,
+				cfgPath:                  "",
+			}
+
+			err := RunPrepareWithManager(data, mockManager)
+			assert.NoError(t, err)
+
+			// Verify SetHubBootstrapConfig was called with the correct server address
+			assert.Equal(t, 1, mockManager.CallCounts["SetHubBootstrapConfig"])
+			assert.Equal(t, 1, len(mockManager.SetHubBootstrapConfigCalls))
+			assert.Equal(t, tc.serverAddr, mockManager.SetHubBootstrapConfigCalls[0].ServerAddr)
+		})
+	}
+}
+
+// TestRunPrepareWithManager_KubernetesVersionVariants tests different Kubernetes version formats
+func TestRunPrepareWithManager_KubernetesVersionVariants(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{"Standard version", "v1.28.0"},
+		{"With pre-release", "v1.28.0-rc.1"},
+		{"With build info", "v1.28.0+build.123"},
+		{"Older version", "v1.20.0"},
+		{"Newer version", "v1.30.0"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockManager := NewMockSystemManager()
+			data := &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.LocalNode,
+				},
+				kubernetesVersion:        tc.version,
+				kubernetesResourceServer: "dl.k8s.io",
+				cfgPath:                  "",
+			}
+
+			err := RunPrepareWithManager(data, mockManager)
+			assert.NoError(t, err)
+
+			// Verify the version was passed correctly to kubelet and kubeadm
+			assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubelet"])
+			assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeletCalls))
+			assert.Equal(t, tc.version, mockManager.CheckAndInstallKubeletCalls[0].Version)
+
+			assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubeadm"])
+			assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeadmCalls))
+			assert.Equal(t, tc.version, mockManager.CheckAndInstallKubeadmCalls[0].Version)
+		})
+	}
+}
+
+// TestRunPrepareWithManager_ResourceServerVariants tests different resource server URLs
+func TestRunPrepareWithManager_ResourceServerVariants(t *testing.T) {
+	testCases := []struct {
+		name   string
+		server string
+	}{
+		{"Standard K8s", "dl.k8s.io"},
+		{"Custom domain", "custom.registry.io"},
+		{"With protocol", "https://custom.registry.io"},
+		{"With port", "registry.io:443"},
+		{"Local registry", "localhost:5000"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockManager := NewMockSystemManager()
+			data := &MockYurtJoinData{
+				nodeRegistration: &joindata.NodeRegistration{
+					WorkingMode: constants.LocalNode,
+				},
+				kubernetesVersion:        "v1.28.0",
+				kubernetesResourceServer: tc.server,
+				cfgPath:                  "",
+			}
+
+			err := RunPrepareWithManager(data, mockManager)
+			assert.NoError(t, err)
+
+			// Verify the server was passed correctly to kubelet and kubeadm
+			assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubelet"])
+			assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeletCalls))
+			assert.Equal(t, tc.server, mockManager.CheckAndInstallKubeletCalls[0].Server)
+
+			assert.Equal(t, 1, mockManager.CallCounts["CheckAndInstallKubeadm"])
+			assert.Equal(t, 1, len(mockManager.CheckAndInstallKubeadmCalls))
+			assert.Equal(t, tc.server, mockManager.CheckAndInstallKubeadmCalls[0].Server)
+		})
+	}
+}
+
+// TestProductionSystemManager_RemoveAll tests ProductionSystemManager.RemoveAll
+func TestProductionSystemManager_RemoveAll(t *testing.T) {
+	manager := &ProductionSystemManager{}
+
+	// Test with a temporary directory
+	tempDir := t.TempDir()
+	testPath := filepath.Join(tempDir, "test_file")
+
+	// Create a test file
+	err := os.WriteFile(testPath, []byte("test content"), 0644)
+	assert.NoError(t, err)
+
+	// Verify file exists
+	_, err = os.Stat(testPath)
+	assert.NoError(t, err)
+
+	// Remove the file using ProductionSystemManager
+	err = manager.RemoveAll(testPath)
+	assert.NoError(t, err)
+
+	// Verify file is removed
+	_, err = os.Stat(testPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+// TestRunPrepare_RealFunction tests the actual RunPrepare function
+func TestRunPrepare_RealFunction(t *testing.T) {
+	// This test verifies that RunPrepare function works correctly with the production manager
+	// We use LocalNode mode to minimize system operations
+
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.LocalNode, // Use LocalNode to avoid system operations
+		},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		cfgPath:                  "/path/to/config", // Set cfgPath to avoid kubeadm operations
+	}
+
+	// This will use the real ProductionSystemManager but with LocalNode mode
+	// which should avoid most system operations
+	err := RunPrepare(data)
+	// We expect this to fail because it will try to perform real system operations
+	// but we're testing that the function is called correctly
+	_ = err
+}
+
+// TestRunPrepare_IntegrationWithProductionManager tests RunPrepare with production manager
+func TestRunPrepare_IntegrationWithProductionManager(t *testing.T) {
+	// Test that RunPrepare correctly creates and uses ProductionSystemManager
+	// We'll verify the function structure and flow
+
+	data := &MockYurtJoinData{
+		nodeRegistration: &joindata.NodeRegistration{
+			WorkingMode: constants.LocalNode,
+		},
+		kubernetesVersion:        "v1.20.0",
+		kubernetesResourceServer: "dl.k8s.io",
+		cfgPath:                  "/path/to/config",
+	}
+
+	// Test that RunPrepare can be called (it may fail due to system dependencies)
+	// but we're testing the function structure and that it uses NewProductionSystemManager
+	err := RunPrepare(data)
+	// In a test environment, this will likely fail, but we're testing the function call
+	_ = err
+
+	// Verify that NewProductionSystemManager returns the correct type
+	manager := NewProductionSystemManager()
+	_, ok := manager.(*ProductionSystemManager)
+	assert.True(t, ok, "NewProductionSystemManager should return *ProductionSystemManager")
+}
+
+// TestProductionSystemManager_AllMethods tests all methods of ProductionSystemManager
+func TestProductionSystemManager_AllMethods(t *testing.T) {
+	manager := &ProductionSystemManager{}
+
+	// Test that all methods exist and can be called (they will likely fail in test environment)
+	// but we're testing that the methods are properly implemented
+
+	// Test RemoveAll
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test.txt")
+	err := os.WriteFile(testFile, []byte("test"), 0644)
+	assert.NoError(t, err)
+
+	err = manager.RemoveAll(testFile)
+	assert.NoError(t, err)
+
+	// Test that other methods are callable (they may fail due to system dependencies)
+	// We're just verifying the method signatures and basic functionality
+
+	// Test NewProductionSystemManager
+	newManager := NewProductionSystemManager()
+	assert.NotNil(t, newManager)
+	_, ok := newManager.(*ProductionSystemManager)
+	assert.True(t, ok)
+}
+
+// TestProductionSystemManager_Constants tests that constants are properly used
+func TestProductionSystemManager_Constants(t *testing.T) {
+	// This test verifies that the constants are properly defined
+	// and can be used in the context of the ProductionSystemManager
+
+	assert.NotEmpty(t, constants.YurthubVersion)
+	assert.NotEmpty(t, constants.KubeletConfigureDir)
+	assert.NotEmpty(t, constants.ManifestsSubDirName)
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> /kind bug


#### What this PR does / why we need it:
In #2449, SetDiscoveryConfig is modified, in which this function is only called in non-local mode for yurtadm join. as the following figure.

<img width="992" height="370" alt="image" src="https://github.com/user-attachments/assets/e81bcb91-545c-4dd7-825c-4d365b7cdb29" />



However, when use in local mode, yurtadm also need call SetDiscoveryConfig to configure discovery file, then kubeadm-config contains this discovery to perfom joining a node.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2449 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
