### PR TITLE
fix: prevent nil pointer panic in NodeLifecycle handleDisruption

### DIFF
--- a/pkg/yurtmanager/controller/nodelifecycle/node_life_cycle_controller.go
+++ b/pkg/yurtmanager/controller/nodelifecycle/node_life_cycle_controller.go
@@ -1016,8 +1016,17 @@ func (nc *ReconcileNodeLifeCycle) handleDisruption(ctx context.Context, zoneToNo
 			now := nc.now()
 			for i := range nodes {
 				v := nc.nodeHealthMap.getDeepCopy(nodes[i].Name)
-				v.probeTimestamp = now
-				v.readyTransitionTimestamp = now
+				if v == nil {
+					// Node is not yet in the health map (e.g., tryUpdateNodeHealth failed for this node).
+					// Initialize with current timestamps to avoid nil pointer dereference.
+					v = &nodeHealthData{
+						probeTimestamp:           now,
+						readyTransitionTimestamp: now,
+					}
+				} else {
+					v.probeTimestamp = now
+					v.readyTransitionTimestamp = now
+				}
 				nc.nodeHealthMap.set(nodes[i].Name, v)
 			}
 			// We reset all rate limiters to settings appropriate for the given state.


### PR DESCRIPTION
### What does this PR do?
This PR fixes a potential nil pointer dereference in the NodeLifecycle controller when handling the transition out of disruption mode.

---

### Background / Problem
The `handleDisruption` logic assumes that all nodes have corresponding entries in `nodeHealthMap`.
However, during edge or network-disrupted scenarios, this assumption may not always hold.

In particular, if node health updates return early due to API errors or pod listing failures, some nodes
may not be populated in the health map. When the controller later exits disruption mode and iterates
over all nodes, this can lead to a nil dereference and controller panic.

---

### Why is this change needed?
This code path is exercised during recovery from disruption, which is a common and sensitive phase
in edge environments with intermittent connectivity. A controller panic at this point stops node
health processing, including tainting and eviction logic, until the controller is restarted.

---

### What does this change do?
The controller now defensively initializes node health data when it is missing before updating
timestamps. This preserves existing behavior for healthy nodes while preventing a possible crash.

---

### Scope of change
- Adds a nil check in `handleDisruption`
- Initializes node health data only when it is missing
- No behavioral changes to normal node health processing

---

### Testing
This change is small and defensive in nature. It follows existing controller patterns and does not
affect normal execution paths.