### PR TITLE
fix: log yurt-manager Execute() error before exit

### DIFF
--- a/cmd/yurt-manager/yurt-manager.go
+++ b/cmd/yurt-manager/yurt-manager.go
@@ -39,6 +39,7 @@ func main() {
 	defer klog.Flush()
 
 	if err := command.Execute(); err != nil {
+		klog.Errorf("yurt-manager failed: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### Description 
- Adds error logging before os.Exit(1) in yurt-manager’s main function.
- When command.Execute() fails, we now log klog.Errorf("yurt-manager failed: %v", err) before exiting.
### How I tested it
- go test ./cmd/yurt-manager/...
