### PR TITLE
refactor(yurtadm): align join and reset with post-join yurthub lifecycle

### DIFF
--- a/pkg/yurtadm/cmd/config/config.go
+++ b/pkg/yurtadm/cmd/config/config.go
@@ -105,6 +105,7 @@ func getDefaultNodeConfigBytes() (string, error) {
 		"name":                   name,
 		"networkPlugin":          "cni",
 		"apiVersion":             "kubeadm.k8s.io/v1beta3",
+		"rotateCertificates":     true,
 	}
 
 	kubeadmJoinTemplate, err := templates.SubstituteTemplate(constants.KubeadmJoinConf, ctx)

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -221,7 +221,11 @@ func (nodeJoiner *nodeJoiner) Run() error {
 		return err
 	}
 
-	if err := yurtphases.RunPostCheck(joinData); err != nil {
+	if err := yurtphases.RunJoinCheck(joinData); err != nil {
+		return err
+	}
+
+	if err := yurtphases.RunConvert(joinData); err != nil {
 		return err
 	}
 

--- a/pkg/yurtadm/cmd/join/phases/phases_test.go
+++ b/pkg/yurtadm/cmd/join/phases/phases_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
+	yurthubutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
+)
+
+type fakeJoinData struct {
+	cfgPath               string
+	serverAddr            string
+	joinToken             string
+	pauseImage            string
+	yurthubImage          string
+	yurthubBinaryURL      string
+	hostControlPlaneAddr  string
+	yurthubServer         string
+	yurthubTemplate       string
+	yurthubManifest       string
+	kubernetesVersion     string
+	tlsBootstrapCfg       *clientcmdapi.Config
+	bootstrapClient       *clientset.Clientset
+	nodeRegistration      *joindata.NodeRegistration
+	caCertHashes          []string
+	nodeLabels            map[string]string
+	ignorePreflightErrors sets.Set[string]
+	kubernetesResourceSrv string
+	reuseCNIBin           bool
+	namespace             string
+	staticPodTemplates    []string
+	staticPodManifests    []string
+}
+
+func (f fakeJoinData) CfgPath() string                              { return f.cfgPath }
+func (f fakeJoinData) ServerAddr() string                           { return f.serverAddr }
+func (f fakeJoinData) JoinToken() string                            { return f.joinToken }
+func (f fakeJoinData) PauseImage() string                           { return f.pauseImage }
+func (f fakeJoinData) YurtHubImage() string                         { return f.yurthubImage }
+func (f fakeJoinData) YurtHubBinaryUrl() string                     { return f.yurthubBinaryURL }
+func (f fakeJoinData) HostControlPlaneAddr() string                 { return f.hostControlPlaneAddr }
+func (f fakeJoinData) YurtHubServer() string                        { return f.yurthubServer }
+func (f fakeJoinData) YurtHubTemplate() string                      { return f.yurthubTemplate }
+func (f fakeJoinData) YurtHubManifest() string                      { return f.yurthubManifest }
+func (f fakeJoinData) KubernetesVersion() string                    { return f.kubernetesVersion }
+func (f fakeJoinData) TLSBootstrapCfg() *clientcmdapi.Config        { return f.tlsBootstrapCfg }
+func (f fakeJoinData) BootstrapClient() *clientset.Clientset        { return f.bootstrapClient }
+func (f fakeJoinData) NodeRegistration() *joindata.NodeRegistration { return f.nodeRegistration }
+func (f fakeJoinData) CaCertHashes() []string                       { return f.caCertHashes }
+func (f fakeJoinData) NodeLabels() map[string]string                { return f.nodeLabels }
+func (f fakeJoinData) IgnorePreflightErrors() sets.Set[string]      { return f.ignorePreflightErrors }
+func (f fakeJoinData) KubernetesResourceServer() string             { return f.kubernetesResourceSrv }
+func (f fakeJoinData) ReuseCNIBin() bool                            { return f.reuseCNIBin }
+func (f fakeJoinData) Namespace() string                            { return f.namespace }
+func (f fakeJoinData) StaticPodTemplateList() []string              { return f.staticPodTemplates }
+func (f fakeJoinData) StaticPodManifestList() []string              { return f.staticPodManifests }
+
+func TestRunConvert(t *testing.T) {
+	originalCreateYurthubSystemdServiceFunc := createYurthubSystemdServiceFunc
+	originalCheckYurthubServiceHealthFunc := checkYurthubServiceHealthFunc
+	originalCheckYurthubReadyzFunc := checkYurthubReadyzFunc
+	originalRedirectKubeletTrafficFunc := redirectKubeletTrafficFunc
+	originalCheckKubeletStatusFunc := checkKubeletStatusFunc
+	t.Cleanup(func() {
+		createYurthubSystemdServiceFunc = originalCreateYurthubSystemdServiceFunc
+		checkYurthubServiceHealthFunc = originalCheckYurthubServiceHealthFunc
+		checkYurthubReadyzFunc = originalCheckYurthubReadyzFunc
+		redirectKubeletTrafficFunc = originalRedirectKubeletTrafficFunc
+		checkKubeletStatusFunc = originalCheckKubeletStatusFunc
+	})
+
+	testCases := []struct {
+		name         string
+		mode         string
+		wantCalls    []string
+		expectCreate bool
+	}{
+		{
+			name:         "edge node runs full convert flow",
+			mode:         constants.EdgeNode,
+			wantCalls:    []string{"create", "health", "ready", "redirect", "kubelet"},
+			expectCreate: true,
+		},
+		{
+			name:         "cloud node runs full convert flow",
+			mode:         constants.CloudNode,
+			wantCalls:    []string{"create", "health", "ready", "redirect", "kubelet"},
+			expectCreate: true,
+		},
+		{
+			name:      "local node skips convert flow",
+			mode:      constants.LocalNode,
+			wantCalls: nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotCalls []string
+			var gotConfigNodeName string
+			var gotConfigNodePool string
+			var gotConfigMode string
+			var gotConfigNamespace string
+			var gotConfigServerAddr string
+			var gotBootstrapMode string
+
+			createYurthubSystemdServiceFunc = func(cfg *yurthubutil.YurthubHostConfig) error {
+				gotCalls = append(gotCalls, "create")
+				gotConfigNodeName = cfg.NodeName
+				gotConfigNodePool = cfg.NodePoolName
+				gotConfigMode = cfg.WorkingMode
+				gotConfigNamespace = cfg.Namespace
+				gotConfigServerAddr = cfg.ServerAddr
+				gotBootstrapMode = cfg.BootstrapMode
+				return nil
+			}
+			checkYurthubServiceHealthFunc = func(addr string) error {
+				gotCalls = append(gotCalls, "health")
+				if addr != "127.0.0.1" {
+					t.Fatalf("CheckYurthubServiceHealth() addr got %q, want %q", addr, "127.0.0.1")
+				}
+				return nil
+			}
+			checkYurthubReadyzFunc = func(addr string) error {
+				gotCalls = append(gotCalls, "ready")
+				if addr != "127.0.0.1" {
+					t.Fatalf("CheckYurthubReadyz() addr got %q, want %q", addr, "127.0.0.1")
+				}
+				return nil
+			}
+			redirectKubeletTrafficFunc = func(openyurtDir string) error {
+				gotCalls = append(gotCalls, "redirect")
+				if openyurtDir != constants.OpenyurtDir {
+					t.Fatalf("RedirectTrafficToYurtHub() openyurtDir got %q, want %q", openyurtDir, constants.OpenyurtDir)
+				}
+				return nil
+			}
+			checkKubeletStatusFunc = func() error {
+				gotCalls = append(gotCalls, "kubelet")
+				return nil
+			}
+
+			data := fakeJoinData{
+				serverAddr:    "10.0.0.1:6443",
+				yurthubServer: "127.0.0.1",
+				namespace:     "kube-system",
+				nodeRegistration: &joindata.NodeRegistration{
+					Name:         "node-a",
+					NodePoolName: "pool-a",
+					WorkingMode:  tt.mode,
+				},
+			}
+
+			err := RunConvert(data)
+			if err != nil {
+				t.Fatalf("RunConvert() unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tt.wantCalls, gotCalls) {
+				t.Fatalf("RunConvert() calls got %v, want %v", gotCalls, tt.wantCalls)
+			}
+			if !tt.expectCreate {
+				return
+			}
+
+			if gotBootstrapMode != bootstrapModeKubeletCertificate {
+				t.Fatalf("RunConvert() bootstrap mode got %q, want %q", gotBootstrapMode, bootstrapModeKubeletCertificate)
+			}
+			if gotConfigMode != tt.mode {
+				t.Fatalf("RunConvert() working mode got %q, want %q", gotConfigMode, tt.mode)
+			}
+			if gotConfigNodeName != "node-a" || gotConfigNodePool != "pool-a" {
+				t.Fatalf("RunConvert() cfg node got (%q,%q), want (%q,%q)", gotConfigNodeName, gotConfigNodePool, "node-a", "pool-a")
+			}
+			if gotConfigNamespace != "kube-system" {
+				t.Fatalf("RunConvert() namespace got %q, want %q", gotConfigNamespace, "kube-system")
+			}
+			if gotConfigServerAddr != "10.0.0.1:6443" {
+				t.Fatalf("RunConvert() server addr got %q, want %q", gotConfigServerAddr, "10.0.0.1:6443")
+			}
+		})
+	}
+}
+
+func TestRunJoinCheck(t *testing.T) {
+	originalCheckKubeletStatusFunc := checkKubeletStatusFunc
+	t.Cleanup(func() {
+		checkKubeletStatusFunc = originalCheckKubeletStatusFunc
+	})
+
+	t.Run("checks kubelet status", func(t *testing.T) {
+		called := false
+		checkKubeletStatusFunc = func() error {
+			called = true
+			return nil
+		}
+
+		if err := RunJoinCheck(fakeJoinData{}); err != nil {
+			t.Fatalf("RunJoinCheck() unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("RunJoinCheck() did not check kubelet status")
+		}
+	})
+
+	t.Run("propagates kubelet status error", func(t *testing.T) {
+		expectedErr := errors.New("kubelet down")
+		checkKubeletStatusFunc = func() error {
+			return expectedErr
+		}
+
+		err := RunJoinCheck(fakeJoinData{})
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("RunJoinCheck() error got %v, want %v", err, expectedErr)
+		}
+	})
+}

