### PR TITLE
feat: add Claude Code skill for configuring and troubleshooting service topology

### DIFF
--- a/.claude/skills/openyurt-service-topology/SKILL.md
+++ b/.claude/skills/openyurt-service-topology/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: openyurt-service-topology
+description: Configure and troubleshoot OpenYurt service topology, so that Service traffic stays within a node or a NodePool.
+when_to_use: Use when the user wants to keep Service traffic inside a node or NodePool, is configuring the openyurt.io/topologyKeys annotation, or is debugging why edge traffic is still crossing NodePool boundaries.
+disable-model-invocation: true
+allowed-tools: >
+  Bash(kubectl get *)
+  Bash(kubectl describe *)
+  Bash(kubectl logs *)
+  Bash(kubectl annotate service *)
+  Read
+  Grep
+---
+
+# OpenYurt Service Topology
+
+Service topology restricts which endpoints a client sees, so traffic from an edge
+node is served by a backend on the same node or in the same NodePool instead of
+crossing the network back to the cloud.
+
+It is enforced **on the edge node, inside yurthub**, not by the API server. yurthub
+intercepts `list`/`watch` responses for `endpointslices` and removes the endpoints
+outside the requested topology (`pkg/yurthub/filter/servicetopology/filter.go`).
+
+Two things follow, and most confusion traces to one of them:
+
+- **Stored objects are never modified.** `kubectl get endpointslice` from your laptop
+  always shows the **unfiltered** list. Only a request from a filtered component, on
+  the node, sees the reduced set. Never conclude topology works from a workstation.
+- **The feature has a cloud half too.** Changing the annotation mutates the *Service*,
+  which by itself generates no EndpointSlice watch event. `yurt-manager` patches the
+  EndpointSlice to force one, so the filter re-runs. If that controller is not
+  running, annotation changes are silently inert.
+
+## Configuration model
+
+Topology is opt-in per Service, via an annotation on the **Service** (not the
+EndpointSlice):
+
+| Annotation value | Traffic is kept within |
+| --- | --- |
+| `kubernetes.io/hostname` | the same node |
+| `openyurt.io/nodepool` | the same NodePool |
+| `kubernetes.io/zone` | the same NodePool (alias of the above) |
+
+```bash
+kubectl annotate service <svc> openyurt.io/topologyKeys=openyurt.io/nodepool
+```
+
+Any other value, or no annotation, means the Service is left untouched.
+
+## How to use this skill
+
+1. Ask the user whether they want to **configure** topology or **diagnose** why it
+   is not taking effect. If they are unsure, diagnose first — misconfiguration is
+   far more common than a missing annotation.
+2. For configuration, follow `references/service-topology-configure.md`.
+3. For diagnosis, follow `references/service-topology-diagnose.md`. Work through the
+   checks in order and stop at the first one that fails; each check narrows the
+   cause and they are ordered cheapest-first.
+4. Consult `references/service-topology-internals.md` when you need to explain a
+   result, or when the behaviour does not match the decision tree.
+
+## Rules
+
+- **Never** conclude that topology works by reading EndpointSlices with your own
+  credentials. That path is unfiltered by design. Verify from a filtered component
+  on the node, as described in the diagnose reference.
+- Treat an empty endpoint list as a legitimate outcome, not a bug. The filter
+  deliberately returns an empty slice rather than falling back to all endpoints
+  (`filter.go:242`, `filter.go:269`), so a NodePool with no local backend correctly
+  serves nothing.
+- Do not edit node labels to force a result. `openyurt.io/is-edge-worker` and the
+  NodePool label are controller-owned; hand-editing them fights the controller.
+- Prefer read-only commands. The only mutation this skill performs is annotating a
+  Service, and you should confirm with the user before doing so.

