### PR TITLE
Fix NodeAutonomy condition LastTransitionTime never being updated

### DIFF
--- a/pkg/yurthub/proxy/autonomy/autonomy.go
+++ b/pkg/yurthub/proxy/autonomy/autonomy.go
@@ -202,7 +202,7 @@ func setNodeAutonomyCondition(node *v1.Node, expectedStatus v1.ConditionStatus, 
 				node.Status.Conditions[i].Reason = reason
 				node.Status.Conditions[i].Message = message
 				node.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
-				node.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
+				node.Status.Conditions[i].LastTransitionTime = metav1.Now()
 				return
 			}
 		}


### PR DESCRIPTION
## Fix NodeAutonomy condition LastTransitionTime not updating on status change

### Summary
Fixes a copy-paste bug in the YurtHub autonomy proxy where `LastHeartbeatTime` was set twice and `LastTransitionTime` was never updated when the `NodeAutonomy` condition status changed.

This resulted in silent observability data corruption: node autonomy transitions occurred correctly, but condition transition timestamps remained stale.

### Root Cause
An incorrect field assignment in `setNodeAutonomyCondition()` updated `LastHeartbeatTime` twice instead of updating `LastTransitionTime` on status changes.

### Fix
Update `LastTransitionTime` whenever the `NodeAutonomy` condition `Status` changes, in accordance with Kubernetes condition semantics.

### Impact
- Accurate condition transition timestamps
- Correct behavior for monitoring, alerting, and `kubectl describe`
- No functional behavior change beyond observability correctness

### Scope
Minimal, safe, single-line fix with no API or behavior regressions.
