### PR TITLE
Docs: update charts README to list yurt-iot-dock instead of removed yurt-coordinator

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,4 +1,4 @@
 OpenYurt Charts contains three OpenYurt components:
 - yurt-manager
 - yurthub
-- yurt-coordinator
+- yurt-iot-dock


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Updates `charts/README.md` to replace the removed `yurt-coordinator` chart with `yurt-iot-dock`, matching the actual charts in the repository.

#### Which issue(s) this PR fixes:
Fixes #2573 

#### Special notes for your reviewer:
Doc-only change - 1 line updated in `charts/README.md`.

#### Does this PR introduce a user-facing change?
```release-note
NONE