### PR TITLE
Test: add unit tests for yurthub storage validate helpers

### DIFF
--- a/pkg/yurthub/storage/utils/validate_test.go
+++ b/pkg/yurthub/storage/utils/validate_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
+)
+
+type testKey struct {
+	path string
+}
+
+func (k testKey) Key() string {
+	return k.path
+}
+
+func TestValidateKey(t *testing.T) {
+	cases := map[string]struct {
+		key          storage.Key
+		validKeyType interface{}
+		expectedErr  error
+	}{
+		"nil key": {
+			key:          nil,
+			validKeyType: testKey{},
+			expectedErr:  storage.ErrKeyIsEmpty,
+		},
+		"empty key": {
+			key:          testKey{path: ""},
+			validKeyType: testKey{},
+			expectedErr:  storage.ErrKeyIsEmpty,
+		},
+		"unrecognized key type": {
+			key:          testKey{path: "kubelet/pods.v1.core/default/foo"},
+			validKeyType: storage.ClusterInfoKey{},
+			expectedErr:  storage.ErrUnrecognizedKey,
+		},
+		"valid key": {
+			key:          testKey{path: "kubelet/pods.v1.core/default/foo"},
+			validKeyType: testKey{},
+			expectedErr:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateKey(tc.key, tc.validKeyType)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("ValidateKey() error = %v, want %v", err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestValidateKV(t *testing.T) {
+	cases := map[string]struct {
+		key          storage.Key
+		content      []byte
+		validKeyType interface{}
+		expectedErr  error
+	}{
+		"nil key": {
+			key:          nil,
+			content:      []byte("data"),
+			validKeyType: testKey{},
+			expectedErr:  storage.ErrKeyIsEmpty,
+		},
+		"unrecognized key type": {
+			key:          testKey{path: "kubelet/pods.v1.core/default/foo"},
+			content:      []byte("data"),
+			validKeyType: storage.ClusterInfoKey{},
+			expectedErr:  storage.ErrUnrecognizedKey,
+		},
+		"empty content": {
+			key:          testKey{path: "kubelet/pods.v1.core/default/foo"},
+			content:      []byte{},
+			validKeyType: testKey{},
+			expectedErr:  storage.ErrKeyHasNoContent,
+		},
+		"valid key and content": {
+			key:          testKey{path: "kubelet/pods.v1.core/default/foo"},
+			content:      []byte("data"),
+			validKeyType: testKey{},
+			expectedErr:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateKV(tc.key, tc.content, tc.validKeyType)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("ValidateKV() error = %v, want %v", err, tc.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:
Adds unit tests for `ValidateKey` and `ValidateKV` in `pkg/yurthub/storage/utils/validate.go`.

These helpers are used by YurtHub disk storage (`pkg/yurthub/storage/disk/storage.go`) in Create, Get, Update, List, and UpdateKV operations, but previously had no test coverage (`go test` returned `[no test files]`).

This PR adds `validate_test.go` with table-driven tests covering:
- `ValidateKey`: nil key, empty key, unrecognized key type, valid key
- `ValidateKV`: nil key, unrecognized key type, empty content, valid key and content

#### Which issue(s) this PR fixes:
Fixes #2575 

**Verification performed locally:**

1. **Before change** - confirmed gap exists:
   ```bash
   go test ./pkg/yurthub/storage/utils/... -v
   # Result: [no test files]
   ```

2. **New unit tests** - all pass:
   ```bash
   go test ./pkg/yurthub/storage/utils/... -count=1 -v
   ```
   ```
   === RUN   TestValidateKey
   === RUN   TestValidateKey/nil_key
   === RUN   TestValidateKey/empty_key
   === RUN   TestValidateKey/unrecognized_key_type
   === RUN   TestValidateKey/valid_key
   --- PASS: TestValidateKey (0.00s)

   === RUN   TestValidateKV
   === RUN   TestValidateKV/nil_key
   === RUN   TestValidateKV/unrecognized_key_type
   === RUN   TestValidateKV/empty_content
   === RUN   TestValidateKV/valid_key_and_content
   --- PASS: TestValidateKV (0.00s)

   PASS
   ok   github.com/openyurtio/openyurt/pkg/yurthub/storage/utils
   ```

3. **Regression check** -  disk storage package still passes:
   ```bash
   go test ./pkg/yurthub/storage/... -count=1
   ```
   ```
   ok   github.com/openyurtio/openyurt/pkg/yurthub/storage/disk
   ok   github.com/openyurtio/openyurt/pkg/yurthub/storage/utils
   ```

4. **Manual behavior check** (before writing tests) - confirmed expected errors:
   - nil/empty key → `specified key is empty`
   - wrong key type → `unrecognized key`
   - empty content → `specified key has no contents`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```