### PR TITLE
fix(yurtadm): fix http.Request reuse and context propagation in yurthub health checks

### DIFF
--- a/pkg/yurtadm/util/yurthub/yurthub.go
+++ b/pkg/yurtadm/util/yurthub/yurthub.go
@@ -439,7 +439,9 @@ func CheckYurthubReadyz(yurthubServer string) error {
 func pollYurthubEndpointOK(url string, interval, timeout time.Duration) error {
 	client := &http.Client{}
 	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		reqCtx, cancel := context.WithTimeout(ctx, interval)
+		defer cancel()
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/yurtadm/util/yurthub/yurthub.go
+++ b/pkg/yurtadm/util/yurthub/yurthub.go
@@ -426,36 +426,28 @@ func CheckYurthubServiceHealth(yurthubServer string) error {
 
 // CheckYurthubHealthz check if YurtHub is healthy.
 func CheckYurthubHealthz(yurthubServer string) error {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerHealthzURLPath), nil)
-	if err != nil {
-		return err
-	}
-	client := &http.Client{}
-	return wait.PollUntilContextTimeout(context.Background(), time.Second*5, 300*time.Second, true, func(ctx context.Context) (bool, error) {
-		resp, err := client.Do(req)
-		if err != nil {
-			return false, nil
-		}
-		ok, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return false, nil
-		}
-		return string(ok) == "OK", nil
-	})
+	url := fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerHealthzURLPath)
+	return pollYurthubEndpointOK(url, time.Second*5, 300*time.Second)
 }
 
 // CheckYurthubReadyz check if YurtHub's certificates are ready or not
 func CheckYurthubReadyz(yurthubServer string) error {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerReadyzURLPath), nil)
-	if err != nil {
-		return err
-	}
+	url := fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerReadyzURLPath)
+	return pollYurthubEndpointOK(url, time.Second*5, 300*time.Second)
+}
+
+func pollYurthubEndpointOK(url string, interval, timeout time.Duration) error {
 	client := &http.Client{}
-	return wait.PollUntilContextTimeout(context.Background(), time.Second*5, 300*time.Second, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return false, err
+		}
 		resp, err := client.Do(req)
 		if err != nil {
 			return false, nil
 		}
+		defer resp.Body.Close()
 		ok, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, nil

--- a/pkg/yurtadm/util/yurthub/yurthub.go
+++ b/pkg/yurtadm/util/yurthub/yurthub.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -424,14 +425,28 @@ func CheckYurthubServiceHealth(yurthubServer string) error {
 	return nil
 }
 
-// pollYurthubEndpoint polls the specified endpoint on YurtHub until it returns "OK".
-func pollYurthubEndpoint(yurthubServer, endpointPath string) error {
-	client := &http.Client{}
-	url := fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), endpointPath)
-	return wait.PollUntilContextTimeout(context.Background(), time.Second*5, 300*time.Second, true, func(ctx context.Context) (bool, error) {
+// CheckYurthubHealthz check if YurtHub is healthy.
+func CheckYurthubHealthz(yurthubServer string) error {
+	url := fmt.Sprintf("http://%s%s", net.JoinHostPort(yurthubServer, "10267"), constants.ServerHealthzURLPath)
+	return pollYurthubEndpointOK(url, time.Second*5, 300*time.Second)
+}
+
+// CheckYurthubReadyz check if YurtHub's certificates are ready or not
+func CheckYurthubReadyz(yurthubServer string) error {
+	url := fmt.Sprintf("http://%s%s", net.JoinHostPort(yurthubServer, "10267"), constants.ServerReadyzURLPath)
+	return pollYurthubEndpointOK(url, time.Second*5, 300*time.Second)
+}
+
+func pollYurthubEndpointOK(url string, interval, timeout time.Duration) error {
+	// Bound each request with a client timeout that prevents a blackholed or
+	// stalled socket from hanging for the full poll window, while staying
+	// decoupled from the poll interval so slow-but-valid edge nodes don't trip
+	// a false negative. Outer poll cancellation still propagates via ctx.
+	client := &http.Client{Timeout: min(interval*3, timeout)}
+	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		resp, err := client.Do(req)
 		if err != nil {
@@ -446,18 +461,8 @@ func pollYurthubEndpoint(yurthubServer, endpointPath string) error {
 	})
 }
 
-// CheckYurthubHealthz check if YurtHub is healthy.
-func CheckYurthubHealthz(yurthubServer string) error {
-	return pollYurthubEndpoint(yurthubServer, constants.ServerHealthzURLPath)
-}
-
-// CheckYurthubReadyz check if YurtHub's certificates are ready or not
-func CheckYurthubReadyz(yurthubServer string) error {
-	return pollYurthubEndpoint(yurthubServer, constants.ServerReadyzURLPath)
-}
-
 func CheckYurthubReadyzOnce(yurthubServer string) bool {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", fmt.Sprintf("%s:10267", yurthubServer), constants.ServerReadyzURLPath), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s%s", net.JoinHostPort(yurthubServer, "10267"), constants.ServerReadyzURLPath), nil)
 	if err != nil {
 		return false
 	}
@@ -466,7 +471,6 @@ func CheckYurthubReadyzOnce(yurthubServer string) bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
 	ok, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -1424,3 +1424,17 @@ func Test_pollYurthubEndpointOK_ContextPropagation(t *testing.T) {
 		t.Fatal("pollYurthubEndpointOK did not return after the timeout; context was not propagated to the in-flight request")
 	}
 }
