### PR TITLE
Feat: Support other IoT platforms similar to EdgeX

### DIFF
--- a/cmd/yurt-iot-dock/app/core.go
+++ b/cmd/yurt-iot-dock/app/core.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	"github.com/openyurtio/openyurt/pkg/apis"
+	"github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
 	edgexclients "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
@@ -128,17 +129,24 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 		}
 	}
 
-	edgexdock := edgexclients.NewEdgexDock(opts.Version, opts.CoreMetadataAddr, opts.CoreCommandAddr)
+	var iotDock clients.IoTDock
+	switch opts.Platform {
+	case "edgex", "":
+		iotDock = edgexclients.NewEdgexDock(opts.Version, opts.CoreMetadataAddr, opts.CoreCommandAddr)
+	default:
+		setupLog.Error(fmt.Errorf("unsupported platform: %s", opts.Platform), "failed to initialize iot dock")
+		os.Exit(1)
+	}
 
 	// setup the DeviceProfile Reconciler and Syncer
 	if err = (&controllers.DeviceProfileReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, opts, edgexdock); err != nil {
+	}).SetupWithManager(mgr, opts, iotDock); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DeviceProfile")
 		os.Exit(1)
 	}
-	dfs, err := controllers.NewDeviceProfileSyncer(mgr.GetClient(), opts, edgexdock)
+	dfs, err := controllers.NewDeviceProfileSyncer(mgr.GetClient(), opts, iotDock)
 	if err != nil {
 		setupLog.Error(err, "unable to create syncer", "syncer", "DeviceProfile")
 		os.Exit(1)
@@ -153,11 +161,11 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 	if err = (&controllers.DeviceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, opts, edgexdock); err != nil {
+	}).SetupWithManager(mgr, opts, iotDock); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Device")
 		os.Exit(1)
 	}
-	ds, err := controllers.NewDeviceSyncer(mgr.GetClient(), opts, edgexdock)
+	ds, err := controllers.NewDeviceSyncer(mgr.GetClient(), opts, iotDock)
 	if err != nil {
 		setupLog.Error(err, "unable to create syncer", "controller", "Device")
 		os.Exit(1)
@@ -172,11 +180,11 @@ func Run(opts *options.YurtIoTDockOptions, stopCh <-chan struct{}) {
 	if err = (&controllers.DeviceServiceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, opts, edgexdock); err != nil {
+	}).SetupWithManager(mgr, opts, iotDock); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DeviceService")
 		os.Exit(1)
 	}
-	dss, err := controllers.NewDeviceServiceSyncer(mgr.GetClient(), opts, edgexdock)
+	dss, err := controllers.NewDeviceServiceSyncer(mgr.GetClient(), opts, iotDock)
 	if err != nil {
 		setupLog.Error(err, "unable to create syncer", "syncer", "DeviceService")
 		os.Exit(1)

--- a/cmd/yurt-iot-dock/app/options/options.go
+++ b/cmd/yurt-iot-dock/app/options/options.go
@@ -35,6 +35,7 @@ type YurtIoTDockOptions struct {
 	CoreMetadataAddr     string
 	CoreCommandAddr      string
 	EdgeSyncPeriod       uint
+	Platform             string
 }
 
 func NewYurtIoTDockOptions() *YurtIoTDockOptions {
@@ -49,6 +50,7 @@ func NewYurtIoTDockOptions() *YurtIoTDockOptions {
 		CoreMetadataAddr:     "edgex-core-metadata:59881",
 		CoreCommandAddr:      "edgex-core-command:59882",
 		EdgeSyncPeriod:       5,
+		Platform:             "edgex",
 	}
 }
 
@@ -70,6 +72,7 @@ func (o *YurtIoTDockOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.CoreMetadataAddr, "core-metadata-address", "edgex-core-metadata:59881", "The address of edge core-metadata service.")
 	fs.StringVar(&o.CoreCommandAddr, "core-command-address", "edgex-core-command:59882", "The address of edge core-command service.")
 	fs.UintVar(&o.EdgeSyncPeriod, "edge-sync-period", 5, "The period of the device management platform synchronizing the device status to the cloud.(in seconds,not less than 5 seconds)")
+	fs.StringVar(&o.Platform, "platform", "edgex", "The IoT device management platform to support (default: \"edgex\").")
 }
 
 func ValidateEdgePlatformAddress(options *YurtIoTDockOptions) error {

--- a/pkg/apis/addtoscheme_iot_v1alpha1.go
+++ b/pkg/apis/addtoscheme_iot_v1alpha1.go
@@ -16,11 +16,11 @@ limitations under the License.
 
 package apis
 
-// import (
-// 	version "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
-// )
+import (
+	version "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
+)
 
-// func init() {
-// 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-// 	AddToSchemes = append(AddToSchemes, version.SchemeBuilder.AddToScheme)
-// }
+func init() {
+	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+	AddToSchemes = append(AddToSchemes, version.SchemeBuilder.AddToScheme)
+}

--- a/pkg/yurtiotdock/controllers/device_controller.go
+++ b/pkg/yurtiotdock/controllers/device_controller.go
@@ -34,7 +34,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
-	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
 	util "github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
 )
 
