### PR TITLE
Cleanup: remove outdated Kubernetes 1.22 TODO comments in nodelifecycle

### DIFF
--- a/pkg/yurtmanager/controller/nodelifecycle/node_life_cycle_controller.go
+++ b/pkg/yurtmanager/controller/nodelifecycle/node_life_cycle_controller.go
@@ -147,14 +147,12 @@ var labelReconcileInfo = []struct {
 }{
 	{
 		// Reconcile the beta and the stable OS label using the stable label as the source of truth.
-		// TODO(#89477): no earlier than 1.22: drop the beta labels if they differ from the GA labels
 		primaryKey:            v1.LabelOSStable,
 		secondaryKey:          kubeletapis.LabelOS,
 		ensureSecondaryExists: true,
 	},
 	{
 		// Reconcile the beta and the stable arch label using the stable label as the source of truth.
-		// TODO(#89477): no earlier than 1.22: drop the beta labels if they differ from the GA labels
 		primaryKey:            v1.LabelArchStable,
 		secondaryKey:          kubeletapis.LabelArch,
 		ensureSecondaryExists: true,


### PR DESCRIPTION
#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:
This PR cleans up outdated `TODO` comments in the `nodelifecycle` controller. Specifically, it removes the Kubernetes 1.22 references on lines 150 and 157. 

Since OpenYurt v1.7.0 now supports Kubernetes 1.34 and we are well past the 1.22 deprecation thresholds, these comments are no longer relevant. Removing them reduces confusion and improves code maintainability.

#### Which issue(s) this PR fixes:
Fixes #2568 

#### Special notes for your reviewer:
/assign @Itx-Psycho0 @zyjhtangtang

#### Does this PR introduce a user-facing change?
```release-note
NONE
