### PR TITLE
support Kubeadm join conf v1beta4

### DIFF
--- a/pkg/yurtadm/cmd/config/config.go
+++ b/pkg/yurtadm/cmd/config/config.go
@@ -104,10 +104,9 @@ func getDefaultNodeConfigBytes() (string, error) {
 		"criSocket":              constants.DefaultDockerCRISocket,
 		"name":                   name,
 		"networkPlugin":          "cni",
-		"apiVersion":             "kubeadm.k8s.io/v1beta3",
 	}
 
-	kubeadmJoinTemplate, err := templates.SubstituteTemplate(constants.KubeadmJoinConf, ctx)
+	kubeadmJoinTemplate, err := templates.SubstituteTemplate(constants.KubeadmJoinConfV1Beta4, ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -49,6 +49,7 @@ type joinOptions struct {
 	token                    string
 	nodeType                 string
 	nodeName                 string
+	nodeIP                   string
 	nodePoolName             string
 	criSocket                string
 	organizations            string
@@ -133,6 +134,10 @@ func addJoinConfigFlags(flagSet *flag.FlagSet, joinOptions *joinOptions) {
 	flagSet.StringVar(
 		&joinOptions.nodeName, yurtconstants.NodeName, joinOptions.nodeName,
 		`Specify the node name. if not specified, hostname will be used.`,
+	)
+	flagSet.StringVar(
+		&joinOptions.nodeIP, yurtconstants.NodeIP, joinOptions.nodeIP,
+		"Specify the node internal ip address. if unset, node's default IPv4 address will be used",
 	)
 	flagSet.StringVar(
 		&joinOptions.namespace, yurtconstants.Namespace, joinOptions.namespace,
@@ -245,6 +250,7 @@ type joinData struct {
 	yurthubManifest          string
 	kubernetesVersion        string
 	caCertHashes             []string
+	nodeIP                   string
 	nodeLabels               map[string]string
 	kubernetesResourceServer string
 	yurthubServer            string
@@ -331,6 +337,7 @@ func newJoinData(args []string, opt *joinOptions) (*joinData, error) {
 		yurthubServer:         opt.yurthubServer,
 		caCertHashes:          opt.caCertHashes,
 		organizations:         opt.organizations,
+		nodeIP:                opt.nodeIP,
 		nodeLabels:            make(map[string]string),
 		joinNodeData: &joindata.NodeRegistration{
 			Name:          name,
@@ -542,6 +549,10 @@ func (j *joinData) IgnorePreflightErrors() sets.Set[string] {
 
 func (j *joinData) CaCertHashes() []string {
 	return j.caCertHashes
+}
+
+func (j *joinData) NodeIP() string {
+	return j.nodeIP
 }
 
 func (j *joinData) NodeLabels() map[string]string {

--- a/pkg/yurtadm/cmd/join/joindata/data.go
+++ b/pkg/yurtadm/cmd/join/joindata/data.go
@@ -46,6 +46,7 @@ type YurtJoinData interface {
 	BootstrapClient() *clientset.Clientset
 	NodeRegistration() *NodeRegistration
 	CaCertHashes() []string
+	NodeIP() string
 	NodeLabels() map[string]string
 	IgnorePreflightErrors() sets.Set[string]
 	KubernetesResourceServer() string

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -224,6 +224,45 @@ nodeRegistration:
     {{end}}
 `
 
+	KubeadmJoinConfV1Beta4 = `
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+discovery:
+  file:
+    kubeConfigPath: {{.kubeConfigPath}}
+  tlsBootstrapToken: {{.tlsBootstrapToken}}
+nodeRegistration:
+  criSocket: {{.criSocket}}
+  name: {{.name}}
+  {{- if .ignorePreflightErrors}}
+  ignorePreflightErrors:
+    {{- range $index, $value := .ignorePreflightErrors}}
+    - {{$value}}
+    {{- end}}
+  {{- end}}
+  kubeletExtraArgs:
+	- name: rotate-certificates
+ 	  value: "{{.rotateCertificates}}"
+	- name: pod-infra-container-image
+	  value: {{.podInfraContainerImage}}
+	{{- if .nodeLabels}}
+	- name: node-labels
+	  value: {{.nodeLabels}}
+    {{- end}}
+    {{- if .networkPlugin}}
+	- name: network-plugin
+	  value: {{.networkPlugin}}
+    {{end}}
+    {{- if .containerRuntime}}
+	- name: container-runtime
+	  value: {{.containerRuntime}}
+    {{end}}
+    {{- if .containerRuntimeEndpoint}}
+	- name: container-runtime-endpoint
+	  value: {{.containerRuntimeEndpoint}}
+    {{end}}
+`
+
 	YurthubTemplate = `
 apiVersion: v1
 kind: Pod

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -355,7 +355,11 @@ After=network.target
 Type=simple
 ExecStart=/usr/local/bin/yurthub
 Restart=always
+
+[Install]
+WantedBy=multi-user.target
 `
+
 	YurthubSyetmdServiceContent = `
 [Unit]
 Description=local mode yurthub is deployed in systemd

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -104,6 +104,8 @@ const (
 	NodeLabels = "node-labels"
 	// NodeName flag sets the node name.
 	NodeName = "node-name"
+	// NodeIp flag sets the internal ip for worker node.
+	NodeIP = "node-ip"
 	// NodePoolName flag sets the nodePool name.
 	NodePoolName = "nodepool-name"
 	// NodeType flag sets the type of worker node to edge or cloud.
@@ -213,6 +215,9 @@ nodeRegistration:
 	{{- if .nodeLabels}}
     node-labels: {{.nodeLabels}}
     {{- end}}
+	{{- if .nodeIP}}
+    node-ip: {{.nodeIP}}
+    {{- end}}
     {{- if .networkPlugin}}
     network-plugin: {{.networkPlugin}}
     {{end}}
@@ -248,6 +253,10 @@ nodeRegistration:
 	{{- if .nodeLabels}}
 	- name: node-labels
 	  value: {{.nodeLabels}}
+    {{- end}}
+	{{- if .nodeIP}}
+	- name: node-ip
+	  value: {{.nodeIP}}
     {{- end}}
     {{- if .networkPlugin}}
 	- name: network-plugin
@@ -368,6 +377,6 @@ Environment="YURTHUB_BOOTSTRAP_ARGS=--bootstrap-file={{.bootstrapFile}}"
 Environment="YURTHUB_CONFIG_ARGS=--bind-address={{.bindAddress}} --working-mode={{.workingMode}} --namespace={{.namespace}}"
 Environment="YURTHUB_EXTRA_ARGS=--v=2"
 ExecStart=
-ExecStart=/usr/local/bin/yurthub --node-name={{.nodeName}}{{if .nodePoolName}} --nodepool-name={{.nodePoolName}}{{end}} --server-addr={{.serverAddr}} $YURTHUB_BOOTSTRAP_ARGS $YURTHUB_CONFIG_ARGS $YURTHUB_EXTRA_ARGS
+ExecStart=/usr/local/bin/yurthub --node-name={{.nodeName}}{{if .nodeIP}} --node-ip={{.nodeIP}}{{end}}{{if .nodePoolName}} --nodepool-name={{.nodePoolName}}{{end}} --server-addr={{.serverAddr}} $YURTHUB_BOOTSTRAP_ARGS $YURTHUB_CONFIG_ARGS $YURTHUB_EXTRA_ARGS
 `
 )

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -355,6 +355,8 @@ After=network.target
 Type=simple
 ExecStart=/usr/local/bin/yurthub
 Restart=always
+StartLimitInterval=0
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -246,29 +246,29 @@ nodeRegistration:
     {{- end}}
   {{- end}}
   kubeletExtraArgs:
-	- name: rotate-certificates
- 	  value: "{{.rotateCertificates}}"
-	- name: pod-infra-container-image
-	  value: {{.podInfraContainerImage}}
-	{{- if .nodeLabels}}
-	- name: node-labels
-	  value: {{.nodeLabels}}
+    - name: rotate-certificates
+      value: "{{.rotateCertificates}}"
+    - name: pod-infra-container-image
+      value: {{.podInfraContainerImage}}
+    {{- if .nodeLabels}}
+    - name: node-labels
+      value: {{.nodeLabels}}
     {{- end}}
-	{{- if .nodeIP}}
-	- name: node-ip
-	  value: {{.nodeIP}}
+    {{- if .nodeIP}}
+    - name: node-ip
+      value: {{.nodeIP}}
     {{- end}}
     {{- if .networkPlugin}}
-	- name: network-plugin
-	  value: {{.networkPlugin}}
+    - name: network-plugin
+      value: {{.networkPlugin}}
     {{end}}
     {{- if .containerRuntime}}
-	- name: container-runtime
-	  value: {{.containerRuntime}}
+    - name: container-runtime
+      value: {{.containerRuntime}}
     {{end}}
     {{- if .containerRuntimeEndpoint}}
-	- name: container-runtime-endpoint
-	  value: {{.containerRuntimeEndpoint}}
+    - name: container-runtime-endpoint
+      value: {{.containerRuntimeEndpoint}}
     {{end}}
 `
 

--- a/pkg/yurtadm/util/kubernetes/kubernetes.go
+++ b/pkg/yurtadm/util/kubernetes/kubernetes.go
@@ -406,6 +406,7 @@ func SetKubeadmJoinConfig(data joindata.YurtJoinData) error {
 		"podInfraContainerImage": data.PauseImage(),
 		"criSocket":              nodeReg.CRISocket,
 		"name":                   nodeReg.Name,
+		"nodeIP":                 data.NodeIP(),
 	}
 
 	// if node isn't local node, we need to set ignorePreflightErrors and nodeLabels

--- a/pkg/yurtadm/util/kubernetes/kubernetes.go
+++ b/pkg/yurtadm/util/kubernetes/kubernetes.go
@@ -441,15 +441,24 @@ func SetKubeadmJoinConfig(data joindata.YurtJoinData) error {
 	if err != nil {
 		return err
 	}
+	v3, err := version.NewVersion("v1.31.0")
+	if err != nil {
+		return err
+	}
 	// This is to adapt the apiVersion of JoinConfiguration
 	// https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/
+	// https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/
+	joinConfTpl := constants.KubeadmJoinConf
 	if v1.LessThan(v2) {
 		ctx["apiVersion"] = "kubeadm.k8s.io/v1beta2"
-	} else {
+	} else if v1.LessThan(v3) {
 		ctx["apiVersion"] = "kubeadm.k8s.io/v1beta3"
+	} else {
+		ctx["apiVersion"] = "kubeadm.k8s.io/v1beta4"
+		joinConfTpl = constants.KubeadmJoinConfV1Beta4
 	}
 
-	kubeadmJoinTemplate, err := templates.SubstituteTemplate(constants.KubeadmJoinConf, ctx)
+	kubeadmJoinTemplate, err := templates.SubstituteTemplate(joinConfTpl, ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/yurtadm/util/yurthub/yurthub.go
+++ b/pkg/yurtadm/util/yurthub/yurthub.go
@@ -109,6 +109,7 @@ func setYurthubUnitService(data joindata.YurtJoinData) error {
 		"bindAddress":   "127.0.0.1",
 		"serverAddr":    fmt.Sprintf("https://%s", data.ServerAddr()),
 		"nodeName":      data.NodeRegistration().Name,
+		"nodeIP":        data.NodeIP(),
 		"bootstrapFile": constants.YurtHubBootstrapConfig,
 		"workingMode":   data.NodeRegistration().WorkingMode,
 		"namespace":     data.Namespace(),

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -392,6 +392,10 @@ func (j *testData) NodeLabels() map[string]string {
 	return nil
 }
 
+func (j *testData) NodeIP() string {
+	return ""
+}
+
 func (j *testData) KubernetesResourceServer() string {
 	return ""
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
1. support kubeadm JoinConfiguration v1beta4
2. support `--node-ip` argument to `yurtadm join`
3. fix yurthub.service enable failed due to miss of unit config

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
```shell
$ sudo systemctl enable yurthub.service
The unit files have no installation config (WantedBy=, RequiredBy=, UpheldBy=,
Also=, or Alias= settings in the [Install] section, and DefaultInstance= for
template units). This means they are not meant to be enabled or disabled using systemctl.

Possible reasons for having these kinds of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/, .requires/, or .upholds/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
```

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
1. support kubeadm JoinConfiguration v1beta4
2. support `--node-ip` argument to `yurtadm join`
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
