### PR TITLE
fix: prevent yurthub panic on EndpointSlice with nil NodeName

### DIFF
--- a/pkg/yurthub/filter/servicetopology/filter.go
+++ b/pkg/yurthub/filter/servicetopology/filter.go
@@ -253,6 +253,15 @@ func reassembleEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, nodeName 
 
 	var newEps []discoveryv1.Endpoint
 	for i := range endpointSlice.Endpoints {
+		// Endpoint.NodeName is an optional field, so it may be nil for endpoints
+		// whose hosting node is unknown (e.g. externalName or headless backends).
+		// Such endpoints can not be located to a node/nodePool, so they are
+		// discarded here, consistent with the v1beta1 topology handling where a
+		// missing hostname never matches the local node/nodePool.
+		if endpointSlice.Endpoints[i].NodeName == nil {
+			continue
+		}
+
 		if len(nodeName) != 0 {
 			if *endpointSlice.Endpoints[i].NodeName == nodeName {
 				newEps = append(newEps, endpointSlice.Endpoints[i])

--- a/pkg/yurthub/filter/servicetopology/filter_test.go
+++ b/pkg/yurthub/filter/servicetopology/filter_test.go
@@ -1448,6 +1448,213 @@ func TestFilter(t *testing.T) {
 				},
 			},
 		},
+		"v1.EndpointSlice: endpoint with nil NodeName does not panic(node topology)": {
+			responseObject: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						// Endpoint.NodeName is an optional field and can be nil,
+						// e.g. for endpoints whose hosting node is unknown. The
+						// filter must discard it instead of panicking.
+						Addresses: []string{
+							"10.244.1.9",
+						},
+						NodeName: nil,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNode,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind),
+			expectObject: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+				},
+			},
+		},
+		"v1.EndpointSlice: endpoint with nil NodeName does not panic(nodePool topology)": {
+			enableNodePool: true,
+			responseObject: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						// Endpoint.NodeName is an optional field and can be nil,
+						// e.g. for endpoints whose hosting node is unknown. The
+						// filter must discard it instead of panicking.
+						Addresses: []string{
+							"10.244.1.9",
+						},
+						NodeName: nil,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.3",
+						},
+						NodeName: &nodeName2,
+					},
+				},
+			},
+			kubeClient: k8sfake.NewSimpleClientset(
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: currentNodeName,
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "shanghai",
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+						Labels: map[string]string{
+							projectinfo.GetNodePoolLabel(): "hangzhou",
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+						},
+					},
+				},
+			),
+			yurtClient: fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind,
+				&v1beta2.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hangzhou",
+					},
+					Spec: v1beta2.NodePoolSpec{
+						Type: v1beta2.Edge,
+					},
+					Status: v1beta2.NodePoolStatus{
+						Nodes: []string{
+							currentNodeName,
+							"node3",
+						},
+					},
+				},
+				&v1beta2.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shanghai",
+					},
+					Spec: v1beta2.NodePoolSpec{
+						Type: v1beta2.Edge,
+					},
+					Status: v1beta2.NodePoolStatus{
+						Nodes: []string{
+							"node2",
+						},
+					},
+				},
+			),
+			expectObject: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1-np7sf",
+					Namespace: "default",
+					Labels: map[string]string{
+						discovery.LabelServiceName: "svc1",
+					},
+				},
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"10.244.1.2",
+						},
+						NodeName: &currentNodeName,
+					},
+					{
+						Addresses: []string{
+							"10.244.1.5",
+						},
+						NodeName: &nodeName3,
+					},
+				},
+			},
+		},
 		"v1.EndpointSlice: topologyKeys is kubernetes.io/zone": {
 			enableNodePool: true,
 			responseObject: &discovery.EndpointSlice{
@@ -2466,6 +2673,73 @@ func TestFilter(t *testing.T) {
 			}
 			if !reflect.DeepEqual(newObj, tt.expectObject) {
 				t.Errorf("serviceTopologyHandler expect: \n%#+v\nbut got: \n%#+v\n", tt.expectObject, newObj)
+			}
+		})
+	}
+}
+
+func TestReassembleEndpointSlice(t *testing.T) {
+	node1 := "node1"
+	node2 := "node2"
+
+	testcases := map[string]struct {
+		nodeName     string
+		nodes        []string
+		endpoints    []discovery.Endpoint
+		expectNodes  []string // NodeName of endpoints expected to be kept, "" for a nil NodeName endpoint
+		expectLength int
+	}{
+		"node topology keeps only the local node and skips nil NodeName": {
+			nodeName: node1,
+			endpoints: []discovery.Endpoint{
+				{NodeName: &node1, Addresses: []string{"10.244.1.2"}},
+				{NodeName: nil, Addresses: []string{"10.244.1.3"}},
+				{NodeName: &node2, Addresses: []string{"10.244.1.4"}},
+			},
+			expectNodes:  []string{node1},
+			expectLength: 1,
+		},
+		"nodePool topology keeps in-pool nodes and skips nil NodeName": {
+			nodes: []string{node1, node2},
+			endpoints: []discovery.Endpoint{
+				{NodeName: &node1, Addresses: []string{"10.244.1.2"}},
+				{NodeName: nil, Addresses: []string{"10.244.1.3"}},
+				{NodeName: &node2, Addresses: []string{"10.244.1.4"}},
+			},
+			expectNodes:  []string{node1, node2},
+			expectLength: 2,
+		},
+		"all endpoints have nil NodeName results in empty endpoints": {
+			nodeName: node1,
+			endpoints: []discovery.Endpoint{
+				{NodeName: nil, Addresses: []string{"10.244.1.2"}},
+				{NodeName: nil, Addresses: []string{"10.244.1.3"}},
+			},
+			expectNodes:  nil,
+			expectLength: 0,
+		},
+	}
+
+	for k, tt := range testcases {
+		t.Run(k, func(t *testing.T) {
+			eps := &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc-xxxx", Namespace: "default"},
+				Endpoints:  tt.endpoints,
+			}
+
+			// Must not panic even when some endpoints have a nil NodeName.
+			got := reassembleEndpointSlice(eps, tt.nodeName, tt.nodes)
+
+			if len(got.Endpoints) != tt.expectLength {
+				t.Fatalf("expect %d endpoints, but got %d", tt.expectLength, len(got.Endpoints))
+			}
+			for i, ep := range got.Endpoints {
+				if ep.NodeName == nil {
+					t.Fatalf("endpoint with nil NodeName should have been discarded, but got one at index %d", i)
+				}
+				if *ep.NodeName != tt.expectNodes[i] {
+					t.Errorf("expect endpoint[%d] on node %q, but got %q", i, tt.expectNodes[i], *ep.NodeName)
+				}
 			}
 		})
 	}

