### PR TITLE
Test: add ErrUnrecognizedKey tests for disk storage operations

### DIFF
--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -87,6 +87,14 @@ const (
 	  }`
 )
 
+type unrecognizedKey struct {
+	path string
+}
+
+func (k unrecognizedKey) Key() string {
+	return k.path
+}
+
 var _ = BeforeSuite(func() {
 	err := os.RemoveAll(diskStorageTestBaseDir)
 	Expect(err).To(BeNil())
@@ -313,7 +321,34 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 		Expect(err).To(BeNil())
 	})
 
-	// TODO: ErrUnrecognizedKey
+	Context("Test ErrUnrecognizedKey", func() {
+		var unrecognized unrecognizedKey
+		BeforeEach(func() {
+			unrecognized = unrecognizedKey{path: "kubelet/pods.v1.core/default/foo"}
+		})
+
+		It("should return ErrUnrecognizedKey on Create", func() {
+			err = store.Create(unrecognized, []byte("data"))
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
+		})
+		It("should return ErrUnrecognizedKey on Delete", func() {
+			err = store.Delete(unrecognized)
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
+		})
+		It("should return ErrKeyIsEmpty on Get when key type is unrecognized", func() {
+			_, err = store.Get(unrecognized)
+			Expect(err).To(Equal(storage.ErrKeyIsEmpty))
+		})
+		It("should return ErrUnrecognizedKey on List", func() {
+			_, err = store.List(unrecognized)
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
+		})
+		It("should return ErrUnrecognizedKey on Update", func() {
+			_, err = store.Update(unrecognized, []byte("data"), 1)
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
+		})
+	})
+
 	Context("Test Create", func() {
 		var pod *v1.Pod
 		var podKey storage.Key


### PR DESCRIPTION
#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:
Adds integration-level tests for unrecognized key type handling in YurtHub disk storage.

`pkg/yurthub/storage/disk/storage_test.go` had an explicit `// TODO: ErrUnrecognizedKey` but no tests. This PR adds a `Test ErrUnrecognizedKey` context covering Create, Delete, Get, List, and Update when a non-`storageKey` key type is passed.

#### Which issue(s) this PR fixes:
Fixes #2581

#### Special notes for your reviewer:
Test-only change - no production code modified.

**Tests added (5):**
- Create with wrong key type → `ErrUnrecognizedKey`
- Delete with wrong key type → `ErrUnrecognizedKey`
- List with wrong key type → `ErrUnrecognizedKey`
- Update with wrong key type → `ErrUnrecognizedKey`
- Get with wrong key type → `ErrKeyIsEmpty` (current `Get()` maps all `ValidateKey` errors to `ErrKeyIsEmpty` in `storage.go`)

**Verification performed locally:**
```bash
go test ./pkg/yurthub/storage/disk/... -count=1 -ginkgo.focus="ErrUnrecognizedKey" -v
# 5/5 PASS

go test ./pkg/yurthub/storage/disk/... -count=1
# ALL PASS (64 specs)