--- a/.claude/skills/openyurt-service-topology/references/service-topology-configure.md
+++ b/.claude/skills/openyurt-service-topology/references/service-topology-configure.md
@@ -1,0 +1,208 @@
+# Configuring service topology
+
+Goal: make a Service's traffic stay on the same node, or inside the same NodePool.
+
+Confirm the prerequisites first. Enabling the annotation on a cluster that cannot
+enforce it produces no error and no warning — it simply does nothing — so verifying
+before annotating saves the user a confusing debugging session.
+
+---
+
+## Step 1 — Decide the scope
+
+Ask which behaviour is wanted:
+
+| Intent | Annotation value |
+| --- | --- |
+| Serve only from a backend on the same node | `kubernetes.io/hostname` |
+| Serve only from backends in the same NodePool | `openyurt.io/nodepool` |
+
+`kubernetes.io/zone` is accepted and behaves identically to `openyurt.io/nodepool`
+(`pkg/yurthub/filter/servicetopology/filter.go:150`). Prefer the explicit
+`openyurt.io/nodepool` spelling; `kubernetes.io/zone` reads as if it maps to real
+cloud zones, which it does not.
+
+Node-local scope is strict. If no backend runs on the node, the client gets an empty
+endpoint list and the call fails. Recommend it only for a Service backed by a
+DaemonSet, or where a local backend is otherwise guaranteed.
+
+---
+
+## Step 2 — Verify prerequisites
+
+**For node-local scope**, no cluster-level gate is involved; skip to step 3.
+
+**For NodePool scope**, confirm both of the following.
+
+1. Pool topology is enabled in yurthub. It is gated, and when the gate is off the
+   filter silently returns traffic unfiltered (`filter.go:150-155`).
+
+   ```bash
+   kubectl -n kube-system get ds yurt-hub -o yaml | grep -E 'enable-node-pool|enable-pool-service-topology'
+   ```
+
+   Enabled if `--enable-pool-service-topology=true`, or (legacy path)
+   `--enable-node-pool=true`. Defaults are `false` and `true` respectively
+   (`cmd/yurthub/app/options/options.go:121,125`), so a default install is enabled via
+   the legacy flag.
+
+   Prefer `--enable-pool-service-topology=true` for new configuration:
+   `--enable-node-pool` is deprecated and slated for removal (`options.go:233`). Note
+   this is not a pure rename — the two flags read node membership from different
+   resources, so confirm the corresponding CRs exist before switching:
+
+   ```bash
+   kubectl get nodebuckets -A     # required by --enable-pool-service-topology
+   kubectl get nodepools          # required by --enable-node-pool
+   ```
+
+2. Every node that should participate is labelled into the NodePool.
+
+   ```bash
+   kubectl get nodes -L apps.openyurt.io/nodepool
+   ```
+
+   A node with no NodePool label silently degrades to node-local scope
+   (`filter.go:199-202`). Do not hand-edit this label to fix it — node membership is
+   controller-owned; add the node to the pool through the normal conversion flow.
+
+---
+
+## Step 3 — Confirm the consumer is a filtered component
+
+Topology is enforced only for components yurthub is configured to filter. The default
+set is (`cmd/yurthub/app/options/filters.go:53-59`): `kube-proxy`, `coredns`, and
+`nginx-ingress-controller` — and only on `list`/`watch` of `endpoints` and
+`endpointslices`.
+
+If the traffic is routed by something else — a mesh sidecar, a custom controller, a
+differently-named ingress — annotating the Service alone will not constrain it. Say
+so before making the change rather than after.
+
+That default is extendable, though. The `yurt-hub-cfg` ConfigMap adds components to a
+filter, unioned with the defaults (`pkg/yurthub/configuration/manager.go:215-239`),
+keyed by filter name with a comma-separated value (`manager.go:40`):
+
+```yaml
+data:
+  servicetopology: "kube-proxy,coredns,nginx-ingress-controller,my-component"
+```
+
+It is watched by an informer, so it applies without a yurthub restart
+(`manager.go:89-93`). Editing it changes behaviour for every node reading that
+ConfigMap, so confirm with the user first.
+
+---
+
+## Step 4 — Apply the annotation
+
+Confirm with the user before mutating, then:
+
+```bash
+kubectl annotate service <svc> -n <ns> openyurt.io/topologyKeys=openyurt.io/nodepool
+```
+
+Use `--overwrite` when changing an existing value. The value must match one of the
+recognised strings exactly; an unrecognised value is ignored silently
+(`filter.go:156-158`), so a typo behaves the same as no annotation at all.
+
+To remove topology and restore cluster-wide routing:
+
+```bash
+kubectl annotate service <svc> -n <ns> openyurt.io/topologyKeys-
+```
+
+---
+
+## Step 5 — Verify from the edge node
+
+Do **not** verify with `kubectl get endpointslice` from a workstation. yurthub filters
+the response in flight and never rewrites stored objects, so that view is unfiltered
+by design and will always look "wrong".
+
+Verify by observing what a filtered component on the node actually receives: from a
+pod on the edge node, call the Service repeatedly and confirm that only in-scope
+backends answer.
+
+Interpretation:
+
+- Only local/in-pool backends answer → working as intended.
+- No backend answers → in scope, but nothing is running there. Expected: the filter
+  returns an empty endpoint list rather than falling back to all endpoints
+  (`filter.go:242,269`). Schedule a backend into the scope, or widen the scope.
+- Out-of-scope backends still answer → configuration is not taking effect; switch to
+  `service-topology-diagnose.md` and work the checks in order.
+
+---
+
+## Worked example
+
+A Deployment spread across two NodePools (`beijing`, `shanghai`), where each pool
+should serve itself. The backend echoes its own pod name so the answering replica is
+identifiable.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+spec:
+  replicas: 4
+  selector:
+    matchLabels: { app: echo }
+  template:
+    metadata:
+      labels: { app: echo }
+    spec:
+      containers:
+        - name: echo
+          image: hashicorp/http-echo
+          args: ["-text=$(POD_NAME)", "-listen=:5678"]
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef: { fieldPath: metadata.name }
+          ports:
+            - containerPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  annotations:
+    openyurt.io/topologyKeys: openyurt.io/nodepool
+spec:
+  selector: { app: echo }
+  ports:
+    - port: 80
+      targetPort: 5678
+```
+
+Confirm replicas actually exist in both pools, otherwise the test proves nothing:
+
+```bash
+kubectl get pods -l app=echo -o custom-columns=POD:.metadata.name,NODE:.spec.nodeName
+kubectl get nodes -L apps.openyurt.io/nodepool
+```
+
+From a pod on a node in `beijing`, call the Service repeatedly:
+
+```bash
+for i in $(seq 20); do wget -qO- http://echo.default.svc.cluster.local; echo; done | sort | uniq -c
+```
+
+Expected: only replicas scheduled on `beijing` nodes appear. Seeing `shanghai`
+replicas means the annotation is not being enforced on this node — go to
+`service-topology-diagnose.md`.
+
+Then flip the scope and confirm the change actually propagates, which also exercises
+the yurt-manager trigger path:
+
+```bash
+kubectl annotate service echo openyurt.io/topologyKeys=kubernetes.io/hostname --overwrite
+```
+
+Re-run the loop. Only replicas on the *local node* should answer, and if no replica
+runs there the call now fails — which is correct node-scope behaviour, not a
+regression. If the output does not change at all, the annotation is not reaching the
+edge: see diagnose check 4.

--- a/.claude/skills/openyurt-service-topology/references/service-topology-diagnose.md
+++ b/.claude/skills/openyurt-service-topology/references/service-topology-diagnose.md
@@ -1,0 +1,338 @@
+# Diagnosing service topology
+
+Symptom this tree solves: *"I set `openyurt.io/topologyKeys`, but traffic still
+reaches backends outside the node/NodePool."*
+
+Work through the checks in order and **stop at the first failure**. They are ordered
+cheapest-first, and each one rules out a distinct cause. Every check names the source
+that defines the behaviour, so the conclusion can be justified rather than guessed.
+
+## Symptom index
+
+Use this to jump straight to the likely cause, then still confirm with check 0.
+
+| Symptom | Start at |
+| --- | --- |
+| Never worked, on any node | 1 — annotation value |
+| Works for CoreDNS but not my app | 2 — component not filtered |
+| Worked, then I changed the annotation and nothing happened | 4 — propagation |
+| Works on some nodes, not others | 6 — NodePool membership |
+| Traffic is narrower than asked (pool requested, node behaviour) | 6 — NodePool membership |
+| Stopped working after a yurthub restart | 7 — Service read fail-open |
+| Only my legacy `endpoints` consumer is unfiltered | 3 — `endpoints` is not filtered |
+| yurthub is crash-looping | 9 — nil `NodeName` |
+
+Almost every report is checks 1–6. Checks 7–9 are for cases that survive the obvious
+ones.
+
+---
+
+## 0. Establish where you are observing from
+
+Before anything else, make sure the observation is meaningful.
+
+Service topology is applied by yurthub on the edge node while proxying `list`/`watch`
+responses. The objects stored in the cluster are never rewritten
+(`pkg/yurthub/filter/servicetopology/filter.go`). Therefore:
+
+- `kubectl get endpointslice <name> -o yaml` run from a workstation shows the
+  **unfiltered** endpoint set. This is expected and proves nothing.
+- A correct verification must observe what a *filtered component on the node*
+  receives.
+
+Practical verification: from a pod on the edge node, resolve and call the Service
+repeatedly and confirm which backends answer, or inspect the endpoints as seen by
+kube-proxy on that node. If the user has been checking from their laptop, this alone
+often explains the report.
+
+---
+
+## 1. Is the annotation present, on the Service, and a recognised value?
+
+```bash
+kubectl get svc <svc> -n <ns> -o jsonpath='{.metadata.annotations.openyurt\.io/topologyKeys}{"\n"}'
+```
+
+The annotation must be on the **Service**, not the EndpointSlice or the Deployment.
+yurthub resolves the Service that owns the EndpointSlice and reads the annotation
+from it (`filter.go:174-183`).
+
+Recognised values (`filter.go:44-46`):
+
+- `kubernetes.io/hostname` — node-local
+- `openyurt.io/nodepool` — NodePool-local
+- `kubernetes.io/zone` — NodePool-local (alias)
+
+An unrecognised value is **not an error**. The filter's `switch` falls through to
+`default` and returns the object untouched (`filter.go:156-158`), so a typo such as
+`openyurt.io/nodePool` (capital P) or `kubernetes.io/nodepool` silently disables
+topology. This is the single most common cause. Compare the value byte-for-byte
+against the list above.
+
+---
+
+## 2. Is the consuming component actually filtered?
+
+yurthub applies a filter only to requests from components it has been told to filter.
+By default that is (`cmd/yurthub/app/options/filters.go:53-59`):
+
+```
+kube-proxy, coredns, nginx-ingress-controller
+```
+
+The component is taken from the request's client component, which yurthub truncates
+from the `User-Agent` header, and the filter is looked up by the tuple
+`(component, verb, resource)` (`pkg/yurthub/configuration/manager.go:253-259`,
+`filter/approver/approver.go:46`). If the traffic is driven by some other client — a
+custom controller, a service mesh sidecar, an application calling the API directly, or
+an ingress running under a different binary name — that client's EndpointSlice reads
+are **not** filtered, and topology appears to do nothing even though the Service is
+annotated correctly.
+
+Confirm which component the client reports:
+
+```bash
+kubectl -n kube-system logs <yurt-hub-pod> | grep -i "filter settings are as follows"
+```
+
+**This is fixable without changing the application.** The default list is a baseline,
+not a hard limit: the `yurt-hub-cfg` ConfigMap can add components to any filter, and
+the entries are unioned with the defaults rather than replacing them
+(`pkg/yurthub/configuration/manager.go:215-239`). The key is the filter name, the
+value is a comma-separated component list (`manager.go:40`):
+
+```bash
+kubectl -n kube-system get configmap yurt-hub-cfg -o yaml
+```
+
+```yaml
+data:
+  servicetopology: "kube-proxy,coredns,nginx-ingress-controller,my-component"
+```
+
+Because the ConfigMap is watched by an informer (`manager.go:89-93`), this takes
+effect without restarting yurthub — unlike the pool gate in check 5, which is read
+once at startup. Note that adding a component here changes which clients get filtered
+endpoint sets, so confirm with the user before editing a shared ConfigMap.
+
+---
+
+## 3. Is the request a `list`/`watch`, and is it EndpointSlice rather than Endpoints?
+
+Two separate constraints live here.
+
+**Verb.** The filter is registered only for `list` and `watch` (`filters.go:55-58`). A
+plain `get` of a single object is **not** filtered. This matters mainly when
+reproducing by hand: reproduce with a `list`/`watch`, or you will measure the wrong
+path.
+
+**Resource.** This one is a genuine trap. The filter is registered for *both*
+resources (`filters.go:56-57`):
+
+```
+endpoints      → list, watch
+endpointslices → list, watch
+```
+
+but `Filter()` only type-switches on `*discovery.v1.EndpointSlice` and
+`*discovery.v1beta1.EndpointSlice`; anything else falls through to `default` and is
+returned unchanged (`filter.go:131-138`). A `v1.Endpoints` object therefore passes
+through **completely unfiltered**, despite the registration implying otherwise. No
+filter in the yurthub tree handles `v1.Endpoints`.
+
+Practical consequence: a component that consumes the legacy `endpoints` resource
+instead of `endpointslices` silently bypasses service topology entirely. The
+configuration looks correct, the component is in the filtered list, and topology
+still does not apply.
+
+If a user reports that one specific consumer ignores topology while others honour it,
+determine which resource that consumer reads before going further down this tree.
+Worth reporting upstream if encountered in practice — the registration and the
+implementation disagree.
+
+---
+
+## 4. Did the annotation change actually reach the edge nodes?
+
+Check this whenever topology *used to* behave correctly and stopped, or when a freshly
+changed annotation appears to do nothing.
+
+yurthub filters `list`/`watch` **responses**. If the Service annotation changes but the
+EndpointSlice object itself does not, no watch event is generated, and edge nodes keep
+serving the previously filtered view until something unrelated modifies the
+EndpointSlice.
+
+OpenYurt closes that gap on the cloud side rather than the edge. `yurt-manager` watches
+Services, detects a changed `openyurt.io/topologyKeys`
+(`pkg/yurtmanager/controller/servicetopology/util/util.go:25-29`), enqueues that
+Service's EndpointSlices
+(`.../endpointslice/endpointslice_enqueue_handlers.go:44-62`), and patches an
+`openyurt.io/update-trigger` annotation onto them with the current timestamp
+(`.../adapter/adapter.go:53-54`, `.../adapter/endpointslicev1_adapter.go:56-69`). That
+patch is what produces the watch event that makes yurthub re-filter.
+
+So the annotation propagates **only because a controller pokes the EndpointSlice**. If
+that controller is not running, the annotation change is effectively inert.
+
+```bash
+# Did the trigger actually fire? Compare against when the annotation was changed.
+kubectl get endpointslice -n <ns> -l kubernetes.io/service-name=<svc> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.openyurt\.io/update-trigger}{"\n"}{end}'
+
+# Is the controller enabled and healthy?
+kubectl -n kube-system logs deploy/yurt-manager | grep -i servicetopology
+```
+
+The relevant controllers are `servicetopologyendpointslices` and
+`servicetopologyendpoints` (`cmd/yurt-manager/names/controller_names.go:51-52`). If
+yurt-manager is running with a restricted controller set that excludes them, this is
+the cause.
+
+Workaround to confirm the diagnosis: force an unrelated EndpointSlice change (for
+example, restart one backend pod). If topology snaps to the new behaviour immediately
+afterwards, propagation — not configuration — was the problem.
+
+---
+
+## 5. For NodePool topology only: is pool topology enabled in yurthub?
+
+This check does not apply to `kubernetes.io/hostname`, which always works.
+
+For `openyurt.io/nodepool` and `kubernetes.io/zone`, the filter consults an
+`enablePoolTopology` gate, and **returns the object unfiltered when the gate is off**
+(`filter.go:150-155`). There is no error and no event — topology simply does not
+happen.
+
+The gate is derived in `pkg/yurthub/filter/initializer/nodes_initializer.go:58-73`:
+
+| yurthub flags | Result | Node membership read from |
+| --- | --- | --- |
+| `--enable-pool-service-topology=true` | enabled | **NodeBucket** CRs |
+| else `--enable-node-pool=true` | enabled | **NodePool** CRs |
+| neither | **disabled — silent no-op** | — |
+
+Defaults (`cmd/yurthub/app/options/options.go:121,125`): `--enable-node-pool` is
+`true`, `--enable-pool-service-topology` is `false`. So on a default install the gate
+is on via the legacy path.
+
+Inspect the flags actually in use:
+
+```bash
+kubectl -n kube-system get ds yurt-hub -o yaml | grep -E 'enable-node-pool|enable-pool-service-topology'
+```
+
+Two traps live here:
+
+- **Explicitly disabling the legacy flag without enabling the new one** turns pool
+  topology off silently. `--enable-node-pool=false` alone is enough to break it.
+- **`--enable-node-pool` is deprecated** and slated for removal in favour of
+  `--enable-pool-service-topology` (`options.go:233`). These are not a rename: they
+  read node membership from *different* CRs (NodeBucket vs NodePool, above). A
+  cluster that relies on the default today will lose pool topology when the
+  deprecated flag is removed unless `--enable-pool-service-topology=true` is set and
+  NodeBuckets are present. Flag this proactively when you see a cluster depending on
+  the default.
+
+---
+
+## 6. Is this node actually a member of a NodePool?
+
+```bash
+kubectl get node <node> -o jsonpath='{.metadata.labels.apps\.openyurt\.io/nodepool}{"\n"}'
+```
+
+If the node carries no NodePool label, `nodePoolTopologyHandler` logs at info level
+and **silently falls back to node-local topology** (`filter.go:199-202`).
+
+The visible effect is confusing in a specific way: topology *is* applied, but the
+scope is narrower than requested — the user asked for NodePool and got node. Traffic
+to backends elsewhere in the intended pool disappears, which usually gets reported as
+"topology is too aggressive" rather than as a labelling problem.
+
+Confirm from yurthub's own logs on that node:
+
+```bash
+kubectl -n kube-system logs <yurt-hub-pod> | grep -i "not added into node pool"
+```
+
+---
+
+## 7. Can yurthub read the Service?
+
+To find the topology annotation, the filter looks the Service up through its lister.
+If that lookup fails, it logs a warning and returns an empty topology type
+(`filter.go:174-178`), which means **the object is returned unfiltered**.
+
+This is a fail-open path, and worth calling out explicitly: a transient or permission
+problem reading the Service does not surface as a topology error, it surfaces as
+topology silently not being enforced. Look for:
+
+```bash
+kubectl -n kube-system logs <yurt-hub-pod> | grep "could not get service"
+```
+
+Corresponding symptom: topology works intermittently, or stops working after a
+yurthub restart while its informer cache is still warming.
+
+---
+
+## 8. Is the node-membership source present and synced?
+
+When pool topology is enabled, the filter resolves the node list for the pool through
+`nodesGetter`, and on error returns the object unfiltered (`filter.go:204-208`).
+
+Depending on which gate is active (check 5), the source differs:
+
+- `--enable-pool-service-topology=true` → **NodeBucket** CRs
+  (`nodes_initializer.go:59-61`, GVR `nodebuckets`)
+- `--enable-node-pool=true` → **NodePool** CRs (`nodes_initializer.go:62-64`)
+
+```bash
+kubectl get nodebuckets -A     # when using --enable-pool-service-topology
+kubectl get nodepools          # when using --enable-node-pool
+```
+
+A missing or unsynced CR here produces the same visible outcome as a disabled gate —
+unfiltered traffic — which is why check 5 must be settled before this one.
+
+---
+
+## 9. EndpointSlice version and unlocatable endpoints
+
+The two EndpointSlice versions carry the hosting node differently, and the filter
+handles them separately:
+
+- `discovery.k8s.io/v1` uses `Endpoint.NodeName`, an optional `*string`
+  (`filter.go:248`).
+- `discovery.k8s.io/v1beta1` uses `Endpoint.Topology[kubernetes.io/hostname]`
+  (`filter.go:230,236`).
+
+Endpoints whose hosting node is unknown carry no usable identity, cannot be placed in
+a node or NodePool, and are therefore dropped. Under v1beta1 a missing hostname
+simply never matches. Under v1 a `nil` `NodeName` must be skipped explicitly before
+dereferencing; that guard is the subject of
+[PR #2593](https://github.com/openyurtio/openyurt/pull/2593). On builds predating that
+fix, a v1 EndpointSlice containing an endpoint with `nil` `NodeName` panics yurthub
+rather than degrading, so the symptom is a crash-looping yurthub, not missing
+endpoints.
+
+Check for such endpoints:
+
+```bash
+kubectl get endpointslice -n <ns> -l kubernetes.io/service-name=<svc> \
+  -o jsonpath='{range .items[*].endpoints[*]}{.nodeName}{"\n"}{end}'
+```
+
+Blank lines indicate endpoints with no `nodeName`. Expect these to be absent from the
+filtered result — that is correct behaviour, not data loss.
+
+---
+
+## Reporting the conclusion
+
+State which check failed, what the source says, and the concrete fix. Do not report
+"topology is working" unless it was verified from a filtered component on the node
+per check 0. If every check passes and behaviour is still wrong, say so plainly and
+capture: the Service annotation, the yurthub flags, the node's NodePool label, the
+EndpointSlice version, and the yurthub logs for that node. That set is what a
+maintainer needs to triage further.

--- a/.claude/skills/openyurt-service-topology/references/service-topology-internals.md
+++ b/.claude/skills/openyurt-service-topology/references/service-topology-internals.md
@@ -1,0 +1,199 @@
+# Service topology internals
+
+Background for explaining results and for handling cases the decision tree does not
+cover. All references are to the current implementation.
+
+---
+
+## The two halves
+
+Service topology is not one component. It is an edge-side filter plus a cloud-side
+controller, and they fail in different ways:
+
+| | Where | Job |
+| --- | --- | --- |
+| **yurthub filter** | every edge node | Removes out-of-scope endpoints from `list`/`watch` responses |
+| **yurt-manager controllers** | cloud | Force a watch event when the topology annotation changes, so the filter re-runs |
+
+Missing the second half is the usual reason a correct-looking configuration behaves as
+if it were never applied. See "Propagation" below.
+
+---
+
+## Where enforcement happens
+
+Enforcement is entirely on the edge node, inside yurthub, as a response filter on the
+proxy path. yurthub intercepts `list`/`watch` responses for `endpoints` and
+`endpointslices` and rewrites the endpoint set before handing it to the local
+component (`pkg/yurthub/filter/servicetopology/filter.go`).
+
+Two consequences follow, and most confusion traces back to one of them:
+
+1. **Stored objects are never modified.** Any read that does not pass through
+   yurthub's filtered path — notably `kubectl` from a workstation — sees the full
+   endpoint set. That is by design.
+2. **Enforcement is per-node.** Two nodes in different NodePools legitimately see
+   different endpoint sets for the same Service at the same moment. Divergence
+   between nodes is the feature working, not drift.
+
+---
+
+## Decision flow
+
+`Filter` handles only EndpointSlice objects; everything else passes through
+unchanged (`filter.go:131-138`). For an EndpointSlice:
+
+1. Resolve the owning Service from the EndpointSlice's
+   `kubernetes.io/service-name` label and read its `openyurt.io/topologyKeys`
+   annotation (`filter.go:161-184`).
+2. Empty or unreadable annotation → return unchanged (`filter.go:142-144`).
+3. Dispatch on the value (`filter.go:146-158`):
+   - `kubernetes.io/hostname` → node handler
+   - `openyurt.io/nodepool` or `kubernetes.io/zone` → pool handler, **if** the
+     `enablePoolTopology` gate is on; otherwise return unchanged
+   - anything else → return unchanged
+
+Note that steps 2 and 3 collapse three very different situations — no annotation, an
+unreadable Service, and a typo'd value — into the same observable outcome: traffic is
+not constrained, with no error surfaced to the user. Distinguishing them requires
+yurthub's logs.
+
+---
+
+## Propagation: why an annotation change is visible at all
+
+The filter runs against `list`/`watch` responses, so it only re-evaluates when the
+EndpointSlice is sent again. Changing `openyurt.io/topologyKeys` mutates the
+**Service**, not the EndpointSlice — on its own that produces no EndpointSlice watch
+event, and every edge node would keep serving the previously filtered view
+indefinitely.
+
+`yurt-manager` bridges that gap:
+
+1. Watch Services; compare old and new `openyurt.io/topologyKeys`
+   (`pkg/yurtmanager/controller/servicetopology/util/util.go:25-29`).
+2. On change, enqueue that Service's EndpointSlices
+   (`.../endpointslice/endpointslice_enqueue_handlers.go:44-62`).
+3. Patch `openyurt.io/update-trigger` with the current Unix timestamp
+   (`.../adapter/adapter.go:53-54`, `.../adapter/endpointslicev1_adapter.go:56-69`).
+
+The patch is a no-op semantically; its only purpose is to generate a watch event that
+makes yurthub re-filter. The controllers are `servicetopologyendpointslices` and
+`servicetopologyendpoints` (`cmd/yurt-manager/names/controller_names.go:51-52`).
+
+Consequence worth internalising: **topology configuration is applied by the edge, but
+delivered by the cloud.** A cluster running yurt-manager with a restricted controller
+set that excludes these will accept annotation changes that never take effect, with no
+error anywhere. Pod churn on the Service will eventually deliver the change by
+accident, which makes the failure look intermittent rather than systematic.
+
+---
+
+## The pool gate
+
+`enablePoolTopology` is resolved once at filter-initialisation time
+(`pkg/yurthub/filter/initializer/nodes_initializer.go:52-80`):
+
+```
+if  --enable-pool-service-topology  → enabled, nodes from NodeBucket CRs
+elif --enable-node-pool             → enabled, nodes from NodePool CRs
+else                                → disabled; nodesGetter returns an empty list
+```
+
+Defaults are `--enable-node-pool=true` and
+`--enable-pool-service-topology=false` (`cmd/yurthub/app/options/options.go:121,125`).
+
+Because the gate is read at initialisation, changing these flags requires restarting
+yurthub; editing them without a restart produces no behaviour change and looks like
+the flag was ignored.
+
+`--enable-node-pool` is deprecated in favour of `--enable-pool-service-topology`
+(`options.go:233`), but the two branches read node membership from **different
+resources**. Migration is therefore not a rename: a cluster switching flags must also
+have the corresponding CRs present and synced, or pool resolution fails and traffic
+is returned unfiltered (`filter.go:204-208`).
+
+---
+
+## Node vs pool matching
+
+- **Node scope** keeps endpoints whose hosting node equals the local node name.
+- **Pool scope** resolves the local node's NodePool, expands it to a node list via
+  `nodesGetter`, and keeps endpoints hosted on any node in that list
+  (`filter.go:197-218`).
+
+If the local node has no NodePool label, the pool handler logs at info level and
+delegates to the node handler (`filter.go:199-202`). The request is honoured, but at a
+narrower scope than asked for.
+
+---
+
+## EndpointSlice v1 vs v1beta1
+
+The hosting node is carried differently by version, so the two are reassembled by
+separate functions:
+
+| Version | Node identity | Reassembler |
+| --- | --- | --- |
+| `discovery.k8s.io/v1beta1` | `Endpoint.Topology["kubernetes.io/hostname"]` | `reassembleV1beta1EndpointSlice` (`filter.go:221`) |
+| `discovery.k8s.io/v1` | `Endpoint.NodeName` (`*string`, optional) | `reassembleEndpointSlice` (`filter.go:248`) |
+
+Endpoints with no resolvable hosting node cannot be attributed to a node or NodePool
+and are dropped. Under v1beta1 this happens naturally: a missing hostname matches
+nothing. Under v1 the optional pointer must be checked before dereferencing —
+[PR #2593](https://github.com/openyurtio/openyurt/pull/2593) adds that guard. Without
+it, a v1 EndpointSlice carrying an endpoint with `nil` `NodeName` panics yurthub, so
+the failure presents as a crash-looping hub rather than as missing endpoints.
+
+Both reassemblers deliberately assign the filtered slice even when it is empty
+(`filter.go:242,269`), rather than leaving the original endpoints in place. Empty is a
+meaningful answer: "nothing in scope serves this Service." Falling back to the full
+set would silently defeat the topology guarantee.
+
+---
+
+## Known rough edges
+
+Useful to name explicitly when a user's mental model does not match observed
+behaviour. These are properties of the current implementation, not bugs to fix
+inside this skill.
+
+1. **Silent no-ops dominate.** Unrecognised annotation value, disabled pool gate,
+   unreadable Service, and failed pool resolution all return traffic unfiltered with
+   nothing surfaced to the user beyond a yurthub log line
+   (`filter.go:156-158,152-155,174-178,204-208`). There is no Service event and no
+   status field to inspect, so logs are the only signal.
+2. **Fail-open on Service lookup.** A failed Service read disables topology for that
+   object rather than failing closed (`filter.go:174-178`). Worth stating plainly when
+   the guarantee is being relied on for isolation: a transient read problem relaxes
+   the constraint rather than enforcing it.
+3. **Silent scope narrowing.** A node missing its NodePool label degrades pool scope
+   to node scope (`filter.go:199-202`) — the opposite direction from the above, and
+   easy to misread as the filter being too aggressive.
+4. **`kubernetes.io/zone` is an alias, not zone semantics.** It maps to NodePool
+   scope (`filter.go:150`), which can surprise anyone importing a mental model from
+   upstream topology-aware routing.
+5. **Component-scoped by default.** Only `kube-proxy`, `coredns`, and
+   `nginx-ingress-controller` are filtered out of the box
+   (`cmd/yurthub/app/options/filters.go:53-59`); other clients are unaffected no
+   matter how the Service is annotated. This is extendable through the `yurt-hub-cfg`
+   ConfigMap, whose entries are unioned with the defaults rather than replacing them
+   (`pkg/yurthub/configuration/manager.go:215-239`), but it is opt-in and easy to
+   overlook.
+6. **Two different reload semantics.** The component list is watched by an informer
+   and applies immediately (`manager.go:89-93`), while the pool gate is resolved once
+   at initialisation and requires a yurthub restart (`nodes_initializer.go:52-80`).
+   Configuration that "should have applied by now" is often simply on the wrong side
+   of this split.
+7. **`endpoints` is registered but never filtered.** The filter is registered for both
+   `endpoints` and `endpointslices` (`cmd/yurthub/app/options/filters.go:56-57`), but
+   `Filter()` only type-switches on the two EndpointSlice types and returns everything
+   else unchanged (`filter.go:131-138`). No filter in the yurthub tree handles
+   `v1.Endpoints`. A consumer reading the legacy `endpoints` resource therefore
+   bypasses service topology entirely, while appearing fully configured. The
+   registration and the implementation disagree; treat this as a real gap rather than
+   a documentation nuance.
+8. **Propagation depends on a separate controller.** Annotation changes reach edge
+   nodes only because yurt-manager patches the EndpointSlice (see "Propagation"). If
+   those controllers are disabled, configuration silently does not take effect, and
+   the eventual delivery via unrelated pod churn makes it look intermittent.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,12 @@ gopath
 dockerbuild
 hack/cni
 config/demo
-.claude
+# Ignore local Claude Code state (settings.local.json, caches) while keeping the
+# skills shipped with the repository under version control. The directory itself
+# must not be excluded, otherwise git never descends into it and the negation
+# below would have no effect.
+.claude/*
+!.claude/skills/
 
 vendor
 .vscode


### PR DESCRIPTION
#### What type of PR is this?

/kind enhancement
/sig ai

#### What this PR does / why we need it:

Adds a Claude Code skill, `openyurt-service-topology`, that helps operators configure and troubleshoot service topology — keeping Service traffic within a node or a NodePool.

This is complementary to the deploy/Raven skills proposed in #2559 and drafted in #2592, and deliberately does not overlap them. It follows the modular layout preferred in that discussion: a short `SKILL.md` entrypoint with frontmatter (`disable-model-invocation: true`, scoped `allowed-tools`), plus reference documents holding the detail.

```
.claude/skills/openyurt-service-topology/
├── SKILL.md                                  # entrypoint + frontmatter
└── references/
    ├── service-topology-configure.md         # setup + runnable worked example
    ├── service-topology-diagnose.md          # symptom index + 10-step decision tree
    └── service-topology-internals.md         # behaviour model, for explaining results
