### PR TITLE
feat: add Claude Code Skills for deploying OpenYurt

### DIFF
--- a/.claude/skills/openyurt-deploy/SKILL.md
+++ b/.claude/skills/openyurt-deploy/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: openyurt-deploy
+description: >
+  Deploy OpenYurt onto an existing Kubernetes cluster. Installs yurt-manager
+  via Helm, creates Edge NodePool CRs, converts existing worker nodes to edge
+  nodes using the label-driven YurtNodeConversionController, and verifies the
+  deployment end-to-end.
+when_to_use: >
+  Use when the user wants to deploy OpenYurt on an existing Kubernetes cluster,
+  install yurt-manager, create NodePools, convert existing worker nodes to edge
+  nodes, or verify an OpenYurt deployment. Also use when the user asks about
+  uninstalling or rolling back an OpenYurt deployment.
+allowed-tools: >
+  Bash(kubectl *)
+  Bash(helm *)
+  Bash(ssh *)
+  Bash(systemctl *)
+  Bash(journalctl *)
+  Read
+  Grep
+disable-model-invocation: true
+---
+
+# OpenYurt Deployment Skill
+
+This skill guides you through deploying OpenYurt on an existing Kubernetes
+cluster. It covers the full lifecycle: preflight checks, installation,
+node conversion, verification, troubleshooting, and uninstallation.
+
+> **Supported OpenYurt versions**:
+> - v1.7.x (Kubernetes ≥ 1.24)
+
+## How to Use This Skill
+
+Follow the deployment flow document for the step-by-step happy path.
+If you encounter errors at any step, consult the troubleshooting guide.
+For rollback or cleanup, see the uninstall document.
+
+### Reference Documents
+
+| Document | Purpose |
+|----------|---------|
+| `references/openyurt-deploy-flow.md` | Step-by-step deployment (happy path) |
+| `references/openyurt-deploy-troubleshooting.md` | Decision tree for common failures |
+| `references/openyurt-deploy-uninstall.md` | Rollback and uninstall procedures |
+
+## Key Concepts
+
+- **yurt-manager**: The central control-plane component deployed as a
+  Deployment on control-plane nodes. Manages NodePools, node conversion,
+  and other OpenYurt controllers.
+
+- **NodePool**: A cluster-scoped CR (`apps.openyurt.io/v1beta2`) that groups
+  nodes. Type can be `Edge` or `Cloud`.
+
+- **Label-driven node conversion**: Applying the label
+  `apps.openyurt.io/nodepool=<pool-name>` to a worker node triggers the
+  `YurtNodeConversionController`, which automatically creates a
+  `node-servant-conversion-<node>` Job to install YurtHub and redirect
+  kubelet traffic.
+
+- **node-servant**: A privileged Job that runs on the target node, installs
+  YurtHub as a static pod, and redirects kubelet API server traffic through
+  YurtHub. Requires `crictl` on the node.
+
+## Important Notes
+
+1. **`crictl` is a hard dependency**: The node-servant conversion process
+   uses `crictl` to list and restart containers. It is NOT installed by
+   default on standard kubeadm setups. Always verify its presence on each
+   target edge node before labeling.
+
+2. **Do not modify the `apps.openyurt.io/nodepool` label in-place**: The
+   admission webhook forbids in-place value changes. To reassign a node to
+   a different NodePool, first remove the label, then re-add it with the
+   new value.
+
+3. **Conversion is automatic and asynchronous**: Once the label is applied,
+   the controller handles everything. Monitor progress via the
+   `YurtNodeConversionFailed` node condition and the conversion Job.
+
+4. **One node at a time is recommended**: Although the controller supports
+   concurrent conversions, converting nodes one at a time makes it easier
+   to diagnose failures.

