### PR TITLE
feat(yurt-iot-dock): add --skip-preflight-checks flag to bypass prefl…

### DIFF
--- a/cmd/yurt-iot-dock/app/core.go
+++ b/cmd/yurt-iot-dock/app/core.go
@@ -118,11 +118,16 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 	}
 
 	// register the field indexers
-	setupLog.Info("[preflight] Registering the field indexers")
-	if err := util.RegisterFieldIndexers(mgr.GetFieldIndexer()); err != nil {
-		setupLog.Error(err, "could not register field indexers")
-		os.Exit(1)
+	if opts.SkipPreflightChecks {
+	    setupLog.Info("[preflight] Skipping field indexers registration")
+	} else {
+	    setupLog.Info("[preflight] Registering the field indexers")
+	    if err := util.RegisterFieldIndexers(mgr.GetFieldIndexer()); err != nil {
+	        setupLog.Error(err, "could not register field indexers")
+	        os.Exit(1)
+	    }
 	}
+
 	// get nodepool where yurt-iot-dock run
 	if opts.Nodepool == "" {
 		opts.Nodepool, err = util.GetNodePool(mgr.GetConfig())

--- a/cmd/yurt-iot-dock/app/core.go
+++ b/cmd/yurt-iot-dock/app/core.go
@@ -107,10 +107,14 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 	}
 
 	// perform preflight check
-	setupLog.Info("[preflight] Running pre-flight checks")
-	if err := preflightCheck(mgr, opts); err != nil {
-		setupLog.Error(err, "could not run pre-flight checks")
-		os.Exit(1)
+	if opts.SkipPreflightChecks {
+    		setupLog.Info("[preflight] Skipping pre-flight checks")
+	} else {
+    		setupLog.Info("[preflight] Running pre-flight checks")
+    		if err := preflightCheck(mgr, opts); err != nil {
+        		setupLog.Error(err, "could not run pre-flight checks")
+        		os.Exit(1)
+    		}
 	}
 
 	// register the field indexers

--- a/cmd/yurt-iot-dock/app/options/options.go
+++ b/cmd/yurt-iot-dock/app/options/options.go
@@ -35,6 +35,7 @@ type YurtIoTDockOptions struct {
 	CoreMetadataAddr     string
 	CoreCommandAddr      string
 	EdgeSyncPeriod       uint
+	SkipPreflightChecks bool
 }
 
 func NewYurtIoTDockOptions() *YurtIoTDockOptions {
@@ -70,6 +71,7 @@ func (o *YurtIoTDockOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.CoreMetadataAddr, "core-metadata-address", "edgex-core-metadata:59881", "The address of edge core-metadata service.")
 	fs.StringVar(&o.CoreCommandAddr, "core-command-address", "edgex-core-command:59882", "The address of edge core-command service.")
 	fs.UintVar(&o.EdgeSyncPeriod, "edge-sync-period", 5, "The period of the device management platform synchronizing the device status to the cloud.(in seconds,not less than 5 seconds)")
+	fs.BoolVar(&o.SkipPreflightChecks, "skip-preflight-checks", false,"If true, skip preflight checks during startup.")
 }
 
 func ValidateEdgePlatformAddress(options *YurtIoTDockOptions) error {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig iot

#### What this PR does / why we need it:
Adds a new `--skip-preflight-checks` flag to yurt-iot-dock that allows 
bypassing the preflight namespace validation check on startup.

In some edge deployment scenarios (restricted RBAC, bootstrapping, or 
environments where the namespace exists but is temporarily unreachable), 
the preflight check fails and causes the controller to exit immediately, 
even when the rest of the system is functional.

This flag gives operators the flexibility to skip the check when needed.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
The flag defaults to `false`, so existing behavior is completely unchanged.
Only when `--skip-preflight-checks=true` is explicitly passed will the 
preflight check be skipped.

Changes:
- `cmd/yurt-iot-dock/app/options/options.go`: Added `SkipPreflightChecks` bool field and registered the flag
- `cmd/yurt-iot-dock/app/core.go`: Guarded the preflight block with the new flag

#### Does this PR introduce a user-facing change?
```release-note
Added `--skip-preflight-checks` flag to yurt-iot-dock. When set to `true`, 
the preflight namespace validation check is skipped on startup. Defaults to `false`.
```
#### Exmaple

```

yurt-iot-dock --nodepool=edge-pool --skip-preflight-checks=true

```