### PR TITLE
fix dummy-if name length exceeds 15

### DIFF
--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -112,7 +112,7 @@ func NewYurtHubOptions() *YurtHubOptions {
 		EnableProfiling:           true,
 		EnableDummyIf:             true,
 		EnableIptables:            false,
-		HubAgentDummyIfName:       fmt.Sprintf("%s-dummy0", projectinfo.GetHubName()),
+		HubAgentDummyIfName:       "hub-dummy0",
 		DiskCachePath:             disk.CacheBaseDir,
 		EnableResourceFilter:      true,
 		DisabledResourceFilters:   make([]string, 0),

--- a/cmd/yurthub/app/options/options_test.go
+++ b/cmd/yurthub/app/options/options_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -53,7 +52,7 @@ func TestNewYurtHubOptions(t *testing.T) {
 		EnableProfiling:           true,
 		EnableDummyIf:             true,
 		EnableIptables:            false,
-		HubAgentDummyIfName:       fmt.Sprintf("%s-dummy0", projectinfo.GetHubName()),
+		HubAgentDummyIfName:       "hub-dummy0",
 		DiskCachePath:             disk.CacheBaseDir,
 		EnableResourceFilter:      true,
 		DisabledResourceFilters:   make([]string, 0),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
 /kind flake

modify `HubAgentDummyIfName` default value to avoid  its length exceeds 15 caused by project hub-name too long


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