--- a/.claude/skills/openyurt-deploy/references/openyurt-deploy-flow.md
+++ b/.claude/skills/openyurt-deploy/references/openyurt-deploy-flow.md
@@ -1,0 +1,297 @@
+# OpenYurt Deployment Flow
+
+Step-by-step guide for deploying OpenYurt on an existing Kubernetes cluster.
+Execute each step in order. If any step fails, consult
+`openyurt-deploy-troubleshooting.md`.
+
+---
+
+## Step 1: Preflight Checks
+
+### 1.1 Verify kubectl access
+
+```bash
+kubectl cluster-info
+kubectl get nodes
+```
+
+Confirm the cluster is reachable and all nodes are in `Ready` state.
+
+### 1.2 Verify Helm version
+
+```bash
+helm version --short
+```
+
+Helm **v3.x** is required. If Helm is not installed or is v2, stop and ask
+the user to install Helm v3.
+
+### 1.3 Verify Kubernetes version
+
+```bash
+kubectl version --short 2>/dev/null || kubectl version
+```
+
+Kubernetes **≥ 1.24** is required. OpenYurt v1.7.x does not support earlier
+versions.
+
+### 1.4 Identify node roles
+
+```bash
+kubectl get nodes -o wide --show-labels
+```
+
+Identify which nodes are:
+- **Control-plane nodes**: Have the label `node-role.kubernetes.io/control-plane`
+- **Worker nodes**: All other nodes (candidates for edge conversion)
+
+Ask the user which worker nodes they want to convert to edge nodes.
+
+### 1.5 Verify `crictl` on target edge nodes
+
+For **each** worker node the user wants to convert, SSH in and verify:
+
+```bash
+ssh <user>@<node-ip> "which crictl && crictl --version"
+```
+
+`crictl` (from the `cri-tools` package) is a **hard dependency** of the
+node-servant conversion process. It is used to list and restart containers
+during conversion. If `crictl` is not present:
+
+- **Explain** to the user that `crictl` is a hard requirement for the `node-servant` Job to convert the node.
+- **Ask the user for explicit confirmation** before attempting to install it.
+- **Install it only after confirmation**, using the appropriate command for their OS:
+
+```bash
+# Example: install cri-tools on Debian/Ubuntu
+ssh <user>@<node-ip> "sudo apt-get update && sudo apt-get install -y cri-tools"
+
+# Example: install cri-tools on CentOS/RHEL
+ssh <user>@<node-ip> "sudo yum install -y cri-tools"
+```
+
+> **Do not proceed with conversion until `crictl` is confirmed on every
+> target node.** The conversion Job will fail mid-run if `crictl` is missing.
+
+---
+
+## Step 2: Install yurt-manager via Helm
+
+### 2.1 Add the Helm chart
+
+The chart is included in the OpenYurt repository under `charts/yurt-manager/`.
+
+**Ask the user for confirmation** before running the Helm install command.
+
+If working from a local clone:
+
+```bash
+helm install yurt-manager ./charts/yurt-manager \
+  --namespace kube-system \
+  --create-namespace
+```
+
+If using a remote chart repository:
+
+```bash
+helm repo add openyurt https://openyurtio.github.io/openyurt-helm
+helm repo update
+helm install yurt-manager openyurt/yurt-manager \
+  --namespace kube-system \
+  --create-namespace
+```
+
+### 2.2 Key default values
+
+These are the defaults from `charts/yurt-manager/values.yaml`:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `image.registry` | `openyurt` | Container registry |
+| `image.repository` | `yurt-manager` | Image name |
+| `image.tag` | `""` (uses appVersion `v1.7.0`) | Image tag |
+| `nodeServant.image.registry` | `openyurt` | node-servant registry |
+| `nodeServant.image.repository` | `node-servant` | node-servant image |
+| `nodeServant.image.tag` | `latest` | node-servant tag |
+| `controllers` | `-nodelifecycle,*` | Enabled controllers |
+
+### 2.3 Wait for yurt-manager to be ready
+
+```bash
+kubectl -n kube-system rollout status deployment/yurt-manager --timeout=120s
+```
+
+Verify the pod is running:
+
+```bash
+kubectl -n kube-system get pods -l app.kubernetes.io/name=yurt-manager
+```
+
+### 2.4 Verify CRDs are installed
+
+```bash
+kubectl get crd nodepools.apps.openyurt.io
+```
+
+The Helm chart installs CRDs automatically from `charts/yurt-manager/crds/`,
+including `nodepools.apps.openyurt.io`, `yurtappsets.apps.openyurt.io`, etc.
+
+---
+
+## Step 3: Create Edge NodePool CR
+
+### 3.1 Create an Edge NodePool
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: apps.openyurt.io/v1beta2
+kind: NodePool
+metadata:
+  name: <edge-pool-name>
+spec:
+  type: Edge
+EOF
+```
+
+Replace `<edge-pool-name>` with the desired name (e.g., `edge-beijing`,
+`edge-factory-01`). **Ask the user for the name and wait for their confirmation** before applying the CR.
+
+### 3.2 (Optional) Create a Cloud NodePool
+
+For control-plane / cloud nodes:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: apps.openyurt.io/v1beta2
+kind: NodePool
+metadata:
+  name: <cloud-pool-name>
+spec:
+  type: Cloud
+EOF
+```
+
+### 3.3 Verify NodePool creation
+
+```bash
+kubectl get nodepools
+```
+
+Expected output shows the NodePool(s) with `Type` column set to `Edge`
+or `Cloud`.
+
+---
+
+## Step 4: Convert Worker Nodes to Edge Nodes
+
+This step uses the **label-driven conversion** mechanism. The
+`YurtNodeConversionController` in yurt-manager watches for changes to the
+`apps.openyurt.io/nodepool` label on Node objects. When the label is added,
+it automatically:
+
+1. Cordons the node (sets `spec.unschedulable = true`)
+2. Creates a `node-servant-conversion-<node-name>` Job in `kube-system`
+3. The Job installs YurtHub and redirects kubelet traffic
+4. On success, the controller sets `openyurt.io/is-edge-worker=true`,
+   sets `topology.kubernetes.io/zone=<pool-name>`, and uncordons the node
+
+### 4.1 Label a worker node
+
+Convert one node at a time for easier monitoring. **Ask the user for confirmation** before applying the label:
+
+```bash
+kubectl label node <node-name> apps.openyurt.io/nodepool=<edge-pool-name>
+```
+
+### 4.2 Monitor the conversion Job
+
+```bash
+# Watch the Job
+kubectl -n kube-system get jobs -l openyurt.io/conversion-node=<node-name> -w
+
+# Watch the Job Pod logs
+kubectl -n kube-system logs -f job/node-servant-conversion-<node-name>
+```
+
+### 4.3 Check the node conversion condition
+
+```bash
+kubectl get node <node-name> -o jsonpath='{range .status.conditions[?(@.type=="YurtNodeConversionFailed")]}{.reason}{" "}{.message}{"\n"}{end}'
+```
+
+Expected progression:
+- `Converting` → `conversion Job node-servant-conversion-<node> is running`
+- `Converted` → `YurtHub installed and node converted successfully`
+
+If you see `ConvertFailed`, consult the troubleshooting guide.
+
+### 4.4 Repeat for additional nodes
+
+Label each additional worker node one at a time:
+
+```bash
+kubectl label node <next-node> apps.openyurt.io/nodepool=<edge-pool-name>
+```
+
+Wait for each node to reach `Converted` before proceeding to the next.
+
+---
+
+## Step 5: Verification
+
+### 5.1 Verify NodePool status
+
+```bash
+kubectl get nodepools -o wide
+```
+
+The `ReadyNodes` column should reflect the number of converted nodes.
+The `Nodes` field in the status should list all member nodes.
+
+### 5.2 Verify edge worker labels
+
+```bash
+kubectl get nodes -l openyurt.io/is-edge-worker=true
+```
+
+All converted nodes should appear in this list.
+
+### 5.3 Verify topology zone labels
+
+```bash
+kubectl get nodes --show-labels | grep topology.kubernetes.io/zone
+```
+
+Each converted node should have `topology.kubernetes.io/zone=<pool-name>`.
+
+### 5.4 Verify YurtHub is running on edge nodes
+
+```bash
+# Check for YurtHub static pod on each edge node
+kubectl get pods -A -o wide | grep yurthub
+```
+
+### 5.5 Verify node conditions
+
+```bash
+kubectl get nodes -o custom-columns=NAME:.metadata.name,CONVERSION:.status.conditions[?\(@.type==\"YurtNodeConversionFailed\"\)].reason
+```
+
+All converted nodes should show `Converted`.
+
+### 5.6 Final checklist
+
+Present this final verification checklist to the user to confirm success:
+
+- [x] **yurt-manager pods Ready**: `kubectl -n kube-system get deployment yurt-manager` shows 1/1 ready.
+- [x] **NodePool exists**: `kubectl get nodepools` lists the newly created NodePool.
+- [x] **node-servant completed**: `kubectl -n kube-system get jobs -l openyurt.io/conversion-node` shows completions.
+- [x] **node has edge labels**: `kubectl get nodes -l openyurt.io/is-edge-worker=true` lists the converted nodes.
+- [x] **node is in zone**: Node has `topology.kubernetes.io/zone` set to the NodePool name.
+- [x] **node condition present**: `YurtNodeConversionFailed` shows `Reason: Converted`.
+- [x] **edge node Ready**: Converted nodes remain in a `Ready` state.
+
+```bash
+echo "=== OpenYurt Deployment Complete ==="
+```