```

Tool access is read-only by default (`kubectl get/describe/logs`, `Read`, `Grep`); the only mutation is `kubectl annotate service`, and the skill is instructed to confirm before using it.

Every behavioural claim in the references is cited to a specific file and line so a reviewer can check it rather than take it on trust.

#### Two issues found while writing this against current source

These are documented in the references, but both are really code-level observations and I'm happy to split either into its own issue if maintainers prefer.

**1. The `servicetopology` filter is registered for `endpoints`, but never filters them.**

`cmd/yurthub/app/options/filters.go:56-57` registers the filter for both `endpoints` and `endpointslices`. However `Filter()` only type-switches on `*discovery.v1.EndpointSlice` and `*discovery.v1beta1.EndpointSlice`; anything else falls through to `default` and is returned unchanged (`pkg/yurthub/filter/servicetopology/filter.go:131-138`). No filter in the yurthub tree handles `v1.Endpoints`.

Practical effect: a component consuming the legacy `endpoints` resource bypasses service topology entirely, while appearing correctly configured. The registration and the implementation disagree.

**2. Annotation changes propagate only because yurt-manager forces a watch event.**

The filter runs against `list`/`watch` responses, so it re-evaluates only when the EndpointSlice is re-sent. Changing `openyurt.io/topologyKeys` mutates the *Service*, which by itself produces no EndpointSlice event. `yurt-manager` bridges this by detecting the changed annotation (`pkg/yurtmanager/controller/servicetopology/util/util.go:25-29`), enqueuing the Service's EndpointSlices (`.../endpointslice/endpointslice_enqueue_handlers.go:44-62`), and patching `openyurt.io/update-trigger` (`.../adapter/adapter.go:53-54`).

Practical effect: with `servicetopologyendpointslices` / `servicetopologyendpoints` disabled, annotation changes are silently inert until unrelated pod churn delivers them — which presents as intermittent rather than broken. This is now an explicit diagnostic step in the skill.

#### `.gitignore` change

`.gitignore` excluded `.claude` outright, so files under it could only be committed with `git add -f`. This PR narrows it:

```gitignore
.claude/*
!.claude/skills/
```

so shipped skills are tracked while local `settings.local.json` stays ignored. Note a directory cannot be re-included once its parent is excluded, which is why the parent pattern had to change rather than just adding a negation.

This also affects #2592, whose files sit under `.claude/commands/` and appear to have been force-added. Not a criticism of that PR — just flagging that whichever lands first should probably own the fix, and the other rebase onto it. Happy to adjust my path to match if maintainers want a single canonical location (`.claude/skills/` vs `.claude/commands/`).

#### Which issue(s) this PR fixes:

Related to #2559

#### Special notes for your reviewer:

- The skill documents behaviour verified by reading the current implementation; it has **not** been exercised end-to-end against a live edge cluster. The worked example in the configure reference is written to be runnable, but I'd value confirmation from someone with a multi-NodePool environment.
- I recently opened #2593 (nil `NodeName` panic in this same filter). The diagnose reference mentions it in the context of crash-looping yurthub; if that PR is rejected the reference to it should be dropped.
- AI assistance (Claude) was used to research the implementation and draft these documents; all cited line references were verified against the tree at the time of writing.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