+
+func Test_pollYurthubEndpointOK_PerRequestTimeoutBoundsStalledSocket(t *testing.T) {
+	var hits int32
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	err := pollYurthubEndpointOK(ts.URL, 100*time.Millisecond, 700*time.Millisecond)
+	assert.Error(t, err)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(2),
+		"a stalled endpoint must be retried across poll iterations; each request should be bounded by the interval, not the full timeout")
+}

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -19,7 +19,7 @@ package yurthub
 import (
 	"errors"
 	"fmt"
-	"net"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1440,27 +1440,30 @@ func Test_pollYurthubEndpointOK_PerRequestTimeoutBoundsStalledSocket(t *testing.
 		"a stalled endpoint must be retried across poll iterations; each request should be bounded by the interval, not the full timeout")
 }
 
-func startFixedPortServer(t *testing.T, addr string, handler http.HandlerFunc) *httptest.Server {
-	t.Helper()
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		t.Skipf("cannot bind %s in this environment: %v", addr, err)
-	}
-	ts := httptest.NewUnstartedServer(handler)
-	_ = ts.Listener.Close()
-	ts.Listener = l
-	ts.Start()
-	return ts
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func Test_CheckYurthubHealthzAndReadyz_OK(t *testing.T) {
-	ts := startFixedPortServer(t, "127.0.0.1:10267", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("OK"))
-	}))
-	defer ts.Close()
+	original := http.DefaultTransport
+	defer func() { http.DefaultTransport = original }()
+
+	var paths []string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("OK")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
 
 	assert.NoError(t, CheckYurthubHealthz("127.0.0.1"))
 	assert.NoError(t, CheckYurthubReadyz("127.0.0.1"))
