### PR TITLE
feat/naitve service topology

### DIFF
--- a/charts/yurt-manager/templates/yurthub-cfg.yaml
+++ b/charts/yurt-manager/templates/yurthub-cfg.yaml
@@ -71,26 +71,23 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: yurt-hub-yurt-static-set-role
+  name: yurt-hub-bootstrap
 rules:
   - apiGroups:
-      - ""
+      - apps.openyurt.io
     resources:
-      - configmaps
-    resourceNames:
-      - yurt-static-set-yurt-hub
-      - yurt-static-set-yurt-hub-cloud
+      - nodepools
     verbs:
       - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: bootstrap-static-pod
+  name: yurt-hub-bootstrap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: yurt-hub-yurt-static-set-role
+  name: yurt-hub-bootstrap
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
@@ -103,9 +100,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     openyurt.io/configmap-name: yurt-hub-cfg
-    {{- include "yurthub.labels" . | nindent 4 }}
+    {{- include "yurt-manager.labels" . | nindent 4 }}
 data:
-  cache_agents: {{ .Values.cacheAgents | quote }}
+  cache_agents: {{ .Values.yurthub.cacheAgents | quote }}
   servicetopology: ""
   discardcloudservice: ""
   masterservice: ""

--- a/charts/yurt-manager/values.yaml
+++ b/charts/yurt-manager/values.yaml
@@ -37,6 +37,9 @@ nodeServant:
     repository: node-servant
     tag: "latest"
 
+yurthub:
+  cacheAgents: ""
+
 # support extra args of yurt-manager cmd
 extraArgs: []
 

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -415,11 +415,6 @@ func newJoinData(args []string, opt *joinOptions) (*joinData, error) {
 			}
 			// add nodePool label for node by kubelet
 			data.nodeLabels[projectinfo.GetNodePoolLabel()] = opt.nodePoolName
-
-			// set nodePool as topology.kubernetes.io/zone label
-			klog.Infof("setting %s=%s for native trafficDistribution compatibility",
-				yurtconstants.KubernetesTopologyZoneLabel, opt.nodePoolName)
-			data.nodeLabels[yurtconstants.KubernetesTopologyZoneLabel] = opt.nodePoolName
 		}
 
 		// check static pods has value and yurtstaticset is already exist

--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -415,6 +415,11 @@ func newJoinData(args []string, opt *joinOptions) (*joinData, error) {
 			}
 			// add nodePool label for node by kubelet
 			data.nodeLabels[projectinfo.GetNodePoolLabel()] = opt.nodePoolName
+
+			// set nodePool as topology.kubernetes.io/zone label
+			klog.Infof("setting %s=%s for native trafficDistribution compatibility",
+				yurtconstants.KubernetesTopologyZoneLabel, opt.nodePoolName)
+			data.nodeLabels[yurtconstants.KubernetesTopologyZoneLabel] = opt.nodePoolName
 		}
 
 		// check static pods has value and yurtstaticset is already exist