--- a/.claude/skills/openyurt-deploy/references/openyurt-deploy-troubleshooting.md
+++ b/.claude/skills/openyurt-deploy/references/openyurt-deploy-troubleshooting.md
@@ -1,0 +1,66 @@
+# OpenYurt Deployment Troubleshooting
+
+Decision tree for diagnosing and resolving common deployment failures. Claude should follow this step-by-step logic when an error occurs.
+
+---
+
+## 1. Conversion Job Failures
+
+Did the conversion fail (Node stuck in `Converting` or condition shows `ConvertFailed`)?
+
+**↓ Yes**
+
+Is the `node-servant-conversion-<node>` Job created?
+Run `kubectl -n kube-system get jobs -l openyurt.io/conversion-node=<node-name>`
+
+- **Yes, Job exists:**
+  - **↓**
+  - Check the Pod status: `kubectl -n kube-system get pods -l openyurt.io/conversion-node=<node-name>`
+  - Is the Pod `Pending`?
+    - **Yes:** Check for scheduling issues (`kubectl describe pod...`). E.g., is the node cordoned by another controller? Is there an image pull failure?
+    - **No (Running/Error/CrashLoopBackOff):** Check the logs: `kubectl -n kube-system logs job/node-servant-conversion-<node-name>`
+    - Does the log say `crictl: command not found`?
+      - **Yes:** Ask the operator for confirmation to install `cri-tools` on the node, then delete the stale Job to retry.
+      - **No:** Does the log say `failed to get apiServerAddress`?
+        - **Yes:** Verify `/etc/kubernetes/kubelet.conf` exists and contains a valid `server` address.
+
+- **No, Job is missing:**
+  - **↓**
+  - Is `yurt-manager` running successfully?
+    - **No:** Go to Section 2 (yurt-manager Issues).
+    - **Yes:** Verify the NodePool type. Is the NodePool type `Cloud`?
+      - **Yes:** The controller intentionally skips `Cloud` NodePools. Only `Edge` NodePools trigger conversion.
+      - **No:** Check if the node already has `openyurt.io/is-edge-worker=true`. If yes, it's already converted.
+
+---
+
+## 2. yurt-manager Issues
+
+Did `yurt-manager` fail to start or are CRDs missing?
+
+**↓ Yes**
+
+Is the `yurt-manager` Pod stuck in `Pending`?
+- **Yes:** Check `node-role.kubernetes.io/control-plane` label on the master node (yurt-manager has a nodeAffinity for control-plane nodes).
+
+Are there errors in the `yurt-manager` logs (`kubectl -n kube-system logs deployment/yurt-manager`)?
+- **Yes:**
+  - Are they certificate/webhook errors? The manager creates self-signed certs at startup. Ensure it has permissions.
+  - Are they RBAC errors? Verify `yurt-manager-controller-role-binding` exists.
+
+Are CRDs missing (`kubectl get crd | grep openyurt`)?
+- **Yes:** Reinstall/upgrade with Helm: `helm upgrade --install yurt-manager ./charts/yurt-manager -n kube-system`
+
+---
+
+## 3. NodePool Label Webhook Rejection
+
+Did `kubectl label node` return: `apps.openyurt.io/nodepool can only be added or removed, not modified in-place`?
+
+**↓ Yes**
+
+- **Explanation:** The OpenYurt admission webhook strictly forbids changing the value of this label in-place to prevent race conditions.
+- **Resolution:**
+  1. Remove the label: `kubectl label node <node-name> apps.openyurt.io/nodepool-` (this triggers a revert).
+  2. Wait for the node condition to show `Reverted`.
+  3. Re-add the label with the new NodePool name: `kubectl label node <node-name> apps.openyurt.io/nodepool=<new-pool-name>`

