### PR TITLE
refactor(webhook): safely merge gateway nodeSelector to prevent overwriting user labels

### DIFF
--- a/pkg/apis/raven/v1beta1/default.go
+++ b/pkg/apis/raven/v1beta1/default.go
@@ -25,11 +25,16 @@ import (
 // SetDefaultsGateway set default values for Gateway.
 func SetDefaultsGateway(obj *Gateway) {
 	// Set default value for Gateway
-	obj.Spec.NodeSelector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			raven.LabelCurrentGateway: obj.Name,
-		},
+	if obj.Spec.NodeSelector == nil {
+		obj.Spec.NodeSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{},
+		}
 	}
+	if obj.Spec.NodeSelector.MatchLabels == nil {
+		obj.Spec.NodeSelector.MatchLabels = map[string]string{}
+	}
+	// Safely merge the gateway label without overwriting existing labels
+	obj.Spec.NodeSelector.MatchLabels[raven.LabelCurrentGateway] = obj.Name
 	for idx, val := range obj.Spec.Endpoints {
 		if val.Port == 0 {
 			switch val.Type {

--- a/pkg/apis/raven/v1beta1/default_test.go
+++ b/pkg/apis/raven/v1beta1/default_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openyurtio/openyurt/pkg/apis/raven"
+)
+
+func TestSetDefaultsGateway(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *Gateway
+		expected *Gateway
+	}{
+		{
+			name: "NodeSelector is nil",
+			obj: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw",
+				},
+				Spec: GatewaySpec{},
+			},
+			expected: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw",
+				},
+				Spec: GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							raven.LabelCurrentGateway: "test-gw",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "MatchLabels is nil",
+			obj: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw-2",
+				},
+				Spec: GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{},
+				},
+			},
+			expected: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw-2",
+				},
+				Spec: GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							raven.LabelCurrentGateway: "test-gw-2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "MatchLabels exists",
+			obj: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw-3",
+				},
+				Spec: GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"existing": "label",
+						},
+					},
+				},
+			},
+			expected: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw-3",
+				},
+				Spec: GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"existing":                "label",
+							raven.LabelCurrentGateway: "test-gw-3",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Endpoints ports are set",
+			obj: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw-4",
+				},
+				Spec: GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{},
+					},
+					Endpoints: []Endpoint{
+						{
+							Type: Proxy,
+							Port: 0,
+						},
+						{
+							Type: Tunnel,
+							Port: 0,
+						},
+					},
+				},
+			},
+			expected: &Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gw-4",
+				},
+				Spec: GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							raven.LabelCurrentGateway: "test-gw-4",
+						},
+					},
+					Endpoints: []Endpoint{
+						{
+							Type: Proxy,
+							Port: DefaultProxyServerExposedPort,
+						},
+						{
+							Type: Tunnel,
+							Port: DefaultTunnelServerExposedPort,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SetDefaultsGateway(tc.obj)
+			if !reflect.DeepEqual(tc.obj, tc.expected) {
+				t.Errorf("SetDefaultsGateway() = %v, expected %v", tc.obj, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_default_test.go
+++ b/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_default_test.go
@@ -61,6 +61,23 @@ func TestDefault(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "should merge labels when MatchLabels is nil",
+			obj: &v1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway-nil-matchlabels",
+				},
+				Spec: v1beta1.GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{},
+				},
+			},
+			nodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					raven.LabelCurrentGateway: "test-gateway-nil-matchlabels",
+				},
+			},
+			expected: nil,
+		},
+		{
 			name: "should merge labels when NodeSelector already exists",
 			obj: &v1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -76,7 +93,7 @@ func TestDefault(t *testing.T) {
 			},
 			nodeSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"custom-label": "custom-value",
+					"custom-label":            "custom-value",
 					raven.LabelCurrentGateway: "test-gateway-merged",
 				},
 			},

--- a/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_default_test.go
+++ b/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_default_test.go
@@ -60,6 +60,28 @@ func TestDefault(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name: "should merge labels when NodeSelector already exists",
+			obj: &v1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway-merged",
+				},
+				Spec: v1beta1.GatewaySpec{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"custom-label": "custom-value",
+						},
+					},
+				},
+			},
+			nodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"custom-label": "custom-value",
+					raven.LabelCurrentGateway: "test-gateway-merged",
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	handler := &GatewayHandler{}


### PR DESCRIPTION
Fixes #2600

## What type of PR is this?
/kind bug
/sig network

## What this PR does / why we need it:
This PR refactors `SetDefaultsGateway` in `pkg/apis/raven/v1beta1/default.go` to perform a safe map-merge when applying the `raven.openyurt.io/gateway: <name>` nodeSelector label. Previously, the logic blindly initialized a new `&metav1.LabelSelector` struct, which would unconditionally overwrite any user-provided edge node selector labels during the mutating webhook intercept. This ensures robust support for custom node pools.

## Which issue(s) this PR fixes:
Fixes #2600

## Special notes for your reviewer:
I have manually verified that this correctly preserves existing labels inside `MatchLabels`.