--- a/pkg/yurtadm/constants/constants.go
+++ b/pkg/yurtadm/constants/constants.go
@@ -136,6 +136,8 @@ const (
 	// StaticPods flag set the specified static pods on this node want to install
 	StaticPods = "static-pods"
 
+	KubernetesTopologyZoneLabel = "topology.kubernetes.io/zone"
+
 	KubeletConfFileAvailableError = "FileAvailable--etc-kubernetes-kubelet.conf"
 	ManifestsDirAvailableError    = "DirAvailable--etc-kubernetes-manifests"
 

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -403,45 +403,65 @@ func (r *ReconcileYurtNodeConversion) ensureTopologyZoneLabel(ctx context.Contex
 		return err
 	}
 
-	updated := node.DeepCopy()
-	existingZone, hasZone := node.Labels[zoneLabel]
-
+	existingZone := node.Labels[zoneLabel]
 	klog.Info(Format("node(%s) has %s=%s, isConvert=%t", nodeName, zoneLabel, existingZone, isConvert))
+
 	if isConvert {
-		if len(nodePoolName) == 0 {
-			return nil
-		}
-		if hasZone {
-			if existingZone != nodePoolName {
-				klog.Info(Format("node(%s) already has %s=%s, keep it because it is not nodepool=%s",
-					nodeName, zoneLabel, existingZone, nodePoolName))
-			}
-			return nil
-		}
-		if updated.Labels == nil {
-			updated.Labels = map[string]string{}
-		}
-		updated.Labels[zoneLabel] = nodePoolName
-	} else {
-		if !hasZone {
-			return nil
-		}
-		isNodePool, err := r.isNodePoolName(ctx, existingZone)
-		if err != nil {
-			return err
-		}
-		if !isNodePool {
-			klog.Info(Format("node(%s) keeps %s=%s because it is not a NodePool",
-				nodeName, zoneLabel, existingZone))
-			return nil
-		}
-		delete(updated.Labels, zoneLabel)
+		return r.ensureConvertZoneLabel(ctx, node, nodePoolName)
 	}
+	return r.ensureRevertZoneLabel(ctx, node)
+}
+
+func (r *ReconcileYurtNodeConversion) ensureConvertZoneLabel(ctx context.Context, node *corev1.Node, nodePoolName string) error {
+	if len(nodePoolName) == 0 {
+		return nil
+	}
+
+	existingZone, hasZone := node.Labels[zoneLabel]
+	if hasZone {
+		if existingZone != nodePoolName {
+			klog.Info(Format("node(%s) already has %s=%s, keep it because it is not nodepool=%s",
+				node.Name, zoneLabel, existingZone, nodePoolName))
+		}
+		return nil
+	}
+
+	updated := node.DeepCopy()
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	updated.Labels[zoneLabel] = nodePoolName
 
 	if reflect.DeepEqual(node.Labels, updated.Labels) {
 		return nil
 	}
-	klog.V(4).Info(Format("patch node(%s) %s for native trafficDistribution compatibility", nodeName, zoneLabel))
+	klog.V(4).Info(Format("patch node(%s) %s for native trafficDistribution compatibility", node.Name, zoneLabel))
+	return r.Patch(ctx, updated, client.MergeFrom(node))
+}
+
+func (r *ReconcileYurtNodeConversion) ensureRevertZoneLabel(ctx context.Context, node *corev1.Node) error {
+	existingZone, hasZone := node.Labels[zoneLabel]
+	if !hasZone {
+		return nil
+	}
+
+	isNodePool, err := r.isNodePoolName(ctx, existingZone)
+	if err != nil {
+		return err
+	}
+	if !isNodePool {
+		klog.Info(Format("node(%s) keeps %s=%s because it is not a NodePool",
+			node.Name, zoneLabel, existingZone))
+		return nil
+	}
+
+	updated := node.DeepCopy()
+	delete(updated.Labels, zoneLabel)
+
+	if reflect.DeepEqual(node.Labels, updated.Labels) {
+		return nil
+	}
+	klog.V(4).Info(Format("patch node(%s) %s for native trafficDistribution compatibility", node.Name, zoneLabel))
 	return r.Patch(ctx, updated, client.MergeFrom(node))
 }
 

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -43,6 +43,7 @@ import (
 	appsv1beta2 "github.com/openyurtio/openyurt/pkg/apis/apps/v1beta2"
 	nodeservant "github.com/openyurtio/openyurt/pkg/node-servant"
 	"github.com/openyurtio/openyurt/pkg/projectinfo"
+	"github.com/openyurtio/openyurt/pkg/yurtadm/constants"
 	nodeutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/node"
 	conversionconfig "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/yurtnodeconversion/config"
 )