--- a/.claude/skills/openyurt-deploy/references/openyurt-deploy-uninstall.md
+++ b/.claude/skills/openyurt-deploy/references/openyurt-deploy-uninstall.md
@@ -1,0 +1,183 @@
+# OpenYurt Uninstall & Rollback
+
+Procedures for reverting node conversions and removing OpenYurt from the
+cluster. Follow the steps in order.
+
+---
+
+## Step 1: Revert Edge Nodes
+
+Removing the `apps.openyurt.io/nodepool` label from a converted node
+triggers the `YurtNodeConversionController` to create a **revert** Job.
+The revert Job uninstalls YurtHub and restores direct kubelet-to-apiserver
+communication.
+
+### 1.1 Remove the NodePool label from each edge node
+
+**Ask the user for explicit confirmation** before removing the labels, as this will trigger the revert process.
+
+```bash
+# List all edge nodes
+kubectl get nodes -l openyurt.io/is-edge-worker=true
+
+# Remove the NodePool label (triggers revert)
+kubectl label node <node-name> apps.openyurt.io/nodepool-
+```
+
+### 1.2 Monitor the revert Job
+
+```bash
+kubectl -n kube-system get jobs -l openyurt.io/conversion-node=<node-name> -w
+kubectl -n kube-system logs -f job/node-servant-conversion-<node-name>
+```
+
+### 1.3 Verify the revert completed
+
+```bash
+kubectl get node <node-name> -o jsonpath='{range .status.conditions[?(@.type=="YurtNodeConversionFailed")]}{.reason}{" "}{.message}{"\n"}{end}'
+```
+
+Expected output: `Reverted YurtHub uninstalled and node reverted successfully`
+
+The controller also:
+- Removes the `openyurt.io/is-edge-worker` label
+- Removes the `topology.kubernetes.io/zone` label (only if its value
+  matches a NodePool name)
+- Uncordons the node
+
+### 1.4 Repeat for all edge nodes
+
+```bash
+# Bulk remove labels (use with caution)
+for node in $(kubectl get nodes -l openyurt.io/is-edge-worker=true -o name); do
+  kubectl label "$node" apps.openyurt.io/nodepool-
+  echo "Triggered revert for $node"
+done
+```
+
+Wait for all nodes to reach `Reverted` state before proceeding.
+
+---
+
+## Step 2: Delete NodePool CRs
+
+```bash
+kubectl get nodepools
+kubectl delete nodepool <edge-pool-name>
+kubectl delete nodepool <cloud-pool-name>  # if created
+```
+
+Verify no NodePools remain:
+
+```bash
+kubectl get nodepools
+```
+
+---
+
+## Step 3: Uninstall yurt-manager
+
+```bash
+helm uninstall yurt-manager -n kube-system
+```
+
+Verify the Deployment and associated resources are removed:
+
+```bash
+kubectl -n kube-system get deployment yurt-manager
+kubectl -n kube-system get service yurt-manager-webhook-service
+kubectl -n kube-system get secret yurt-manager-webhook-certs
+```
+
+All should return `not found`.
+
+---
+
+## Step 4: (Optional) Remove CRDs
+
+Helm does **not** remove CRDs on uninstall by design. If you want a full
+cleanup:
+
+```bash
+kubectl delete crd \
+  nodepools.apps.openyurt.io \
+  nodebuckets.apps.openyurt.io \
+  yurtappdaemons.apps.openyurt.io \
+  yurtappsets.apps.openyurt.io \
+  yurtstaticsets.apps.openyurt.io \
+  platformadmins.iot.openyurt.io \
+  poolservices.network.openyurt.io \
+  gateways.raven.openyurt.io
+```
+
+> **Warning**: Deleting CRDs will delete **all** custom resources of those
+> types across the cluster. Only do this if you are fully removing OpenYurt.
+
+---
+
+## Step 5: (Optional) Clean up RBAC
+
+```bash
+kubectl delete clusterrolebinding yurt-manager-controller-role-binding
+kubectl delete clusterrolebinding yurt-manager-webhook-role-binding
+kubectl delete clusterrolebinding yurt-hub-multiplexer-binding
+kubectl delete clusterrole yurt-hub-multiplexer
+```
+
+---
+
+## Step 6: Verify Full Cleanup
+
+```bash
+echo "=== OpenYurt Uninstall Verification ==="
+echo ""
+echo "--- CRDs ---"
+kubectl get crd | grep openyurt || echo "No OpenYurt CRDs found"
+echo ""
+echo "--- NodePools ---"
+kubectl get nodepools 2>/dev/null || echo "NodePool CRD not found (good)"
+echo ""
+echo "--- Edge Worker Labels ---"
+kubectl get nodes -l openyurt.io/is-edge-worker=true 2>/dev/null || echo "No edge worker nodes found (good)"
+echo ""
+echo "--- yurt-manager ---"
+kubectl -n kube-system get deployment yurt-manager 2>/dev/null || echo "yurt-manager not found (good)"
+echo ""
+echo "--- Conversion Jobs ---"
+kubectl -n kube-system get jobs -l openyurt.io/conversion-node 2>/dev/null || echo "No conversion jobs found (good)"
+echo ""
+echo "=== Uninstall Complete ==="
+```
+
+---
+
+## Troubleshooting Revert Failures
+
+If a node revert fails (shows `RevertFailed`):
+
+```bash
+# Check the revert Job logs
+kubectl -n kube-system logs job/node-servant-conversion-<node-name>
+
+# SSH into the node and check YurtHub status
+ssh <user>@<node-ip> "ls /etc/kubernetes/manifests/ | grep yurthub"
+ssh <user>@<node-ip> "systemctl status kubelet"
+```
+
+If the revert Job cannot clean up properly, manual intervention may be
+required on the node:
+
+```bash
+# Remove YurtHub static pod manifest
+ssh <user>@<node-ip> "sudo rm -f /etc/kubernetes/manifests/yurthub.yaml"
+
+# Restore kubelet configuration to point directly to API server
+ssh <user>@<node-ip> "sudo systemctl restart kubelet"
+```
+
+After manual cleanup, remove any remaining labels:
+
+```bash
+kubectl label node <node-name> openyurt.io/is-edge-worker-
+kubectl label node <node-name> topology.kubernetes.io/zone-
+```

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ gopath
 dockerbuild
 hack/cni
 config/demo
