### PR TITLE
protect yurthub transport client map from races

### DIFF
--- a/pkg/yurthub/transport/transport.go
+++ b/pkg/yurthub/transport/transport.go
@@ -21,9 +21,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
-
 	"sync"
+	"time"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/yurthub/transport/transport.go
+++ b/pkg/yurthub/transport/transport.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"time"
 
+	"sync"
+
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -65,6 +67,7 @@ type transportAndClientManager struct {
 	closeAll          func()
 	close             func(string)
 	stopCh            <-chan struct{}
+	mu                sync.RWMutex
 	serverToClientset map[string]kubernetes.Interface
 }
 
@@ -104,16 +107,7 @@ func NewTransportAndClientManager(servers []*url.URL, timeout int, certGetter Ce
 		DialContext:         d.DialContext,
 	})
 
-	tcm := &transportAndClientManager{
-		currentTransport:  t,
-		bearerTransport:   bt,
-		certGetter:        certGetter,
-		closeAll:          d.CloseAll,
-		close:             d.Close,
-		stopCh:            stopCh,
-		serverToClientset: make(map[string]kubernetes.Interface),
-	}
-
+	serverToClientset := make(map[string]kubernetes.Interface)
 	for i := range servers {
 		config := &rest.Config{
 			Host:      servers[i].String(),
@@ -127,8 +121,18 @@ func NewTransportAndClientManager(servers []*url.URL, timeout int, certGetter Ce
 		}
 
 		if len(servers[i].String()) != 0 {
-			tcm.serverToClientset[servers[i].String()] = clientset
+			serverToClientset[servers[i].String()] = clientset
 		}
+	}
+
+	tcm := &transportAndClientManager{
+		currentTransport:  t,
+		bearerTransport:   bt,
+		certGetter:        certGetter,
+		closeAll:          d.CloseAll,
+		close:             d.Close,
+		stopCh:            stopCh,
+		serverToClientset: serverToClientset,
 	}
 
 	tcm.start()
@@ -149,23 +153,38 @@ func (tcm *transportAndClientManager) Close(address string) {
 }
 
 func (tcm *transportAndClientManager) GetDirectClientset(url *url.URL) kubernetes.Interface {
-	if url != nil {
-		return tcm.serverToClientset[url.String()]
+	if url == nil {
+		return nil
 	}
-	return nil
+
+	tcm.mu.RLock()
+	defer tcm.mu.RUnlock()
+
+	return tcm.serverToClientset[url.String()]
 }
 
 func (tcm *transportAndClientManager) GetDirectClientsetAtRandom() kubernetes.Interface {
+	tcm.mu.RLock()
+	defer tcm.mu.RUnlock()
+
 	// iterating map uses random order
-	for server := range tcm.serverToClientset {
-		return tcm.serverToClientset[server]
+	for _, client := range tcm.serverToClientset {
+		return client
 	}
 
 	return nil
 }
 
 func (tcm *transportAndClientManager) ListDirectClientset() map[string]kubernetes.Interface {
-	return tcm.serverToClientset
+	tcm.mu.RLock()
+	defer tcm.mu.RUnlock()
+
+	serverToClientset := make(map[string]kubernetes.Interface, len(tcm.serverToClientset))
+	for k, v := range tcm.serverToClientset {
+		serverToClientset[k] = v
+	}
+
+	return serverToClientset
 }
 
 func (tcm *transportAndClientManager) start() {

--- a/pkg/yurthub/transport/transport_test.go
+++ b/pkg/yurthub/transport/transport_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2025 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+import (
+	"net/url"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	clientfake "k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	testServer1 = &url.URL{Host: "127.0.0.1:6443"}
+	testServer2 = &url.URL{Host: "127.0.0.2:6443"}
+	testServer3 = &url.URL{Host: "127.0.0.3:6443"}
+)
+
+func TestGetDirectClientset(t *testing.T) {
+	server1URL := testServer1
+	server2URL := testServer2
+	client1 := clientfake.NewSimpleClientset()
+	client2 := clientfake.NewSimpleClientset()
+
+	fakeClients := map[string]kubernetes.Interface{
+		server1URL.String(): client1,
+		server2URL.String(): client2,
+	}
+
+	manager := NewFakeTransportManager(200, fakeClients)
+
+	testcases := map[string]struct {
+		url      *url.URL
+		expected kubernetes.Interface
+	}{
+		"nil url should return nil": {
+			url:      nil,
+			expected: nil,
+		},
+		"valid server1 url should return client1": {
+			url:      server1URL,
+			expected: client1,
+		},
+		"valid server2 url should return client2": {
+			url:      server2URL,
+			expected: client2,
+		},
+		"non-existent server should return nil": {
+			url:      testServer3,
+			expected: nil,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			result := manager.GetDirectClientset(tc.url)
+			if result != tc.expected {
+				t.Errorf("expect %v, but got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetDirectClientsetAtRandom(t *testing.T) {
+	server1URL := testServer1
+	server2URL := testServer2
+	client1 := clientfake.NewSimpleClientset()
+	client2 := clientfake.NewSimpleClientset()
+
+	fakeClients := map[string]kubernetes.Interface{
+		server1URL.String(): client1,
+		server2URL.String(): client2,
+	}
+
+	manager := NewFakeTransportManager(200, fakeClients)
+
+	result := manager.GetDirectClientsetAtRandom()
+	if result == nil {
+		t.Errorf("expect a clientset, but got nil")
+	}
+	if result != client1 && result != client2 {
+		t.Errorf("expect one of the clientsets, but got %v", result)
+	}
+
+	emptyManager := NewFakeTransportManager(200, map[string]kubernetes.Interface{})
+	emptyResult := emptyManager.GetDirectClientsetAtRandom()
+	if emptyResult != nil {
+		t.Errorf("expect nil for empty map, but got %v", emptyResult)
+	}
+}
+
+func TestListDirectClientset(t *testing.T) {
+	server1URL := testServer1
+	server2URL := testServer2
+	client1 := clientfake.NewSimpleClientset()
+	client2 := clientfake.NewSimpleClientset()
+
+	fakeClients := map[string]kubernetes.Interface{
+		server1URL.String(): client1,
+		server2URL.String(): client2,
+	}
+
+	manager := NewFakeTransportManager(200, fakeClients)
+
+	result := manager.ListDirectClientset()
+
+	if len(result) != 2 {
+		t.Errorf("expect 2 clientsets, but got %d", len(result))
+	}
+
+	if result[server1URL.String()] != client1 {
+		t.Errorf("expect client1 for server1, but got %v", result[server1URL.String()])
+	}
+
+	if result[server2URL.String()] != client2 {
+		t.Errorf("expect client2 for server2, but got %v", result[server2URL.String()])
+	}
+
+	result[testServer3.String()] = clientfake.NewSimpleClientset()
+
+	secondResult := manager.ListDirectClientset()
+	if len(secondResult) != 2 {
+		t.Errorf("mutating returned map should not affect internal map, expect 2, but got %d", len(secondResult))
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	server1URL := testServer1
+	server2URL := testServer2
+	client1 := clientfake.NewSimpleClientset()
+	client2 := clientfake.NewSimpleClientset()
+
+	fakeClients := map[string]kubernetes.Interface{
+		server1URL.String(): client1,
+		server2URL.String(): client2,
+	}
+
+	manager := NewFakeTransportManager(200, fakeClients)
+
+	var wg sync.WaitGroup
+	concurrency := 50
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = manager.GetDirectClientset(server1URL)
+			_ = manager.GetDirectClientsetAtRandom()
+			_ = manager.ListDirectClientset()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestListDirectClientsetReturnsCopy(t *testing.T) {
+	server1URL := testServer1
+	client1 := clientfake.NewSimpleClientset()
+
+	fakeClients := map[string]kubernetes.Interface{
+		server1URL.String(): client1,
+	}
+
+	manager := NewFakeTransportManager(200, fakeClients)
+
+	result1 := manager.ListDirectClientset()
+	result2 := manager.ListDirectClientset()
+
+	if &result1 == &result2 {
+		t.Errorf("expect different map instances, but got same address")
+	}
+
+	if result1[server1URL.String()] != result2[server1URL.String()] {
+		t.Errorf("expect same clientset in both maps, but got different values")
+	}
+}


### PR DESCRIPTION
- Add sync.RWMutex to transportAndClientManager and fakeTransportManager to guard access to serverToClientset.
- Build serverToClientset maps completely before publishing them on the manager structs to avoid concurrent writes.
- Change ListDirectClientset in both managers to return a shallow copy of the internal map, preventing external callers from mutating internal state.
- Keep the existing Interface API unchanged while ensuring safe concurrent reads and better encapsulation.