@@ -60,6 +61,8 @@ const (
 	reasonReverted      = "Reverted"
 	reasonConvertFailed = "ConvertFailed"
 	reasonRevertFailed  = "RevertFailed"
+
+	zoneLabel = constants.KubernetesTopologyZoneLabel
 )
 
 type ReconcileYurtNodeConversion struct {
@@ -333,6 +336,12 @@ func (r *ReconcileYurtNodeConversion) handleSuccessfulAction(ctx context.Context
 		return err
 	}
 
+	// sync topology.kubernetes.io/zone label for Kubernetes native Service
+	nodePoolName := node.Labels[projectinfo.GetNodePoolLabel()]
+	if err := r.ensureTopologyZoneLabel(ctx, nodeName, action == actionConvert, nodePoolName); err != nil {
+		return err
+	}
+
 	if !hasSucceededConditionForAction(getConversionCondition(node), action) {
 		if err := r.ensureNodeConversionCondition(ctx, nodeName,
 			newConversionCondition(action, succeededReasonForAction(action), succeededMessage(action))); err != nil {
@@ -384,6 +393,70 @@ func (r *ReconcileYurtNodeConversion) ensureEdgeWorkerLabel(ctx context.Context,
 	}
 	klog.V(4).Info(Format("patch node(%s) %s=%t", nodeName, projectinfo.GetEdgeWorkerLabelKey(), enabled))
 	return r.Patch(ctx, updated, client.MergeFrom(node))
+}
+
+// ensureTopologyZoneLabel only manages the topology.kubernetes.io/zone label
+// when it is absent during convert or still points to a NodePool during revert.
+func (r *ReconcileYurtNodeConversion) ensureTopologyZoneLabel(ctx context.Context, nodeName string, isConvert bool, nodePoolName string) error {
+	node := &corev1.Node{}
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		return err
+	}
+
+	updated := node.DeepCopy()
+	existingZone, hasZone := node.Labels[zoneLabel]
+
+	if isConvert {
+		if len(nodePoolName) == 0 {
+			return nil
+		}
+		if hasZone {
+			if existingZone != nodePoolName {
+				klog.Info(Format("node(%s) already has %s=%s, keep it because it is not nodepool=%s",
+					nodeName, zoneLabel, existingZone, nodePoolName))
+			}
+			return nil
+		}
+		if updated.Labels == nil {
+			updated.Labels = map[string]string{}
+		}
+		updated.Labels[zoneLabel] = nodePoolName
+	} else {
+		if !hasZone {
+			return nil
+		}
+		isNodePool, err := r.isNodePoolName(ctx, existingZone)
+		if err != nil {
+			return err
+		}
+		if !isNodePool {
+			klog.Info(Format("node(%s) keeps %s=%s because it is not a NodePool",
+				nodeName, zoneLabel, existingZone))
+			return nil
+		}
+		delete(updated.Labels, zoneLabel)
+	}
+
+	if reflect.DeepEqual(node.Labels, updated.Labels) {
+		return nil
+	}
+	klog.V(4).Info(Format("patch node(%s) %s for native trafficDistribution compatibility", nodeName, zoneLabel))
+	return r.Patch(ctx, updated, client.MergeFrom(node))
+}
+
+func (r *ReconcileYurtNodeConversion) isNodePoolName(ctx context.Context, nodePoolName string) (bool, error) {
+	if len(strings.TrimSpace(nodePoolName)) == 0 {
+		return false, nil
+	}
+
+	np := &appsv1beta2.NodePool{}
+	if err := r.Get(ctx, types.NamespacedName{Name: nodePoolName}, np); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // ensureNodeConversionCondition upserts the single conversion condition that

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -406,6 +406,7 @@ func (r *ReconcileYurtNodeConversion) ensureTopologyZoneLabel(ctx context.Contex
 	updated := node.DeepCopy()
 	existingZone, hasZone := node.Labels[zoneLabel]
 
+	klog.Info(Format("node(%s) has %s=%s, isConvert=%t", nodeName, zoneLabel, existingZone, isConvert))
 	if isConvert {
 		if len(nodePoolName) == 0 {
 			return nil

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
@@ -89,6 +89,7 @@ func TestReconcileConvertSuccess(t *testing.T) {
 	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, updatedNode))
 	assert.False(t, updatedNode.Spec.Unschedulable)
 	assert.Equal(t, "true", updatedNode.Labels[projectinfo.GetEdgeWorkerLabelKey()])
+	assert.Equal(t, "pool-a", updatedNode.Labels["topology.kubernetes.io/zone"])
 
 	cond := getConversionCondition(updatedNode)
 	require.NotNil(t, cond)
@@ -196,6 +197,7 @@ func TestReconcileRevertSuccess(t *testing.T) {
 	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, updatedNode))
 	assert.False(t, updatedNode.Spec.Unschedulable)
 	assert.NotContains(t, updatedNode.Labels, projectinfo.GetEdgeWorkerLabelKey())
+	assert.NotContains(t, updatedNode.Labels, "topology.kubernetes.io/zone")
 
 	cond := getConversionCondition(updatedNode)
 	require.NotNil(t, cond)
@@ -564,4 +566,73 @@ func newCloudNodePool(name string) *appsv1beta2.NodePool {
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       appsv1beta2.NodePoolSpec{Type: appsv1beta2.Cloud},
 	}
+}
+
+func TestConvertSuccessKeepsExistingNonNodePoolZoneLabel(t *testing.T) {
+	node := newNode("node-a", map[string]string{
+		projectinfo.GetNodePoolLabel(): "pool-a",
+		"topology.kubernetes.io/zone":  "old-zone",
+	}, true, newNodeCondition(reasonConverting, corev1.ConditionFalse))
+	job := newConversionJobForTest(t, actionConvert, "node-a")
+	job.Status.Conditions = []batchv1.JobCondition{{
+		Type:   batchv1.JobComplete,
+		Status: corev1.ConditionTrue,
+	}}
+	job.Status.Succeeded = 1
+
+	r, cli := newReconcilerForTest(t, node, job)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-a"}})
+	require.NoError(t, err)
+
+	updatedNode := &corev1.Node{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, updatedNode))
+	assert.Equal(t, "old-zone", updatedNode.Labels["topology.kubernetes.io/zone"],
+		"zone label should be kept when it does not match the nodepool name")
+}
+
+func TestRevertSuccessRemovesNodePoolZoneLabel(t *testing.T) {
+	node := newNode("node-a", map[string]string{
+		projectinfo.GetEdgeWorkerLabelKey(): "true",
+		"topology.kubernetes.io/zone":       "pool-a",
+	}, true, newNodeCondition(reasonReverting, corev1.ConditionFalse))
+	job := newConversionJobForTest(t, actionRevert, "node-a")
+	job.Status.Conditions = []batchv1.JobCondition{{
+		Type:   batchv1.JobComplete,
+		Status: corev1.ConditionTrue,
+	}}
+	job.Status.Succeeded = 1
+
+	r, cli := newReconcilerForTest(t, node, job, newEdgeNodePool("pool-a"))
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-a"}})
+	require.NoError(t, err)
+
+	updatedNode := &corev1.Node{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, updatedNode))
+	assert.NotContains(t, updatedNode.Labels, "topology.kubernetes.io/zone",
+		"nodepool zone label should be removed after revert")
+}
+
+func TestRevertSuccessKeepsNonNodePoolZoneLabel(t *testing.T) {
+	node := newNode("node-a", map[string]string{
+		projectinfo.GetEdgeWorkerLabelKey(): "true",
+		"topology.kubernetes.io/zone":       "old-zone",
+	}, true, newNodeCondition(reasonReverting, corev1.ConditionFalse))
+	job := newConversionJobForTest(t, actionRevert, "node-a")
+	job.Status.Conditions = []batchv1.JobCondition{{
+		Type:   batchv1.JobComplete,
+		Status: corev1.ConditionTrue,
+	}}
+	job.Status.Succeeded = 1
+
+	r, cli := newReconcilerForTest(t, node, job, newEdgeNodePool("pool-a"))
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-a"}})
+	require.NoError(t, err)
+
+	updatedNode := &corev1.Node{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, updatedNode))
+	assert.Equal(t, "old-zone", updatedNode.Labels["topology.kubernetes.io/zone"],
+		"non-nodepool zone label should be kept after revert")
 }

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -48,13 +48,6 @@ const (
 	conversionConditionType corev1.NodeConditionType = "YurtNodeConversionFailed"
 )
 
