### PR TITLE
Fix dead reflect.DeepEqual in ensureConvertZoneLabel (#2588)

### DIFF
--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -432,9 +432,6 @@ func (r *ReconcileYurtNodeConversion) ensureConvertZoneLabel(ctx context.Context
 	}
 	updated.Labels[zoneLabel] = nodePoolName
 
-	if reflect.DeepEqual(node.Labels, updated.Labels) {
-		return nil
-	}
 	klog.V(4).Info(Format("patch node(%s) %s for native trafficDistribution compatibility", node.Name, zoneLabel))
 	return r.Patch(ctx, updated, client.MergeFrom(node))
 }


### PR DESCRIPTION
 What type of PR is this?
/kind bug

 What this PR does / why we need it:
The `reflect.DeepEqual` check in `ensureConvertZoneLabel` was unreachable dead code. The only code path that reaches this check is when `hasZone` is false, meaning the label is always newly added when reaching that point. 

Because `node.Labels` (without the `zoneLabel`) can never equal `updated.Labels` (with the newly added `zoneLabel`), the equality check always evaluated to false and the early return was never executed.

This PR removes the dead check to avoid confusion about when the Patch is skipped, preventing potential logic errors in future refactors.

Which issue(s) this PR fixes:
Fixes #2588

Special notes for your reviewer:
@deepak0x


 Does this PR introduce a user-facing change?
```release-note
NONE
