### PR TITLE
feat(yurthub): introduce jittered backoff for certificate manager

### DIFF
--- a/pkg/yurthub/certificate/manager/manager.go
+++ b/pkg/yurthub/certificate/manager/manager.go
@@ -21,8 +21,10 @@ import (
 	"net"
 	"net/url"
 	"path/filepath"
+	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	"github.com/openyurtio/openyurt/cmd/yurthub/app/options"
@@ -108,6 +110,12 @@ func NewYurtHubCertManager(options *options.YurtHubOptions, remoteServers []*url
 }
 
 func (hcm *yurtHubCertManager) Start() {
+	if !hcm.Ready() {
+		// apply jittered backoff before starting to avoid APIServer throttling from sudden spikes in CSR creation
+		delay := wait.Jitter(time.Second, 29.0)
+		klog.Infof("certificates are not ready, apply jittered backoff for %v to avoid APIServer throttling", delay)
+		time.Sleep(delay)
+	}
 	hcm.YurtClientCertificateManager.Start()
 	hcm.YurtServerCertificateManager.Start()
 }

--- a/pkg/yurthub/certificate/token/token.go
+++ b/pkg/yurthub/certificate/token/token.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 	certificatesv1 "k8s.io/api/certificates/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -374,27 +375,47 @@ func (ycm *yurtHubClientCertManager) generateCertClientFn(current *tls.Certifica
 func (ycm *yurtHubClientCertManager) retrieveHubBootstrapConfig(joinToken string) (*clientcmdapi.Config, error) {
 	// retrieve bootstrap config info from cluster-info configmap by bootstrap token
 	serverAddr := findActiveRemoteServer(ycm.remoteServers).Host
-	if cfg, err := token.RetrieveValidatedConfigInfo(ycm.client, &token.BootstrapData{
-		ServerAddr:   serverAddr,
-		JoinToken:    joinToken,
-		CaCertHashes: ycm.caCertHashes,
-	}); err != nil {
-		return nil, errors.Wrap(err, "couldn't retrieve bootstrap config info")
-	} else {
-		clusterInfo := kubeconfigutil.GetClusterFromKubeConfig(cfg)
-		tlsBootstrapCfg := kubeconfigutil.CreateWithToken(
-			fmt.Sprintf("https://%s", serverAddr),
-			"kubernetes",
-			"token-bootstrap-client",
-			clusterInfo.CertificateAuthorityData,
-			joinToken,
-		)
-		if err = kubeconfigutil.WriteToDisk(ycm.getBootstrapConfFile(), tlsBootstrapCfg); err != nil {
-			return nil, errors.Wrap(err, "couldn't save bootstrap-hub.conf to disk")
-		}
 
-		return tlsBootstrapCfg, nil
+	var cfg *clientcmdapi.Config
+	var err error
+
+	backoff := wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   2.0,
+		Jitter:   1.0,
+		Steps:    5,
 	}
+
+	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		cfg, err = token.RetrieveValidatedConfigInfo(ycm.client, &token.BootstrapData{
+			ServerAddr:   serverAddr,
+			JoinToken:    joinToken,
+			CaCertHashes: ycm.caCertHashes,
+		})
+		if err != nil {
+			klog.Errorf("failed to retrieve bootstrap config info, will retry: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't retrieve bootstrap config info after backoff")
+	}
+
+	clusterInfo := kubeconfigutil.GetClusterFromKubeConfig(cfg)
+	tlsBootstrapCfg := kubeconfigutil.CreateWithToken(
+		fmt.Sprintf("https://%s", serverAddr),
+		"kubernetes",
+		"token-bootstrap-client",
+		clusterInfo.CertificateAuthorityData,
+		joinToken,
+	)
+	if err = kubeconfigutil.WriteToDisk(ycm.getBootstrapConfFile(), tlsBootstrapCfg); err != nil {
+		return nil, errors.Wrap(err, "couldn't save bootstrap-hub.conf to disk")
+	}
+
+	return tlsBootstrapCfg, nil
 }
 
 func createHubConfig(tlsBootstrapCfg *clientcmdapi.Config, pemPath string) *clientcmdapi.Config {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
**What this PR does:**
This PR introduces a jittered exponential backoff mechanism in `yurthub`'s certificate manager. Specifically, it injects a randomized delay (using `wait.Jitter`) before the certificate manager loop starts if the certificates are not ready. Additionally, it wraps the `retrieveHubBootstrapConfig` API call with `wait.ExponentialBackoff` so that initial token bootstrapping retries intelligently instead of crashing immediately.

**Why we need it:**
In edge environments, it is common for a network partition to separate the cloud APIServer from edge nodes. If a partition resolves, thousands of disconnected edge nodes will reconnect and simultaneously attempt to request or renew their certificates. This "thunderous herd" of Certificate Signing Requests (CSRs) can severely throttle the cloud APIServer and overwhelm the `yurt-manager` CSR approver. By pushing jittered backoff to the edge agent (`yurthub`), we organically smooth out the load over a randomized time window, preventing cascading control-plane failures.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2579 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
I ran `make test` locally and the `TestReady` logic in `manager_test.go` correctly logged and handled the random jitter delays without breaking test continuity.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Introduced jittered exponential backoff to `yurthub` certificate manager initialization to gracefully scatter CSR generation and prevent APIServer throttling during mass edge-node reconnections.
