### PR TITLE
cleanup: remove dead reflect.DeepEqual guard in ensureConvertZoneLabel

### DIFF
--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -432,9 +432,6 @@ func (r *ReconcileYurtNodeConversion) ensureConvertZoneLabel(ctx context.Context
 	}
 	updated.Labels[zoneLabel] = nodePoolName
 
-	if reflect.DeepEqual(node.Labels, updated.Labels) {
-		return nil
-	}
 	klog.V(4).Info(Format("patch node(%s) %s for native trafficDistribution compatibility", node.Name, zoneLabel))
 	return r.Patch(ctx, updated, client.MergeFrom(node))
 }

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
@@ -484,6 +484,43 @@ func TestReconcileSkipCloudNodePool(t *testing.T) {
 	assert.Error(t, err, "expected no conversion job for Cloud NodePool")
 }
 
+func TestEnsureConvertZoneLabel(t *testing.T) {
+	t.Run("adds zone label when absent", func(t *testing.T) {
+		r, cli := newReconcilerForTest(t, newNode("node-a", map[string]string{
+			projectinfo.GetNodePoolLabel(): "pool-a",
+		}, false, nil))
+
+		require.NoError(t, r.ensureTopologyZoneLabel(context.Background(), "node-a", true, "pool-a"))
+
+		node := &corev1.Node{}
+		require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, node))
+		assert.Equal(t, "pool-a", node.Labels[zoneLabel])
+	})
+
+	t.Run("keeps existing zone label", func(t *testing.T) {
+		r, cli := newReconcilerForTest(t, newNode("node-b", map[string]string{
+			zoneLabel: "custom-zone",
+		}, false, nil))
+
+		require.NoError(t, r.ensureTopologyZoneLabel(context.Background(), "node-b", true, "pool-a"))
+
+		node := &corev1.Node{}
+		require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-b"}, node))
+		assert.Equal(t, "custom-zone", node.Labels[zoneLabel])
+	})
+
+	t.Run("skips when nodepool name is empty", func(t *testing.T) {
+		r, cli := newReconcilerForTest(t, newNode("node-c", map[string]string{}, false, nil))
+
+		require.NoError(t, r.ensureTopologyZoneLabel(context.Background(), "node-c", true, ""))
+
+		node := &corev1.Node{}
+		require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-c"}, node))
+		_, ok := node.Labels[zoneLabel]
+		assert.False(t, ok)
+	})
+}
+
 func newReconcilerForTest(t *testing.T, objs ...client.Object) (*ReconcileYurtNodeConversion, client.Client) {
 	t.Helper()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In `ensureConvertZoneLabel` the `reflect.DeepEqual` check is dead code. It is only reached when `hasZone` is false, since the `hasZone` branch returns earlier, and the line just above it sets `updated.Labels[zoneLabel] = nodePoolName`. That means `updated.Labels` always has one more entry than `node.Labels`, so `reflect.DeepEqual` is never true, the `return nil` is unreachable, and the `Patch` always runs.

Removing the guard lets the function go straight to the `Patch`, which is what already happens today, so behavior does not change. The same `DeepEqual` pattern in `ensureEdgeWorkerLabel` and `ensureRevertZoneLabel` is meaningful there (the label can already hold the same value), so I left those alone.

#### Which issue(s) this PR fixes:

Fixes #2588

#### Special notes for your reviewer:

No functional change; this is dead-code removal. I added `TestEnsureConvertZoneLabel` with three cases: adds the label when it is absent, keeps an existing zone label, and skips when the nodepool name is empty. `TestReconcileConvertSuccess` already asserts the zone label gets patched on convert. `go test` on the package and `go vet` both pass before and after the change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