-var (
-	converterExecCommand               = exec.Command
-	converterInstallRenderedComponents = func(kubeConfigPath, manifestPath string) error {
-		return kubeutil.NewBuilder(kubeConfigPath).InstallComponents(manifestPath, false)
-	}
-)
-
 type ClusterConverter struct {
 	RootDir                   string
 	ClientSet                 kubeclientset.Interface
@@ -86,12 +79,6 @@ func (c *ClusterConverter) Run() error {
 	klog.Info("Deploying yurt-manager")
 	if err := c.installYurtManagerByHelm(); err != nil {
 		klog.Errorf("failed to deploy yurt-manager with image %s, %s", c.YurtManagerImage, err)
-		return err
-	}
-
-	klog.Info("Deploying yurthub chart resources")
-	if err := c.installYurthubByHelm(); err != nil {
-		klog.Errorf("failed to deploy yurthub chart resources, %v", err)
 		return err
 	}
 
@@ -461,48 +448,6 @@ func (c *ClusterConverter) installYurtManagerByHelm() error {
 		return err
 	}
 
-	return nil
-}
-
-func (c *ClusterConverter) installYurthubByHelm() error {
-	helmPath := filepath.Join(c.RootDir, "bin", "helm")
-	yurthubChartPath := filepath.Join(c.RootDir, "charts", "yurthub")
-
-	cmd := converterExecCommand(
-		helmPath,
-		"template",
-		"yurthub",
-		yurthubChartPath,
-		"--namespace",
-		"kube-system",
-		"--show-only",
-		"templates/yurthub-cfg.yaml",
-	)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		klog.Errorf("couldn't install yurthub, %v, %s", err, string(output))
-		return err
-	}
-
-	manifestFile, err := os.CreateTemp("", "openyurt-yurthub-cfg-*.yaml")
-	if err != nil {
-		return fmt.Errorf("failed to create temp file for yurthub resources: %w", err)
-	}
-	defer os.Remove(manifestFile.Name())
-
-	if _, err := manifestFile.Write(output); err != nil {
-		_ = manifestFile.Close()
-		return fmt.Errorf("failed to write rendered yurthub resources: %w", err)
-	}
-	if err := manifestFile.Close(); err != nil {
-		return fmt.Errorf("failed to close rendered yurthub resources file: %w", err)
-	}
-
-	if err := converterInstallRenderedComponents(c.KubeConfigPath, manifestFile.Name()); err != nil {
-		return fmt.Errorf("failed to install rendered yurthub resources: %w", err)
-	}
-
-	klog.Infof("start to install yurthub shared resources, %s", string(output))
 	return nil
 }
 

