### PR TITLE
fix(yurtadm): fix http.Request reuse and context leaks in polling closures

### DIFF
--- a/pkg/yurtadm/util/yurthub/yurthub.go
+++ b/pkg/yurtadm/util/yurthub/yurthub.go
@@ -426,16 +426,18 @@ func CheckYurthubServiceHealth(yurthubServer string) error {
 
 // CheckYurthubHealthz check if YurtHub is healthy.
 func CheckYurthubHealthz(yurthubServer string) error {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerHealthzURLPath), nil)
-	if err != nil {
-		return err
-	}
 	client := &http.Client{}
+	url := fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerHealthzURLPath)
 	return wait.PollUntilContextTimeout(context.Background(), time.Second*5, 300*time.Second, true, func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return false, err
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			return false, nil
 		}
+		defer resp.Body.Close()
 		ok, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, nil
@@ -446,16 +448,18 @@ func CheckYurthubHealthz(yurthubServer string) error {
 
 // CheckYurthubReadyz check if YurtHub's certificates are ready or not
 func CheckYurthubReadyz(yurthubServer string) error {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerReadyzURLPath), nil)
-	if err != nil {
-		return err
-	}
 	client := &http.Client{}
+	url := fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerReadyzURLPath)
 	return wait.PollUntilContextTimeout(context.Background(), time.Second*5, 300*time.Second, true, func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return false, err
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			return false, nil
 		}
+		defer resp.Body.Close()
 		ok, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, nil

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package yurthub
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1357,5 +1359,60 @@ func Test_CheckYurthubHealthz_WithTimeout(t *testing.T) {
 	}
 
 	err := CheckYurthubServiceHealth("127.0.0.1")
+	assert.Error(t, err)
+}
+
+func TestCheckYurthubHealthz(t *testing.T) {
+	// Start a test server that returns "OK"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	// Override default transport to route all traffic to our test server
+	oldTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	http.DefaultTransport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// Extract the port of the test server
+			tsURL, _ := url.Parse(ts.URL)
+			return net.Dial(network, tsURL.Host)
+		},
+	}
+
+	err := CheckYurthubHealthz("127.0.0.1")
+	assert.NoError(t, err)
+
+	// Test invalid URL parsing to cover the NewRequestWithContext error branch
+	err = CheckYurthubHealthz("invalid \x7f host")
+	assert.Error(t, err)
+}
+
+func TestCheckYurthubReadyz(t *testing.T) {
+	// Start a test server that returns "OK"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	// Override default transport to route all traffic to our test server
+	oldTransport := http.DefaultTransport
+	defer func() { http.DefaultTransport = oldTransport }()
+
+	http.DefaultTransport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			tsURL, _ := url.Parse(ts.URL)
+			return net.Dial(network, tsURL.Host)
+		},
+	}
+
+	err := CheckYurthubReadyz("127.0.0.1")
+	assert.NoError(t, err)
+
+	// Test invalid URL parsing to cover the NewRequestWithContext error branch
+	err = CheckYurthubReadyz("invalid \x7f host")
 	assert.Error(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
A concurrency bug existed in `CheckYurthubHealthz` and `CheckYurthubReadyz` where a single `*http.Request` was constructed before `wait.PollUntilContextTimeout`, and then reused iteratively in `client.Do(req)`. Go's `net/http` does not support reusing request objects once consumed by a client round-trip.

This PR fixes the behavior by:
1. Moving the request construction inside the polling closure.
2. Using `http.NewRequestWithContext(ctx, ...)` so that the `PollUntilContextTimeout` context properly propagates to the in-flight HTTP request.
3. Deferring `resp.Body.Close()` to prevent connection/body leaks.

#### Which issue(s) this PR fixes:
Fixes #2603

#### Special notes for your reviewer:
Verified the build passes cleanly via `make build WHAT="cmd/yurtadm"`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```