### PR TITLE
avoid panic on pod without owner refs

### DIFF
--- a/pkg/yurthub/otaupdate/ota.go
+++ b/pkg/yurthub/otaupdate/ota.go
@@ -116,7 +116,12 @@ func UpdatePod(clientset kubernetes.Interface, nodeName string) http.Handler {
 		}
 
 		var upgrader OTAUpgrader
-		kind := pod.GetOwnerReferences()[0].Kind
+		ownerRefs := pod.GetOwnerReferences()
+		if len(ownerRefs) == 0 {
+			util.WriteErr(w, "Pod has no owner references", http.StatusBadRequest)
+			return
+		}
+		kind := ownerRefs[0].Kind
 		switch kind {
 		case StaticPod:
 			ok, staticName, err := upgrade.PreCheck(podName, nodeName, namespace, clientset)

--- a/pkg/yurthub/otaupdate/ota_test.go
+++ b/pkg/yurthub/otaupdate/ota_test.go
@@ -225,6 +225,14 @@ func TestUpdatePod(t *testing.T) {
 			podName:        "nginx",
 		},
 		{
+			name:           "pod with no owner references",
+			pod:            createPodWithNoOwnerReferences("nginx", "default", "node1"),
+			nodeName:       "node1",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "Pod has no owner references",
+			podName:        "nginx",
+		},
+		{
 			name:           "static pod with configmap found but apply fails",
 			pod:            createStaticPod("nginx-node1", "default", "node1"),
 			nodeName:       "node1",
@@ -372,6 +380,27 @@ func createReplicaSetPod(name, namespace string) *corev1.Pod {
 		},
 		Spec: corev1.PodSpec{
 			NodeName: "node1",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   daemonsetupgradestrategy.PodNeedUpgrade,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	return pod
+}
+
+func createPodWithNoOwnerReferences(name, namespace, nodeName string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
 		},
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{


### PR DESCRIPTION
- Prevents a panic in pkg/yurthub/otaupdate/ota.go when UpdatePod is called on a Pod with an empty ownerReferences list.
- Adds a guard (len(ownerRefs) == 0) and returns 400 BadRequest with message "Pod has no owner references" instead of  crashing.
- Adds a unit test covering the no-ownerRefs case in pkg/yurthub/otaupdate/ota_test.go.