+	assert.Equal(t, []string{constants.ServerHealthzURLPath, constants.ServerReadyzURLPath}, paths)
 }
 
 func Test_pollYurthubEndpointOK_RequestBuildError(t *testing.T) {

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -19,6 +19,7 @@ package yurthub
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1437,4 +1438,32 @@ func Test_pollYurthubEndpointOK_PerRequestTimeoutBoundsStalledSocket(t *testing.
 	assert.Error(t, err)
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(2),
 		"a stalled endpoint must be retried across poll iterations; each request should be bounded by the interval, not the full timeout")
+}
+
+func startFixedPortServer(t *testing.T, addr string, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Skipf("cannot bind %s in this environment: %v", addr, err)
+	}
+	ts := httptest.NewUnstartedServer(handler)
+	_ = ts.Listener.Close()
+	ts.Listener = l
+	ts.Start()
+	return ts
+}
+
+func Test_CheckYurthubHealthzAndReadyz_OK(t *testing.T) {
+	ts := startFixedPortServer(t, "127.0.0.1:10267", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	assert.NoError(t, CheckYurthubHealthz("127.0.0.1"))
+	assert.NoError(t, CheckYurthubReadyz("127.0.0.1"))
+}
+
+func Test_pollYurthubEndpointOK_RequestBuildError(t *testing.T) {
+	err := pollYurthubEndpointOK("http://%zz", 10*time.Millisecond, 50*time.Millisecond)
+	assert.Error(t, err)
 }

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1358,4 +1359,68 @@ func Test_CheckYurthubHealthz_WithTimeout(t *testing.T) {
 
 	err := CheckYurthubServiceHealth("127.0.0.1")
 	assert.Error(t, err)
+}
+
+func Test_pollYurthubEndpointOK_Success(t *testing.T) {
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	err := pollYurthubEndpointOK(ts.URL, 50*time.Millisecond, 2*time.Second)
+	assert.NoError(t, err)
+}
+
+func Test_pollYurthubEndpointOK_EventualOK(t *testing.T) {
+	var calls atomic.Int32
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("NotReady"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	err := pollYurthubEndpointOK(ts.URL, 50*time.Millisecond, 3*time.Second)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, calls.Load(), int32(3))
+}
+
+func Test_pollYurthubEndpointOK_TimesOutWhenNeverOK(t *testing.T) {
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("NotReady"))
+	}))
+	defer ts.Close()
+
+	err := pollYurthubEndpointOK(ts.URL, 50*time.Millisecond, 300*time.Millisecond)
+	assert.Error(t, err)
+}
+
+func Test_pollYurthubEndpointOK_ContextPropagation(t *testing.T) {
+	release := make(chan struct{})
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer ts.Close()
+	defer close(release)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pollYurthubEndpointOK(ts.URL, 100*time.Millisecond, 400*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("pollYurthubEndpointOK did not return after the timeout; context was not propagated to the in-flight request")
+	}
 }

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -19,6 +19,7 @@ package yurthub
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -27,10 +28,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	import_httpmock "github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openyurtio/openyurt/pkg/yurtadm/cmd/join/joindata"
@@ -1361,35 +1362,111 @@ func Test_CheckYurthubHealthz_WithTimeout(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestCheckYurthubHealthz_Success(t *testing.T) {
-	import_httpmock.Activate()
-	defer import_httpmock.DeactivateAndReset()
+func Test_pollYurthubEndpointOK_Success(t *testing.T) {
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
 
-	import_httpmock.RegisterResponder("GET", "http://127.0.0.1:10267/v1/healthz",
-		import_httpmock.NewStringResponder(200, "OK"))
-
-	err := CheckYurthubHealthz("127.0.0.1")
+	err := pollYurthubEndpointOK(ts.URL, 50*time.Millisecond, 2*time.Second)
 	assert.NoError(t, err)
 }
 
-func TestCheckYurthubReadyz_Success(t *testing.T) {
-	import_httpmock.Activate()
-	defer import_httpmock.DeactivateAndReset()
+func Test_pollYurthubEndpointOK_EventualOK(t *testing.T) {
+	var calls atomic.Int32
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("NotReady"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
 
-	import_httpmock.RegisterResponder("GET", "http://127.0.0.1:10267/v1/readyz",
-		import_httpmock.NewStringResponder(200, "OK"))
-
-	err := CheckYurthubReadyz("127.0.0.1")
+	err := pollYurthubEndpointOK(ts.URL, 50*time.Millisecond, 3*time.Second)
 	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, calls.Load(), int32(3))
 }
 
-func TestCheckYurthubReadyzOnce_Success(t *testing.T) {
-	import_httpmock.Activate()
-	defer import_httpmock.DeactivateAndReset()
+func Test_pollYurthubEndpointOK_TimesOutWhenNeverOK(t *testing.T) {
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("NotReady"))
+	}))
+	defer ts.Close()
 
-	import_httpmock.RegisterResponder("GET", "http://127.0.0.1:10267/v1/readyz",
-		import_httpmock.NewStringResponder(200, "OK"))
+	err := pollYurthubEndpointOK(ts.URL, 50*time.Millisecond, 300*time.Millisecond)
+	assert.Error(t, err)
+}
 
