### PR TITLE
Bugfix : remove deprecated rand.Seed() calls

### DIFF
--- a/cmd/yurt-manager/yurt-manager.go
+++ b/cmd/yurt-manager/yurt-manager.go
@@ -17,10 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	_ "net/http/pprof"
 	"os"
-	"time"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/component-base/logs"
@@ -30,9 +28,6 @@ import (
 )
 
 func main() {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	newRand.Seed(time.Now().UnixNano())
-
 	command := app.NewYurtManagerCommand()
 
 	// TODO: once we switch everything over to Cobra commands, we can go back to calling

--- a/cmd/yurt-node-servant/node-servant.go
+++ b/cmd/yurt-node-servant/node-servant.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -35,9 +33,6 @@ import (
 // running on specific node, do convert/revert job
 // node-servant convert/revert join/reset, yurtcluster operator shall start a k8s job to run this.
 func main() {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	newRand.Seed(time.Now().UnixNano())
-
 	version := fmt.Sprintf("%#v", projectinfo.Get())
 	rootCmd := &cobra.Command{
 		Use:     "node-servant",

--- a/cmd/yurthub/yurthub.go
+++ b/cmd/yurthub/yurthub.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"flag"
-	"math/rand"
-	"time"
 
 	"k8s.io/apiserver/pkg/server"
 
@@ -27,9 +25,6 @@ import (
 )
 
 func main() {
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	newRand.Seed(time.Now().UnixNano())
-
 	cmd := app.NewCmdStartYurtHub(server.SetupSignalContext())
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR removes deprecated `rand.Seed()` calls that will cause compilation failures in future Go versions. The `rand.New(rand.NewSource(time.Now().UnixNano()))` function already seeds the random number generator, making the explicit `Seed()` call redundant and deprecated.

**Why this is needed:**
The `rand.Seed()` function has been deprecated in Go 1.20+ and will be removed in future versions. This change prevents future compilation failures and follows Go best practices. The random number generator created by `rand.New()` is already properly seeded, so the additional `Seed()` call was unnecessary.