--- a/pkg/yurthub/proxy/multiplexer/testing/fake_endpointslicesfilter.go
+++ b/pkg/yurthub/proxy/multiplexer/testing/fake_endpointslicesfilter.go
@@ -40,7 +40,7 @@ func (ie *IgnoreEndpointslicesWithNodeName) Filter(obj runtime.Object, stopCh <-
 	var newEps []discovery.Endpoint
 
 	for _, ep := range endpointslice.Endpoints {
-		if *ep.NodeName != ie.IgnoreNodeName {
+		if ep.NodeName == nil || *ep.NodeName != ie.IgnoreNodeName {
 			newEps = append(newEps, ep)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig network

#### What this PR does / why we need it:

`discovery/v1` `Endpoint.NodeName` is an optional `*string` field and can legitimately be `nil` (e.g. for endpoints whose hosting node is unknown). `reassembleEndpointSlice()` in the `servicetopology` filter (`pkg/yurthub/filter/servicetopology/filter.go`) unconditionally dereferenced this pointer, so yurthub panics whenever it processes an `EndpointSlice` with such an endpoint under node/nodePool topology routing.

Because yurthub re-lists/re-watches `EndpointSlice`s on restart, a single offending `EndpointSlice` can put the process into a crash-loop — and since yurthub is the sole reverse-proxy for all kubelet/kube-proxy traffic on an edge node, that node effectively loses its entire path to the API server until the underlying `EndpointSlice` is fixed.

This PR:
- Skips endpoints with a nil `NodeName` instead of dereferencing them, matching the existing `v1beta1` sibling function (`reassembleV1beta1EndpointSlice`), which already handles this safely via a map lookup that returns `""` for a missing key.
- Fixes the same unguarded dereference found in `pkg/yurthub/proxy/multiplexer/testing/fake_endpointslicesfilter.go` (a test fixture used by other packages' tests), so the same bug pattern isn't copy-pasted into future code.
- Audited all other `.NodeName` dereferences in the codebase (`pkg/yurtmanager/webhook/endpointslice`, `pkg/yurtmanager/webhook/endpoints`) — those already guard against nil correctly.

Reproduced the panic with a standalone test before applying the fix, confirmed it's gone after.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

- Added two full end-to-end test cases in `TestFilter` (through the actual `Filter()` entry point, not just the internal helper) covering both node-topology and nodePool-topology routing with a nil-`NodeName` endpoint mixed into valid ones.
- Added a focused `TestReassembleEndpointSlice` unit test (3 cases) run under `-race`.
- Verified: `go build ./...`, `go vet ./...` (whole repo, zero issues), `gofmt -l` (clean), `go test ./pkg/yurthub/...` (all packages pass), `go test -race` on touched packages.
- `go.mod`/`go.sum` untouched.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug in yurthub's servicetopology filter that could cause a panic (and potential crash-loop) when processing an EndpointSlice containing an endpoint with an unset NodeName under node/nodePool topology routing.
```

#### other Note