### PR TITLE
feat(raven): support fine-grained network config for L3/L7 via gatewa…

### DIFF
--- a/pkg/apis/raven/well_known_labels_annotations.go
+++ b/pkg/apis/raven/well_known_labels_annotations.go
@@ -20,4 +20,7 @@ const (
 	// LabelCurrentGateway indicates which gateway the node is currently belonging to
 	LabelCurrentGateway     = "raven.openyurt.io/gateway"
 	LabelCurrentGatewayType = "raven.openyurt.io/gateway-type"
+
+	AnnotationEnableProxy  = "raven.openyurt.io/enable-proxy"
+	AnnotationEnableTunnel = "raven.openyurt.io/enable-tunnel"
 )

--- a/pkg/yurtmanager/controller/raven/gatewaypickup/gateway_pickup_controller.go
+++ b/pkg/yurtmanager/controller/raven/gatewaypickup/gateway_pickup_controller.go
@@ -240,7 +240,10 @@ func (r *ReconcileGateway) electActiveEndpoint(nodeList corev1.NodeList, gw *rav
 	}
 	klog.V(1).Info(Format("Ready node has %d, node %v", len(readyNodes), readyNodes))
 	// init a endpoints slice
-	enableProxy, enableTunnel := util.CheckServer(context.TODO(), r.Client)
+	globalEnableProxy, globalEnableTunnel := util.CheckServer(context.TODO(), r.Client)
+	enableProxy := util.GetBoolAnnotation(gw.Annotations, raven.AnnotationEnableProxy, globalEnableProxy)
+	enableTunnel := util.GetBoolAnnotation(gw.Annotations, raven.AnnotationEnableTunnel, globalEnableTunnel)
+
 	eps := make([]*ravenv1beta1.Endpoint, 0)
 	if enableProxy {
 		eps = append(eps, electEndpoints(gw, ravenv1beta1.Proxy, readyNodes)...)
@@ -357,7 +360,10 @@ func getActiveEndpointsInfo(eps []*ravenv1beta1.Endpoint) (map[string][]string, 
 }
 
 func (r *ReconcileGateway) configEndpoints(ctx context.Context, gw *ravenv1beta1.Gateway) {
-	enableProxy, enableTunnel := util.CheckServer(ctx, r.Client)
+	globalEnableProxy, globalEnableTunnel := util.CheckServer(ctx, r.Client)
+	enableProxy := util.GetBoolAnnotation(gw.Annotations, raven.AnnotationEnableProxy, globalEnableProxy)
+	enableTunnel := util.GetBoolAnnotation(gw.Annotations, raven.AnnotationEnableTunnel, globalEnableTunnel)
+
 	for idx, val := range gw.Status.ActiveEndpoints {
 		if gw.Status.ActiveEndpoints[idx].Config == nil {
 			gw.Status.ActiveEndpoints[idx].Config = make(map[string]string)

--- a/pkg/yurtmanager/controller/raven/gatewaypickup/gateway_pickup_controller_test.go
+++ b/pkg/yurtmanager/controller/raven/gatewaypickup/gateway_pickup_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/openyurtio/openyurt/pkg/apis/raven"
 	ravenv1beta1 "github.com/openyurtio/openyurt/pkg/apis/raven/v1beta1"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/gatewaypickup/config"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/util"
@@ -417,6 +418,66 @@ func TestReconcileGateway_electActiveEndpoint(t *testing.T) {
 					NodeName: "node-2",
 					Type:     ravenv1beta1.Proxy,
 				},
+			},
+		},
+		{
+			name: "gateway annotation overrides global config to disable proxy",
+			nodeList: corev1.NodeList{
+				Items: []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+						Status:     nodeReadyStatus,
+					},
+				},
+			},
+			gw: &ravenv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gateway-1",
+					Annotations: map[string]string{
+						raven.AnnotationEnableProxy: "false",
+					},
+				},
+				Spec: ravenv1beta1.GatewaySpec{
+					ProxyConfig:  ravenv1beta1.ProxyConfiguration{Replicas: 1},
+					TunnelConfig: ravenv1beta1.TunnelConfiguration{Replicas: 1},
+					Endpoints: []ravenv1beta1.Endpoint{
+						{NodeName: "node-1", Type: ravenv1beta1.Tunnel},
+						{NodeName: "node-1", Type: ravenv1beta1.Proxy},
+					},
+				},
+			},
+			expectedEps: []*ravenv1beta1.Endpoint{
+				{NodeName: "node-1", Type: ravenv1beta1.Tunnel},
+			},
+		},
+		{
+			name: "gateway annotation overrides global config to disable tunnel",
+			nodeList: corev1.NodeList{
+				Items: []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+						Status:     nodeReadyStatus,
+					},
+				},
+			},
+			gw: &ravenv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gateway-1",
+					Annotations: map[string]string{
+						raven.AnnotationEnableTunnel: "false",
+					},
+				},
+				Spec: ravenv1beta1.GatewaySpec{
+					ProxyConfig:  ravenv1beta1.ProxyConfiguration{Replicas: 1},
+					TunnelConfig: ravenv1beta1.TunnelConfiguration{Replicas: 1},
+					Endpoints: []ravenv1beta1.Endpoint{
+						{NodeName: "node-1", Type: ravenv1beta1.Tunnel},
+						{NodeName: "node-1", Type: ravenv1beta1.Proxy},
+					},
+				},
+			},
+			expectedEps: []*ravenv1beta1.Endpoint{
+				{NodeName: "node-1", Type: ravenv1beta1.Proxy},
 			},
 		},
 	}

--- a/pkg/yurtmanager/controller/raven/util/util.go
+++ b/pkg/yurtmanager/controller/raven/util/util.go
@@ -112,3 +112,15 @@ func computeHash(target string) string {
 func FormatName(name string) string {
 	return strings.Join([]string{name, fmt.Sprintf("%08x", rand.Uint32())}, "-")
 }
+
+func GetBoolAnnotation(annotations map[string]string, key string, fallback bool) bool {
+	if val, ok := annotations[key]; ok {
+		if strings.ToLower(val) == "true" {
+			return true
+		}
+		if strings.ToLower(val) == "false" {
+			return false
+		}
+	}
+	return fallback
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind feature
/sig network

#### What this PR does / why we need it:
**What this PR does:**
This PR introduces Gateway-level annotations (`raven.openyurt.io/enable-proxy` and `raven.openyurt.io/enable-tunnel`) to override the cluster-wide `raven-global-config` ConfigMap. It adds a fallback parsing utility (`GetBoolAnnotation`) in the `gatewaypickup` controller to read these annotations before electing endpoints and configuring proxy/tunnel settings. 

**Why we need it:**
This addresses the 2026 H2 Roadmap item to support fine-grained network configuration. In many edge deployments, different NodePools (physical edge sites) have varying network topologies. Some NodePools may require L3 tunneling, while others only need L7 proxy capabilities. Relying solely on the global configuration forces an inefficient "all-or-nothing" approach. This feature empowers administrators with granular control over their individual network domains.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2577 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
I have added unit tests in `gateway_pickup_controller_test.go` to explicitly verify that Gateway annotation overrides take precedence over the global ConfigMap.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Introduced `raven.openyurt.io/enable-proxy` and `raven.openyurt.io/enable-tunnel` annotations to the Gateway CRD, allowing administrators to enable or disable Raven L3 and L7 networking on a per-NodePool (per-Gateway) basis.
