### PR TITLE
Bugfix: make verify work without fetched tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,8 @@ After committing to your forked OpenYurt repository, you can submit a pull reque
 
 In most cases, one pull request should only focus on one work, such as fixing a bug. Thus, only one commit should be contained in one pull request. You should amend your pull request if you find that there are more than one commits in it, using `git reset` and `git commit` at your local host. After your amending, you can push it to your forked openyurt repository through `git push`(usually need to do it forcefully, take caution). The submitted pull request will sync with the branch you select to merge(at step 3), and no need to create a new pull request.
 
+Before opening the PR, run the same checks that CI expects locally: `make verify`, `make test`, and `make lint`. The verification flow bootstraps pinned helper binaries such as `kustomize` into the repository-local `./bin` directory when needed.
+
 You should check the CI workflow after submitting your pull request and make all the check passed. Then, you just need to wait for the review and approval from community members. If the community accepts your pull request, it will be labeled as `lgtm`(looks good to me) and `approve`.
 
 ## Review

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,12 @@ GOLANGCILINT_VERSION ?= v2.11.4
 GLOBAL_GOLANGCILINT := $(shell which golangci-lint)
 GOBIN := $(shell go env GOPATH)/bin
 GOBIN_GOLANGCILINT := $(shell which $(GOBIN)/golangci-lint)
+GLOBAL_GOLANGCILINT_VERSION := $(shell test -x "$(GLOBAL_GOLANGCILINT)" && "$(GLOBAL_GOLANGCILINT)" version --short 2>/dev/null)
+GOBIN_GOLANGCILINT_VERSION := $(shell test -x "$(GOBIN_GOLANGCILINT)" && "$(GOBIN_GOLANGCILINT)" version --short 2>/dev/null)
 TARGET_PLATFORMS ?= linux/amd64
-BRANCH_TAG = $(shell git describe --abbrev=0 --tags)
+BRANCH_TAG = $(shell bash hack/lib/git-version.sh latest-tag)
 IMAGE_REPO ?= openyurt
-IMAGE_TAG ?= $(BRANCH_TAG)
+IMAGE_TAG ?= $(shell bash hack/lib/git-version.sh image-tag)
 GIT_COMMIT = $(shell git rev-parse HEAD)
 ENABLE_AUTONOMY_TESTS ?=true
 BUILD_KUSTOMIZE ?= _output/manifest
@@ -31,12 +33,6 @@ OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m)
 ifeq ($(ARCH),x86_64)
 	ARCH := amd64
-endif
-
-ifeq ($(IMAGE_TAG),$(BRANCH_TAG))
-	ifeq ($(shell git tag --points-at ${GIT_COMMIT}),)
-		IMAGE_TAG :=$(IMAGE_TAG)-$(shell echo ${GIT_COMMIT} | cut -c 1-7)
-	endif
 endif
 
 GIT_VERSION := $(IMAGE_TAG)
@@ -141,9 +137,9 @@ install-helm: $(LOCALBIN)
 	fi
 
 install-golint: ## check golint if not exist install golint tools
-ifeq ($(shell $(GLOBAL_GOLANGCILINT) version --short), $(GOLANGCILINT_VERSION))
+ifeq ($(GLOBAL_GOLANGCILINT_VERSION), $(GOLANGCILINT_VERSION))
 GOLINT_BIN=$(GLOBAL_GOLANGCILINT)