@@ -109,8 +108,8 @@ func (r *DeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *DeviceReconciler) SetupWithManager(mgr ctrl.Manager, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) error {
-	deviceclient, err := edgexdock.CreateDeviceClient()
+func (r *DeviceReconciler) SetupWithManager(mgr ctrl.Manager, opts *options.YurtIoTDockOptions, dock clients.IoTDock) error {
+	deviceclient, err := dock.CreateDeviceClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/yurtiotdock/controllers/device_syncer.go
+++ b/pkg/yurtiotdock/controllers/device_syncer.go
@@ -31,7 +31,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
 	edgeCli "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
-	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
 )
 
@@ -48,8 +47,8 @@ type DeviceSyncer struct {
 }
 
 // NewDeviceSyncer initialize a New DeviceSyncer
-func NewDeviceSyncer(client client.Client, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) (DeviceSyncer, error) {
-	devicelient, err := edgexdock.CreateDeviceClient()
+func NewDeviceSyncer(client client.Client, opts *options.YurtIoTDockOptions, dock edgeCli.IoTDock) (DeviceSyncer, error) {
+	devicelient, err := dock.CreateDeviceClient()
 	if err != nil {
 		return DeviceSyncer{}, err
 	}

--- a/pkg/yurtiotdock/controllers/deviceprofile_controller.go
+++ b/pkg/yurtiotdock/controllers/deviceprofile_controller.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
-	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
 )
 
@@ -87,8 +86,8 @@ func (r *DeviceProfileReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *DeviceProfileReconciler) SetupWithManager(mgr ctrl.Manager, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) error {
-	deviceprofileclient, err := edgexdock.CreateDeviceProfileClient()
+func (r *DeviceProfileReconciler) SetupWithManager(mgr ctrl.Manager, opts *options.YurtIoTDockOptions, dock clients.IoTDock) error {
+	deviceprofileclient, err := dock.CreateDeviceProfileClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/yurtiotdock/controllers/deviceprofile_syncer.go
+++ b/pkg/yurtiotdock/controllers/deviceprofile_syncer.go
@@ -31,7 +31,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
 	devcli "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
-	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
 )
 
@@ -47,8 +46,8 @@ type DeviceProfileSyncer struct {
 }
 
 // NewDeviceProfileSyncer initialize a New DeviceProfileSyncer
-func NewDeviceProfileSyncer(client client.Client, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) (DeviceProfileSyncer, error) {
-	edgeclient, err := edgexdock.CreateDeviceProfileClient()
+func NewDeviceProfileSyncer(client client.Client, opts *options.YurtIoTDockOptions, dock devcli.IoTDock) (DeviceProfileSyncer, error) {
+	edgeclient, err := dock.CreateDeviceProfileClient()
 	if err != nil {
 		return DeviceProfileSyncer{}, err
 	}

--- a/pkg/yurtiotdock/controllers/deviceservice_controller.go
+++ b/pkg/yurtiotdock/controllers/deviceservice_controller.go
@@ -33,7 +33,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
-	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
 	util "github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
 )
 
@@ -107,8 +106,8 @@ func (r *DeviceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *DeviceServiceReconciler) SetupWithManager(mgr ctrl.Manager, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) error {
-	deviceserviceclient, err := edgexdock.CreateDeviceServiceClient()
+func (r *DeviceServiceReconciler) SetupWithManager(mgr ctrl.Manager, opts *options.YurtIoTDockOptions, dock clients.IoTDock) error {
+	deviceserviceclient, err := dock.CreateDeviceServiceClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/yurtiotdock/controllers/deviceservice_syncer.go
+++ b/pkg/yurtiotdock/controllers/deviceservice_syncer.go
@@ -30,7 +30,6 @@ import (
 	"github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app/options"
 	iotv1alpha1 "github.com/openyurtio/openyurt/pkg/apis/iot/v1alpha1"
 	iotcli "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients"
-	edgexobj "github.com/openyurtio/openyurt/pkg/yurtiotdock/clients/edgex-foundry"
 	"github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util"
 )
 
@@ -44,8 +43,8 @@ type DeviceServiceSyncer struct {
 	Namespace        string
 }
 
-func NewDeviceServiceSyncer(client client.Client, opts *options.YurtIoTDockOptions, edgexdock *edgexobj.EdgexDock) (DeviceServiceSyncer, error) {
-	deviceserviceclient, err := edgexdock.CreateDeviceServiceClient()
+func NewDeviceServiceSyncer(client client.Client, opts *options.YurtIoTDockOptions, dock iotcli.IoTDock) (DeviceServiceSyncer, error) {
+	deviceserviceclient, err := dock.CreateDeviceServiceClient()
 	if err != nil {
 		return DeviceServiceSyncer{}, err
 	}

--- a/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation.go
@@ -107,15 +107,8 @@ func (webhook *PlatformAdminHandler) validatePlatformAdminSpec(platformAdmin *v1
 	// TODO: Need to divert traffic based on the type of platform
 
 	// Verify that the platform is supported
-	if platformAdmin.Spec.Platform != v1alpha2.PlatformAdminPlatformEdgeX {
-		return field.ErrorList{
-			field.Invalid(
-				field.NewPath("spec", "platform"),
-				platformAdmin.Spec.Platform,
-				"must be "+v1alpha2.PlatformAdminPlatformEdgeX,
-			),
-		}
-	}
+	// For now, any string can be passed here since we want to support multiple IoT platforms (like edgex, etc).
+	// Further checks can be added based on what components are installed.
 
 	// Verify that it is a supported platformadmin version
 	for _, version := range webhook.Manifests.Versions {

--- a/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation.go
@@ -106,15 +106,8 @@ func (webhook *PlatformAdminHandler) validatePlatformAdminSpec(platformAdmin *v1
 	// TODO: Need to divert traffic based on the type of platform
 
 	// Verify that the platform is supported
-	if platformAdmin.Spec.Platform != v1beta1.PlatformAdminPlatformEdgeX {
-		return field.ErrorList{
-			field.Invalid(
-				field.NewPath("spec", "platform"),
-				platformAdmin.Spec.Platform,
-				"must be "+v1beta1.PlatformAdminPlatformEdgeX,
-			),
-		}
-	}
+	// For now, any string can be passed here since we want to support multiple IoT platforms (like edgex, etc).
+	// Further checks can be added based on what components are installed.
 
 	// Verify that it is a supported platformadmin version
 	for _, version := range webhook.Manifests.Versions {


### PR DESCRIPTION
### Related Issues
Resolves https://github.com/openyurtio/openyurt/issues/1801
Resolves https://github.com/openyurtio/yurt-edgex-manager/issues/93
## Description
This PR abstracts the IoT platform implementation in yurt-iot-dock to support arbitrary IoT platforms alongside EdgeX.

## Key Changes

- Application Options: Added a `--platform` flag to `yurt-iot-dock` (defaults to edgex for backward compatibility).
- Webhook Validations: Removed strict platform `== "edgex"` checks in PlatformAdmin webhooks (`v1alpha2` and `v1beta1`) to allow custom platforms.
- Refactoring: Updated all device and profile `controllers/syncers` in `pkg/yurtiotdock/controllers/` to rely on the generic `clients.IoTDock` interface rather than `*edgexobj.EdgexDock`.
- Dynamic Initialization: Added a switch statement in `cmd/yurt-iot-dock/app/core.go` to instantiate the appropriate IoTDock implementation based on the `--platform` flag.
- Bug Fix: Uncommented v1alpha1 types in `pkg/apis/addtoscheme_iot_v1alpha1.go` to fix a local scheme registration bug.

## Testing Done
- Webhook Validations: Successfully ran `go test ./pkg/yurtmanager/webhook/platformadmin/...`
```bash
alokkumardalei@Aloks-MacBook-Air openyurt % go test ./pkg/yurtmanager/webhook/platformadmin/...
ok      github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/platformadmin/v1alpha2   0.727s
ok      github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/platformadmin/v1beta1    1.048s
```
- Compilation: Cleanly built the application via `go build ./cmd/yurt-iot-dock`.


- Negative Testing: Verified that unsupported platforms fail gracefully at initialization by running:
```bash

./yurt-iot-dock --platform custom_platform --nodepool fake-pool --health-probe-bind-address :18081 --metrics-bind-address :18080
```
```bash
alokkumardalei@Aloks-MacBook-Air openyurt % ./yurt-iot-dock --platform custom_platform --nodepool fake-pool --health-probe-bind-address :18081 --metrics-bind-address :18080

2026-07-19T20:48:05+05:30       INFO    setup   [preflight] Running pre-flight checks
2026-07-19T20:48:05+05:30       INFO    setup   [preflight] Registering the field indexers
2026-07-19T20:48:05+05:30       ERROR   setup   failed to initialize iot dock   {"error": "unsupported platform: custom_platform"}
github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app.Run
        /Users/alokkumardalei/Desktop/openyurt/openyurt/cmd/yurt-iot-dock/app/core.go:137
github.com/openyurtio/openyurt/cmd/yurt-iot-dock/app.NewCmdYurtIoTDock.func1
        /Users/alokkumardalei/Desktop/openyurt/openyurt/cmd/yurt-iot-dock/app/core.go:76
github.com/spf13/cobra.(*Command).execute
        /Users/alokkumardalei/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019
github.com/spf13/cobra.(*Command).ExecuteC
        /Users/alokkumardalei/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /Users/alokkumardalei/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.main
        /Users/alokkumardalei/Desktop/openyurt/openyurt/cmd/yurt-iot-dock/yurt-iot-dock.go:37
runtime.main
        /usr/local/go/src/runtime/proc.go:285
 ```
Output correctly triggers: failed to initialize iot dock {"error": "unsupported platform: custom_platform"}
