### PR TITLE
Docs: fix incorrect ConfigMap name in YurtHub README

### DIFF
--- a/pkg/yurthub/README.md
+++ b/pkg/yurthub/README.md
@@ -47,7 +47,7 @@ The cached data are saved in the following node disk location
 Only response for built-in agent names such as kubelet/flanneld/coredns/kube-proxy can be cached on local disk.
 In order to leverage the cache capability of Yurthub for customize node components that need to access cloud site APIserver,
 please do the following:
-1. Add component `User-Agent` in `cache_agents` field of `kube-system/yurthb-cfg` configmap. take `foo` and `bar` component as example:
+1. Add component `User-Agent` in `cache_agents` field of `kube-system/yurt-hub-cfg` configmap. take `foo` and `bar` component as example:
 ```
 apiVersion: v1
 kind: ConfigMap
@@ -58,4 +58,4 @@ data:
   cache_agents: "foo, bar"
 ```
 
-2. If you want to enable cache capability for all components, please configure `*` for `cache_agents` field of `kube-system/yurthb-cfg` configmap.
+2. If you want to enable cache capability for all components, please configure `*` for `cache_agents` field of `kube-system/yurt-hub-cfg` configmap.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Fixes incorrect ConfigMap name in the YurtHub README. The **Register Customize Components** section referenced `kube-system/yurthb-cfg`, but the actual ConfigMap used throughout OpenYurt is `yurt-hub-cfg` (in code, Helm charts, and the YAML example in the same section). This typo could mislead users configuring custom cache agents.

#### Which issue(s) this PR fixes:
Fixes #2571 

#### Special notes for your reviewer:
Doc-only change -  2 lines updated in `pkg/yurthub/README.md`. No code or behavior changes.

#### Does this PR introduce a user-facing change?
```release-note
NONE