### PR TITLE
fix: failed to get nodepool with bootstrap token

### DIFF
--- a/charts/yurthub/templates/yurthub-cfg.yaml
+++ b/charts/yurthub/templates/yurthub-cfg.yaml
@@ -82,6 +82,12 @@ rules:
       - yurt-static-set-yurt-hub-cloud
     verbs:
       - get
+  - apiGroups:
+      - apps.openyurt.io
+    resources:
+      - nodepools
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/yurthub/templates/yurthub-cloud-yurtstaticset.yaml
+++ b/charts/yurthub/templates/yurthub-cloud-yurtstaticset.yaml
@@ -43,7 +43,7 @@ spec:
             {{- if .Values.organizations }}
             - --hub-cert-organizations={{ .Values.organizations }}
             {{- end }}
-            {{- if .nodePoolName }}
+            {{- if .Values.nodePoolName }}
             - --nodepool-name={{ .Values.nodePoolName }}
             {{- end }}
           livenessProbe:

--- a/charts/yurthub/templates/yurthub-yurtstaticset.yaml
+++ b/charts/yurthub/templates/yurthub-yurtstaticset.yaml
@@ -43,7 +43,7 @@ spec:
             {{- if .Values.organizations }}
             - --hub-cert-organizations={{ .Values.organizations }}
             {{- end }}
-            {{- if .nodePoolName }}
+            {{- if .Values.nodePoolName }}
             - --nodepool-name={{ .Values.nodePoolName }}
             {{- end }}
           livenessProbe:

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -405,7 +405,11 @@ func newJoinData(args []string, opt *joinOptions) (*joinData, error) {
 		// check whether specified nodePool exists
 		if len(opt.nodePoolName) != 0 {
 			np, err := apiclient.GetNodePoolInfoWithRetry(cfg, opt.nodePoolName)
-			if err != nil || np == nil {
+			if err != nil {
+				klog.Errorf("failed to get nodePool %s, %v", opt.nodePoolName, err)
+				return nil, err
+			}
+			if np == nil {
 				// the specified nodePool not exist, return
 				return nil, errors.Errorf("when --nodepool-name is specified, the specified nodePool should be exist.")
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
As `--nodepool-name` becomes a Required arguments, executing cmd `yurtadm join --nodepool-name=xxx` will failed with error msg `when --nodepool-name is specified, the specified nodePool should be exist.`, but the actual cause is `nodepools.apps.openyurt.io "xxx" is forbidden: User "system:bootstrap:xxxxx" cannot get resource "nodepools" in API group "apps.openyurt.io" at the cluster scope`.

This pr:
1. displays err of GetNodePoolInfoWithRetry
2. add get permission of nodepools to clusterrole `yurt-hub-yurt-static-set-role` which binding to serviceaccount group`system:bootstrappers`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