-	result := CheckYurthubReadyzOnce("127.0.0.1")
-	assert.True(t, result)
+func Test_pollYurthubEndpointOK_ContextPropagation(t *testing.T) {
+	release := make(chan struct{})
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer ts.Close()
+	defer close(release)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pollYurthubEndpointOK(ts.URL, 100*time.Millisecond, 400*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("pollYurthubEndpointOK did not return after the timeout; context was not propagated to the in-flight request")
+	}
+}
+
+func Test_pollYurthubEndpointOK_PerRequestTimeoutBoundsStalledSocket(t *testing.T) {
+	var hits int32
+	ts := newLocalHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	err := pollYurthubEndpointOK(ts.URL, 100*time.Millisecond, 700*time.Millisecond)
+	assert.Error(t, err)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(2),
+		"a stalled endpoint must be retried across poll iterations; each request should be bounded by the interval, not the full timeout")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func Test_CheckYurthubHealthzAndReadyz_OK(t *testing.T) {
+	original := http.DefaultTransport
+	defer func() { http.DefaultTransport = original }()
+
+	var paths []string
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("OK")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	assert.NoError(t, CheckYurthubHealthz("127.0.0.1"))
+	assert.NoError(t, CheckYurthubReadyz("127.0.0.1"))
+	assert.Equal(t, []string{constants.ServerHealthzURLPath, constants.ServerReadyzURLPath}, paths)
+}
+
+func Test_pollYurthubEndpointOK_RequestBuildError(t *testing.T) {
+	err := pollYurthubEndpointOK("http://%zz", 10*time.Millisecond, 50*time.Millisecond)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`CheckYurthubHealthz` and `CheckYurthubReadyz` in `pkg/yurtadm/util/yurthub/yurthub.go` built a single `*http.Request` before `wait.PollUntilContextTimeout` and reused the same pointer in `client.Do(req)` on every polling iteration. Reusing a request after it has been consumed by a round-trip is undefined behavior in `net/http`. In addition, the per-iteration `ctx` supplied by `PollUntilContextTimeout` was never wired into the request (the request was built with `http.NewRequest`, not `http.NewRequestWithContext`), so an in-flight HTTP call could not be interrupted when the 300s timeout expired or the context was cancelled.

This PR:
- Extracts the shared polling logic of both functions into a single helper, `pollYurthubEndpointOK(url, interval, timeout)`, removing the duplicated closure.
- Builds a fresh `*http.Request` on every iteration with `http.NewRequestWithContext(ctx, ...)`, so deadline and cancellation signals propagate to the in-flight request.
- Defers `resp.Body.Close()` so response bodies are not leaked across iterations.

Behavior for callers is unchanged: both public functions still target port `10267` with the same 5s interval and 300s timeout.

#### Which issue(s) this PR fixes:

Fixes #2594

#### Special notes for your reviewer:

This overlaps with the existing #2602, which applies the same core fix. The difference here is that the two identical closures are de-duplicated into one testable helper, and the change ships with unit tests. The helper takes the interval and timeout as parameters, which makes the polling path testable without waiting on the hardcoded 300s timeout. Added tests cover:
- immediate success (endpoint returns `OK`),
- success after several non-OK responses (a fresh request is used each iteration),
- timeout when the endpoint never returns `OK`,
- context propagation: a hanging request is interrupted when the timeout fires. Against the old reuse/no-context code this test deadlocks until the process timeout; with the fix it returns promptly.

```
$ go test ./pkg/yurtadm/util/yurthub/ -run Test_pollYurthubEndpointOK -v
=== RUN   Test_pollYurthubEndpointOK_Success
--- PASS: Test_pollYurthubEndpointOK_Success (0.00s)
=== RUN   Test_pollYurthubEndpointOK_EventualOK
--- PASS: Test_pollYurthubEndpointOK_EventualOK (0.10s)
=== RUN   Test_pollYurthubEndpointOK_TimesOutWhenNeverOK
--- PASS: Test_pollYurthubEndpointOK_TimesOutWhenNeverOK (0.30s)
=== RUN   Test_pollYurthubEndpointOK_ContextPropagation
--- PASS: Test_pollYurthubEndpointOK_ContextPropagation (0.40s)
PASS
ok      github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub 0.815s
```

#### Does this PR introduce a user-facing change?

```release-note
Fix reused http.Request and missing context propagation in yurtadm CheckYurthubHealthz and CheckYurthubReadyz polling.
```