--- a/test/e2e/cmd/init/converter_test.go
+++ b/test/e2e/cmd/init/converter_test.go
@@ -18,9 +18,6 @@ package init
 
 import (
 	"context"
-	"os"
-	"os/exec"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -271,64 +268,6 @@ func TestIsNodeConversionSettled(t *testing.T) {
 				t.Fatalf("unexpected settled state: got %t want %t", settled, tt.wantSettled)
 			}
 		})
-	}
-}
-
-func TestClusterConverter_InstallYurthubByHelm(t *testing.T) {
-	origExecCommand := converterExecCommand
-	origInstallRenderedComponents := converterInstallRenderedComponents
-	defer func() {
-		converterExecCommand = origExecCommand
-		converterInstallRenderedComponents = origInstallRenderedComponents
-	}()
-
-	renderedManifest := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: yurt-hub-cfg\n"
-	converterExecCommand = func(name string, args ...string) *exec.Cmd {
-		expectedName := "/tmp/openyurt/bin/helm"
-		expectedArgs := []string{
-			"template",
-			"yurthub",
-			"/tmp/openyurt/charts/yurthub",
-			"--namespace",
-			"kube-system",
-			"--show-only",
-			"templates/yurthub-cfg.yaml",
-		}
-		if name != expectedName {
-			t.Fatalf("unexpected helm path: got %q want %q", name, expectedName)
-		}
-		if !reflect.DeepEqual(args, expectedArgs) {
-			t.Fatalf("unexpected helm args: got %v want %v", args, expectedArgs)
-		}
-
-		return exec.Command("/bin/sh", "-c", "printf '%s' \""+renderedManifest+"\"")
-	}
-
-	var installedKubeConfig string
-	var installedManifest string
-	converterInstallRenderedComponents = func(kubeConfigPath, manifestPath string) error {
-		content, err := os.ReadFile(manifestPath)
-		if err != nil {
-			return err
-		}
-		installedKubeConfig = kubeConfigPath
-		installedManifest = string(content)
-		return nil
-	}
-
-	converter := &ClusterConverter{
-		RootDir:        "/tmp/openyurt",
-		KubeConfigPath: "/tmp/openyurt/kubeconfig",
-	}
-
-	if err := converter.installYurthubByHelm(); err != nil {
-		t.Fatalf("installYurthubByHelm returned error: %v", err)
-	}
-	if installedKubeConfig != converter.KubeConfigPath {
-		t.Fatalf("unexpected kubeconfig path: got %q want %q", installedKubeConfig, converter.KubeConfigPath)
-	}
-	if installedManifest != renderedManifest {
-		t.Fatalf("unexpected rendered manifest: got %q want %q", installedManifest, renderedManifest)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind enhancement

#### What this PR does / why we need it:
1. https://openyurt.io/docs/next/user-manuals/network/service/service-topology/
As the OpenYurt community will no longer maintain **Service Topology** feature, we recommend using the native `topology.kubernetes.io/zone` label as an alternative. This PR sets `topology.kubernetes.io/zone=<nodepool-name>` by default for nodes managed by OpenYurt, enabling native topology-aware traffic distribution based on NodePool semantics.
2. move the YurtHub-related RBAC under yurt-manager, so they no longer need to be deployed separately.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