-.claude
 
 vendor
 .vscode


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md -->

What type of PR is this?
/kind feature

What this PR does / why we need it:
This PR resolves Phase 1 of #2559 by implementing the `/openyurt-deploy` Claude Code Skill. 

Claude Code Skills are static Markdown files that allow operators to execute interactive, multi-step workflows using slash commands. This lowers the onboarding friction by letting operators deploy OpenYurt end-to-end interactively without needing to manually hunt through documentation.

Implementation Details:
- No code changes: Only static Markdown files added to `.claude/skills/openyurt-deploy/`.
- Safe & Scoped: The skill is restricted via `allowed-tools` to only safe Bash commands (`kubectl`, `helm`, `ssh`, `systemctl`), preventing arbitrary shell execution. It also requires explicit invocation (`disable-model-invocation: true`).
- Preflight Checks: Ensures Kubernetes ≥ 1.24, Helm v3, and explicitly checks for the `crictl` hard-dependency on edge nodes before converting.
- Label-Driven Conversion: Uses the `apps.openyurt.io/nodepool` label to convert nodes and validates the `YurtNodeConversionFailed` condition.
- Interactive: Prompts the operator for explicit confirmation before installing tools, running Helm, applying CRs, or labeling nodes.
- Comprehensive: Includes a step-by-step happy path, a decision tree for troubleshooting common conversion/webhook failures, and a clean uninstall/rollback guide.

Which issue(s) this PR fixes:
Fixes #2559


#### Does this PR introduce a user-facing change?
```release-note
Add Claude Code Skills for deploying OpenYurt interactively via the `/openyurt-deploy` slash command.