-else ifeq ($(shell $(GOBIN_GOLANGCILINT) version --short), $(GOLANGCILINT_VERSION))
+else ifeq ($(GOBIN_GOLANGCILINT_VERSION), $(GOLANGCILINT_VERSION))
 GOLINT_BIN=$(GOBIN_GOLANGCILINT)
 else
 	@{ \
@@ -242,7 +238,6 @@ $(KUBECTL): $(LOCALBIN)
 	test -s $(LOCALBIN)/kubectl || curl https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell go env GOOS)/$(shell go env GOARCH)/kubectl -o $(KUBECTL)
 	chmod +x $(KUBECTL)
 
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -250,7 +245,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
 		rm -f $(LOCALBIN)/kustomize; \
 	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	test -s $(LOCALBIN)/kustomize || bash hack/lib/install-kustomize.sh $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: yq
 yq:

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -86,7 +86,7 @@ get_maintained_versions() {
     MAINTAINED_VERSION_NUM=${MAINTAINED_VERSION_NUM:-3}
     allVersions=$(git for-each-ref refs/tags --sort=authordate | awk '{print $3}' | awk -F '/' '{print $3}')
     latestVersion=$(git for-each-ref refs/tags --sort=authordate | awk 'END{print}' |awk '{print $3}' | awk -F '/' '{print $3}')
-    if [ -z "${latestVersion}" ]; then
+    if [[ -z "${latestVersion}" ]]; then
         return 0
     fi
     major=$(echo $latestVersion | awk -F '.' '{print $1}')

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -86,6 +86,9 @@ get_maintained_versions() {
     MAINTAINED_VERSION_NUM=${MAINTAINED_VERSION_NUM:-3}
     allVersions=$(git for-each-ref refs/tags --sort=authordate | awk '{print $3}' | awk -F '/' '{print $3}')
     latestVersion=$(git for-each-ref refs/tags --sort=authordate | awk 'END{print}' |awk '{print $3}' | awk -F '/' '{print $3}')
+    if [ -z "${latestVersion}" ]; then
+        return 0
+    fi
     major=$(echo $latestVersion | awk -F '.' '{print $1}')
     major=${major#v}
     minor=$(echo $latestVersion | awk -F '.' '{print $2}')
@@ -104,12 +107,5 @@ get_maintained_versions() {
 }
 
 get_image_tag() {
-    tag=$(git describe --abbrev=0 --tags)
-    commit=$(git rev-parse HEAD) 
-    
-    if $(git tag --points-at ${commit}); then
-        echo ${tag}-$(echo ${commit} | cut -c 1-7)
-    else
-        echo ${tag}
-    fi
+    bash "${YURT_ROOT}/hack/lib/git-version.sh" image-tag
 }

--- a/hack/lib/git-version.sh
+++ b/hack/lib/git-version.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The OpenYurt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: hack/lib/git-version.sh <latest-tag|version|image-tag|short-commit>
+EOF
+}
+
+latest_tag() {
+    git describe --abbrev=0 --tags 2>/dev/null || true
+}
+
+short_commit() {
+    git rev-parse --short=7 HEAD
+}
+
+version() {
+    local tag
+    tag=$(latest_tag)
+    if [[ -n "${tag}" ]]; then
+        echo "${tag}"
+        return
+    fi
+
+    echo "dev-$(short_commit)"
+}
+
+image_tag() {
+    local tag
+    tag=$(latest_tag)
+    if [[ -z "${tag}" ]]; then
+        echo "dev-$(short_commit)"
+        return
+    fi
+
+    if git tag --points-at HEAD | grep -q .; then
+        echo "${tag}"
+        return
+    fi
+
+    echo "${tag}-$(short_commit)"
+}
+
+main() {
+    if [[ $# -ne 1 ]]; then
+        usage >&2
+        exit 1
+    fi
+
+    case "$1" in
+        latest-tag)
+            latest_tag
+            ;;
+        version)
+            version
+            ;;
+        image-tag)
+            image_tag
+            ;;
+        short-commit)
+            short_commit
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/hack/lib/git-version.sh
+++ b/hack/lib/git-version.sh
@@ -22,14 +22,17 @@ usage() {
     cat <<'EOF'
 Usage: hack/lib/git-version.sh <latest-tag|version|image-tag|short-commit>
 EOF
+    return 0
 }
 
 latest_tag() {
     git describe --abbrev=0 --tags 2>/dev/null || true
+    return 0
 }
 
 short_commit() {
     git rev-parse --short=7 HEAD
+    return 0
 }
 
 version() {
@@ -41,6 +44,7 @@ version() {
     fi
 
     echo "dev-$(short_commit)"
+    return 0
 }
 
 image_tag() {
@@ -57,6 +61,7 @@ image_tag() {
     fi
 
     echo "${tag}-$(short_commit)"
+    return 0
 }
 
 main() {
@@ -65,7 +70,9 @@ main() {
         exit 1
     fi
 
-    case "$1" in
+    local command="$1"
+
+    case "${command}" in
         latest-tag)
             latest_tag
             ;;
@@ -83,6 +90,8 @@ main() {
             exit 1
             ;;
     esac
+
+    return 0
 }
 
 main "$@"

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -25,7 +25,7 @@ YURT_LOCAL_BIN_DIR=${YURT_OUTPUT_DIR}/local/bin
 
 PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
 LABEL_PREFIX=${LABEL_PREFIX:-openyurt.io}
-GIT_VERSION=${GIT_VERSION:-$(git describe --abbrev=0 --tags)}
+GIT_VERSION=${GIT_VERSION:-$(bash "${YURT_ROOT}/hack/lib/git-version.sh" version)}
 GIT_COMMIT=$(git rev-parse HEAD)
 BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 NODEPOOL_LABEL_KEY=${NODEPOOL_LABEL_KEY:-apps.openyurt.io/nodepool}

--- a/hack/lib/install-kustomize.sh
+++ b/hack/lib/install-kustomize.sh
@@ -22,6 +22,7 @@ usage() {
     cat <<'EOF'
 Usage: hack/lib/install-kustomize.sh <version-without-leading-v> <destination-dir>
 EOF
+    return 0
 }
 
 checksum_command() {
@@ -73,6 +74,7 @@ main() {
     tar -xzf "${archive}" -C "${destination_dir}" kustomize
     chmod +x "${destination_dir}/kustomize"
     rm -f "${archive}" "${checksums}"
+    return 0
 }
 
 main "$@"

--- a/hack/lib/install-kustomize.sh
+++ b/hack/lib/install-kustomize.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The OpenYurt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: hack/lib/install-kustomize.sh <version-without-leading-v> <destination-dir>
+EOF
+}
+
+checksum_command() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        echo "sha256sum"
+        return
+    fi
+
+    if command -v shasum >/dev/null 2>&1; then
+        echo "shasum -a 256"
+        return
+    fi
+
+    echo "missing checksum tool: need sha256sum or shasum" >&2
+    exit 1
+}
+
+main() {
+    if [[ $# -ne 2 ]]; then
+        usage >&2
+        exit 1
+    fi
+
+    local version="$1"
+    local destination_dir="$2"
+    local os
+    local arch
+    os=$(go env GOOS)
+    arch=$(go env GOARCH)
+
+    mkdir -p "${destination_dir}"
+
+    local release_tag="kustomize/v${version}"
+    local asset_name="kustomize_v${version}_${os}_${arch}.tar.gz"
+    local base_url="https://github.com/kubernetes-sigs/kustomize/releases/download/${release_tag}"
+    local archive="${destination_dir}/${asset_name}"
+    local checksums="${destination_dir}/checksums.txt"
+    local checksum_tool
+    checksum_tool=$(checksum_command)
+
+    curl -fsSL -o "${archive}" "${base_url}/${asset_name}"
+    curl -fsSL -o "${checksums}" "${base_url}/checksums.txt"
+
+    (
+        cd "${destination_dir}"
+        grep " ${asset_name}\$" checksums.txt | ${checksum_tool} -c -
+    )
+
+    tar -xzf "${archive}" -C "${destination_dir}" kustomize
+    chmod +x "${destination_dir}/kustomize"
+    rm -f "${archive}" "${checksums}"
+}
+
+main "$@"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
## Summary
- add a shared git-version helper so fresh or `--no-tags` checkouts fall back to `dev-<short-sha>` instead of failing on `git describe`
- replace the runtime kustomize `curl | bash` bootstrap with a repository-owned installer that downloads pinned release assets and verifies checksums
- document the local verification entry points that match CI

#### Which issue(s) this PR fixes:
Fixes #2569

#### Special notes for your reviewer:
- This change is limited to the contributor verification/bootstrap path and related documentation.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

## Linked Issue
Fixes #2569

## What Changed
- added `hack/lib/git-version.sh` and reused it from the `Makefile` and `hack/lib/init.sh`
- guarded `golangci-lint` version detection so fresh clones do not try to execute a bare `version` command during makefile parsing
- added `hack/lib/install-kustomize.sh` to download the pinned kustomize release tarball and verify its checksum
- updated `CONTRIBUTING.md` to point contributors at the same local verification commands CI expects

## Verification
- `tmpdir=$(mktemp -d) && git clone --depth 1 --no-tags file:///Users/rootp1/Documents/repos/openyurt "$tmpdir/openyurt-no-tags" >/dev/null && cp /Users/rootp1/Documents/repos/openyurt/Makefile "$tmpdir/openyurt-no-tags/Makefile" && cp /Users/rootp1/Documents/repos/openyurt/CONTRIBUTING.md "$tmpdir/openyurt-no-tags/CONTRIBUTING.md" && cp /Users/rootp1/Documents/repos/openyurt/hack/lib/git-version.sh /Users/rootp1/Documents/repos/openyurt/hack/lib/install-kustomize.sh /Users/rootp1/Documents/repos/openyurt/hack/lib/init.sh /Users/rootp1/Documents/repos/openyurt/hack/lib/common.sh "$tmpdir/openyurt-no-tags/hack/lib/" && cd "$tmpdir/openyurt-no-tags" && make print-version` — passed
- `make lint` — passed
- `make test` — failed: the local Go 1.25 toolchain on this host is missing `go tool covdata`, which causes repeated `go: no such tool "covdata"` failures in unchanged packages
- `make verify` — not run to completion: the host stalled indefinitely while downloading the pinned `kubectl` binary from `https://dl.k8s.io/release/v1.34.3/bin/darwin/arm64/kubectl`

## Scope
- Only the verify/bootstrap path, its shared git-version helper, and the related contributor documentation were changed.