--- a/pkg/yurtadm/cmd/join/phases/postcheck.go
+++ b/pkg/yurtadm/cmd/join/phases/postcheck.go
@@ -20,31 +20,18 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
-	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
 	"github.com/openyurtio/openyurt/pkg/yurtadm/util/kubernetes"
-	"github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
 
-// RunPostCheck executes the node health check and clean process.
-func RunPostCheck(data joindata.YurtJoinData) error {
+var checkKubeletStatusFunc = kubernetes.CheckKubeletStatus
+
+// RunJoinCheck validates the kubelet state after kubeadm join succeeds.
+func RunJoinCheck(_ joindata.YurtJoinData) error {
 	klog.V(1).Infof("check kubelet status.")
-	if err := kubernetes.CheckKubeletStatus(); err != nil {
+	if err := checkKubeletStatusFunc(); err != nil {
 		return err
 	}
 	klog.V(1).Infof("kubelet service is active")
-
-	if data.NodeRegistration().WorkingMode != constants.LocalNode {
-		klog.V(1).Infof("waiting hub agent ready.")
-		if err := yurthub.CheckYurthubServiceHealth(data.YurtHubServer()); err != nil {
-			return err
-		}
-		klog.V(1).Infof("hub agent is ready")
-
-		if err := yurthub.CleanHubBootstrapConfig(); err != nil {
-			return err
-		}
-		klog.V(1).Infof("clean yurthub bootstrap config file success")
-	}
 
 	return nil
 }

--- a/pkg/yurtadm/cmd/join/phases/postconvert.go
+++ b/pkg/yurtadm/cmd/join/phases/postconvert.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/openyurt/pkg/node-servant/components"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
+	yurthubutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
+)
+
+const bootstrapModeKubeletCertificate = "kubeletcertificate"
+
+var (
+	createYurthubSystemdServiceFunc = yurthubutil.CreateYurthubSystemdServiceWithConfig
+	checkYurthubServiceHealthFunc   = yurthubutil.CheckYurthubServiceHealth
+	checkYurthubReadyzFunc          = yurthubutil.CheckYurthubReadyz
+	redirectKubeletTrafficFunc      = func(openyurtDir string) error {
+		return components.NewKubeletOperator(openyurtDir).RedirectTrafficToYurtHub()
+	}
+)
+
+// RunConvert installs yurthub and redirects kubelet traffic on edge and cloud
+// nodes after kubeadm join has completed.
+func RunConvert(data joindata.YurtJoinData) error {
+	if data.NodeRegistration().WorkingMode == constants.LocalNode {
+		return nil
+	}
+
+	mode := data.NodeRegistration().WorkingMode
+	klog.Infof("[post-convert] starting yurthub installation and kubelet redirect for %s node", mode)
+
+	// 1. Configure yurthub with kubeletcertificate bootstrap mode, identical to what node-servant convert uses.
+	yurthubCfg := &yurthubutil.YurthubHostConfig{
+		BootstrapMode: bootstrapModeKubeletCertificate,
+		Namespace:     data.Namespace(),
+		NodeName:      data.NodeRegistration().Name,
+		NodePoolName:  data.NodeRegistration().NodePoolName,
+		ServerAddr:    data.ServerAddr(),
+		WorkingMode:   mode,
+	}
+
+	// 2. Create and start yurthub systemd service.
+	klog.Info("[post-convert] creating yurthub systemd service")
+	if err := createYurthubSystemdServiceFunc(yurthubCfg); err != nil {
+		return err
+	}
+
+	// 3. Wait for yurthub to become healthy.
+	klog.Info("[post-convert] waiting for yurthub to become healthy")
+	if err := checkYurthubServiceHealthFunc(data.YurtHubServer()); err != nil {
+		return err
+	}
+	klog.Info("[post-convert] yurthub service is healthy")
+
+	// 4. Wait for yurthub certificates to be ready.
+	if err := checkYurthubReadyzFunc(data.YurtHubServer()); err != nil {
+		return err
+	}
+	klog.Info("[post-convert] yurthub certificates are ready")
+
+	// 5. Redirect kubelet traffic to yurthub, using the exact same method as node-servant convert.
+	klog.Info("[post-convert] redirecting kubelet traffic to yurthub")
+	if err := redirectKubeletTrafficFunc(constants.OpenyurtDir); err != nil {
+		return err
+	}
+	klog.Info("[post-convert] kubelet traffic redirected to yurthub successfully")
+
+	// 6. Verify kubelet is healthy after the redirect restart.
+	if err := checkKubeletStatusFunc(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/yurtadm/cmd/join/phases/prepare.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare.go
@@ -70,19 +70,11 @@ func RunPrepare(data joindata.YurtJoinData) error {
 	}
 
 	if data.NodeRegistration().WorkingMode != constants.LocalNode {
-		yurthubCfg := yurthub.NewYurthubHostConfigFromJoinData(data)
-		if err := yurtadmutil.SetKubeletConfigForNode(); err != nil {
-			return err
-		}
-		if err := yurthub.SetHubBootstrapConfig(data.ServerAddr(), data.JoinToken(), data.CaCertHashes()); err != nil {
-			return err
-		}
+		// All non-local nodes: install yurthub binary
 		if err := yurthub.CheckAndInstallYurthub(constants.YurthubVersion); err != nil {
 			return err
 		}
-		if err := yurthub.CreateYurthubSystemdServiceWithConfig(yurthubCfg); err != nil {
-			return err
-		}
+
 		if err := yurtadmutil.SetDiscoveryConfig(data); err != nil {
 			return err
 		}

--- a/pkg/yurtadm/cmd/reset/phases/cleanyurtfile.go
+++ b/pkg/yurtadm/cmd/reset/phases/cleanyurtfile.go
@@ -34,7 +34,9 @@ func RunCleanYurtFile() error {
 		constants.KubeletConfigureDir,
 		constants.SysctlK8sConfig,
 		constants.YurthubServicePath,
-		constants.YurthubServiceConfPath} {
+		constants.YurthubServiceConfPath,
+		constants.OpenyurtDir,
+		constants.YurthubExecStart} {
 		if err := os.RemoveAll(file); err != nil {
 			klog.Warningf("Clean file %s fail: %v, please clean it manually.", file, err)
 		}

--- a/pkg/yurtadm/cmd/reset/phases/resetnode.go
+++ b/pkg/yurtadm/cmd/reset/phases/resetnode.go
@@ -26,10 +26,12 @@ import (
 
 	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/reset/resetdata"
 	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
 
 var (
-	execCommand = exec.Command
+	stopYurthubServiceFunc    = yurthub.StopYurthubService
+	disableYurthubServiceFunc = yurthub.DisableYurthubService
 )
 
 func RunResetNode(data resetdata.YurtResetData, in io.Reader, out io.Writer, outErr io.Writer) error {
@@ -60,15 +62,13 @@ func RunResetNode(data resetdata.YurtResetData, in io.Reader, out io.Writer, out
 	return nil
 }
 
+// runStopYurthubService stops and disables the yurthub systemd service.
+// Uses fault-tolerant helpers that silently ignore "not loaded" / "not found"
+// errors, so reset works correctly on nodes that never had yurthub installed
+// (e.g. local-mode nodes).
 func runStopYurthubService() error {
-	cmd := execCommand("systemctl", "stop", constants.YurtHubServiceName)
-	if err := cmd.Run(); err != nil {
+	if err := stopYurthubServiceFunc(); err != nil {
 		return err
 	}
-
-	cmd = execCommand("systemctl", "disable", constants.YurtHubServiceName)
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	return nil
+	return disableYurthubServiceFunc()
 }

--- a/pkg/yurtadm/cmd/reset/phases/resetnode_test.go
+++ b/pkg/yurtadm/cmd/reset/phases/resetnode_test.go
@@ -17,19 +17,20 @@ limitations under the License.
 package phases
 
 import (
-	"os/exec"
+	"errors"
 	"testing"
-
-	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
 )
 
 func Test_runStopYurthubService_Success(t *testing.T) {
-	old := execCommand
-	defer func() { execCommand = old }()
+	oldStop := stopYurthubServiceFunc
+	oldDisable := disableYurthubServiceFunc
+	defer func() {
+		stopYurthubServiceFunc = oldStop
+		disableYurthubServiceFunc = oldDisable
+	}()
 
-	execCommand = func(name string, arg ...string) *exec.Cmd {
-		return exec.Command("true")
-	}
+	stopYurthubServiceFunc = func() error { return nil }
+	disableYurthubServiceFunc = func() error { return nil }
 
 	if err := runStopYurthubService(); err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
@@ -37,12 +38,15 @@ func Test_runStopYurthubService_Success(t *testing.T) {
 }
 
 func Test_runStopYurthubService_StopFails(t *testing.T) {
-	old := execCommand
-	defer func() { execCommand = old }()
+	oldStop := stopYurthubServiceFunc
+	oldDisable := disableYurthubServiceFunc
+	defer func() {
+		stopYurthubServiceFunc = oldStop
+		disableYurthubServiceFunc = oldDisable
+	}()
 
-	execCommand = func(name string, arg ...string) *exec.Cmd {
-		return exec.Command("false")
-	}
+	stopYurthubServiceFunc = func() error { return errors.New("stop failed") }
+	disableYurthubServiceFunc = func() error { return nil }
 
 	if err := runStopYurthubService(); err == nil {
 		t.Fatalf("expected error when stop fails, got nil")
@@ -50,25 +54,15 @@ func Test_runStopYurthubService_StopFails(t *testing.T) {
 }
 
 func Test_runStopYurthubService_DisableFails(t *testing.T) {
-	old := execCommand
-	defer func() { execCommand = old }()
+	oldStop := stopYurthubServiceFunc
+	oldDisable := disableYurthubServiceFunc
+	defer func() {
+		stopYurthubServiceFunc = oldStop
+		disableYurthubServiceFunc = oldDisable
+	}()
 
-	call := 0
-	execCommand = func(name string, arg ...string) *exec.Cmd {
-		call++
-		if call == 1 {
-			if name != "systemctl" || len(arg) < 2 || arg[0] != "stop" {
-				return exec.Command("true")
-			}
-			return exec.Command("true")
-		}
-		if name == "systemctl" && len(arg) > 0 && arg[0] == "disable" {
-			if len(arg) >= 2 && arg[1] == constants.YurtHubServiceName {
-				return exec.Command("false")
-			}
-		}
-		return exec.Command("true")
-	}
+	stopYurthubServiceFunc = func() error { return nil }
+	disableYurthubServiceFunc = func() error { return errors.New("disable failed") }
 
 	if err := runStopYurthubService(); err == nil {
 		t.Fatalf("expected error when disable fails, got nil")

--- a/pkg/yurtadm/util/kubernetes/kubernetes.go
+++ b/pkg/yurtadm/util/kubernetes/kubernetes.go
@@ -305,13 +305,11 @@ func SetKubeletUnitConfig(data joindata.YurtJoinData) error {
 		}
 	}
 
-	nodeReg := data.NodeRegistration()
 	ctx := map[string]interface{}{
 		"kubeconfig": "--kubeconfig=/etc/kubernetes/kubelet.conf",
 	}
-	if nodeReg.WorkingMode == constants.LocalNode {
-		ctx["bootstrapKubeconfig"] = "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf"
-	}
+	// All nodes need bootstrap-kubeconfig for proper TLS bootstrap.
+	ctx["bootstrapKubeconfig"] = "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf"
 
 	kubeletUnitConfigTemplate, err := templates.SubstituteTemplate(constants.KubeletUnitConfig, ctx)
 	if err != nil {
@@ -408,16 +406,12 @@ func SetKubeadmJoinConfig(data joindata.YurtJoinData) error {
 		"name":                   nodeReg.Name,
 	}
 
-	// if node isn't local node, we need to set ignorePreflightErrors and nodeLabels
-	// besides, we don't need to rotate certificates
+	// Non-local nodes still need join-specific preflight overrides and labels.
 	if nodeReg.WorkingMode != constants.LocalNode {
 		ctx["ignorePreflightErrors"] = data.IgnorePreflightErrors().UnsortedList()
 		ctx["nodeLabels"] = constructNodeLabels(data.NodeLabels(), nodeReg.WorkingMode, projectinfo.GetEdgeWorkerLabelKey())
-		ctx["rotateCertificates"] = false
-	} else {
-		// if node is local node, we need to set rotateCertificates to true
-		ctx["rotateCertificates"] = true
 	}
+	ctx["rotateCertificates"] = true
 
 	v1, err := version.NewVersion(data.KubernetesVersion())
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind enhancement

#### What this PR does / why we need it:
This PR is a follow-up to the label-driven YurtNode conversion work in:
https://github.com/openyurtio/openyurt/pull/2533

It currently covers two related parts in `yurtadm`:

  1. Align `yurtadm join` with the new post-join YurtHub conversion flow for both edge and cloud nodes.
     - stop pre-writing `/etc/kubernetes/kubelet.conf` to the YurtHub proxy address
     - keep kubelet TLS bootstrap and certificate rotation enabled
     - split join-time kubelet validation from post-join YurtHub conversion
     - install and start host-level YurtHub after `kubeadm join`, then redirect kubelet traffic using the same `openyurtDir + kubeadm-flags.env` model used by `node-servant convert`
     - add unit tests for join phase ordering and convert behavior

  2. Improve `yurtadm reset` cleanup for the new host-level YurtHub lifecycle.
     - reuse the shared fault-tolerant YurtHub service stop/disable helpers during reset
     - clean additional host artifacts such as the OpenYurt working directory and embedded `yurthub` binary
     - keep `yurtadm config print join-defaults` aligned with the new join-time `rotateCertificates=true` behavior

  These changes make nodes joined by `yurtadm` converge to the same host-side YurtHub and kubelet traffic model expected by the label-driven convert/revert workflow, while also making reset cleanup
  match that new lifecycle.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
