### PR TITLE
feat: Add Helm chart for yurt-tunnel and include in e2e testing

### DIFF
--- a/charts/yurt-tunnel/.helmignore
+++ b/charts/yurt-tunnel/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/yurt-tunnel/Chart.yaml
+++ b/charts/yurt-tunnel/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: yurt-tunnel
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/yurt-tunnel/templates/rbac.yaml
+++ b/charts/yurt-tunnel/templates/rbac.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.server.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agent.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: yurt-tunnel-server
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "endpoints", "services", "pods", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests"]
+    verbs: ["get", "list", "watch", "create", "update"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests/approval"]
+    verbs: ["update"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["signers"]
+    resourceNames: ["kubernetes.io/kube-apiserver-client", "kubernetes.io/kubelet-serving"]
+    verbs: ["approve"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yurt-tunnel-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: yurt-tunnel-server
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.server.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: yurt-tunnel-agent
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "endpoints", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests"]
+    verbs: ["create", "get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yurt-tunnel-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: yurt-tunnel-agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.agent.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/yurt-tunnel/templates/yurt-tunnel-agent.yaml
+++ b/charts/yurt-tunnel/templates/yurt-tunnel-agent.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: yurt-tunnel-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: yurt-tunnel-agent
+spec:
+  selector:
+    matchLabels:
+      app: yurt-tunnel-agent
+  template:
+    metadata:
+      labels:
+        app: yurt-tunnel-agent
+    spec:
+      serviceAccountName: {{ .Values.agent.serviceAccount.name }}
+      hostNetwork: true
+      nodeSelector:
+{{ toYaml .Values.agent.nodeSelector | indent 8 }}
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: yurt-tunnel-agent
+          image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          command:
+            - yurt-tunnel-agent
+          args:
+            - --tunnelserver-addr=x-tunnel-server-svc.{{ .Release.Namespace }}.svc:10262
+          volumeMounts:
+            - name: k8s-dir
+              mountPath: /etc/kubernetes
+      volumes:
+        - name: k8s-dir
+          hostPath:
+            path: /etc/kubernetes
+            type: DirectoryOrCreate

--- a/charts/yurt-tunnel/templates/yurt-tunnel-agent.yaml
+++ b/charts/yurt-tunnel/templates/yurt-tunnel-agent.yaml
@@ -15,7 +15,7 @@ spec:
         app: yurt-tunnel-agent
     spec:
       serviceAccountName: {{ .Values.agent.serviceAccount.name }}
-      hostNetwork: true
+      hostNetwork: true # NOSONAR
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
       tolerations:
@@ -31,6 +31,8 @@ spec:
           volumeMounts:
             - name: k8s-dir
               mountPath: /etc/kubernetes
+          resources:
+{{ toYaml .Values.agent.resources | indent 12 }}
       volumes:
         - name: k8s-dir
           hostPath:

--- a/charts/yurt-tunnel/templates/yurt-tunnel-server.yaml
+++ b/charts/yurt-tunnel/templates/yurt-tunnel-server.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yurt-tunnel-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: yurt-tunnel-server
+spec:
+  replicas: {{ .Values.server.replicas }}
+  selector:
+    matchLabels:
+      app: yurt-tunnel-server
+  template:
+    metadata:
+      labels:
+        app: yurt-tunnel-server
+    spec:
+      serviceAccountName: {{ .Values.server.serviceAccount.name }}
+      hostNetwork: true
+      nodeSelector:
+{{ toYaml .Values.server.nodeSelector | indent 8 }}
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: yurt-tunnel-server
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          command:
+            - yurt-tunnel-server
+          args:
+            - --bind-address=$(POD_IP)
+            - --insecure-bind-address=$(POD_IP)
+            - --server-count={{ .Values.server.replicas }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - containerPort: 10262
+              name: https
+            - containerPort: 10263
+              name: http
+            - containerPort: 10264
+              name: http-insecure
+          volumeMounts:
+            - name: k8s-dir
+              mountPath: /etc/kubernetes
+      volumes:
+        - name: k8s-dir
+          hostPath:
+            path: /etc/kubernetes
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: x-tunnel-server-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: yurt-tunnel-server
+spec:
+  type: ClusterIP
+  ports:
+    - port: 10262
+      targetPort: 10262
+      name: https
+    - port: 10263
+      targetPort: 10263
+      name: http
+    - port: 10264
+      targetPort: 10264
+      name: http-insecure
+  selector:
+    app: yurt-tunnel-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: x-tunnel-server-internal-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: yurt-tunnel-server
+spec:
+  type: ClusterIP
+  ports:
+    - port: 10262
+      targetPort: 10262
+      name: https
+    - port: 10263
+      targetPort: 10263
+      name: http
+  selector:
+    app: yurt-tunnel-server

--- a/charts/yurt-tunnel/templates/yurt-tunnel-server.yaml
+++ b/charts/yurt-tunnel/templates/yurt-tunnel-server.yaml
@@ -16,7 +16,7 @@ spec:
         app: yurt-tunnel-server
     spec:
       serviceAccountName: {{ .Values.server.serviceAccount.name }}
-      hostNetwork: true
+      hostNetwork: true # NOSONAR
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}
       tolerations:
@@ -46,6 +46,8 @@ spec:
           volumeMounts:
             - name: k8s-dir
               mountPath: /etc/kubernetes
+          resources:
+{{ toYaml .Values.server.resources | indent 12 }}
       volumes:
         - name: k8s-dir
           hostPath:

--- a/charts/yurt-tunnel/values.yaml
+++ b/charts/yurt-tunnel/values.yaml
@@ -1,0 +1,30 @@
+# Default values for yurt-tunnel.
+
+server:
+  image:
+    repository: openyurt/yurt-tunnel-server
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  replicas: 1
+  serviceAccount:
+    create: true
+    name: "yurt-tunnel-server"
+  resources: {}
+  nodeSelector:
+    openyurt.io/is-edge-worker: "false"
+
+agent:
+  image:
+    repository: openyurt/yurt-tunnel-agent
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  serviceAccount:
+    create: true
+    name: "yurt-tunnel-agent"
+  resources: {}
+  nodeSelector:
+    openyurt.io/is-edge-worker: "true"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""

--- a/charts/yurt-tunnel/values.yaml
+++ b/charts/yurt-tunnel/values.yaml
@@ -4,12 +4,20 @@ server:
   image:
     repository: openyurt/yurt-tunnel-server
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: ""
   replicas: 1
   serviceAccount:
     create: true
     name: "yurt-tunnel-server"
-  resources: {}
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi
+      ephemeral-storage: 2048Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 512Mi
   nodeSelector:
     openyurt.io/is-edge-worker: "false"
 
@@ -17,11 +25,19 @@ agent:
   image:
     repository: openyurt/yurt-tunnel-agent
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: ""
   serviceAccount:
     create: true
     name: "yurt-tunnel-agent"
-  resources: {}
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi
+      ephemeral-storage: 2048Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 512Mi
   nodeSelector:
     openyurt.io/is-edge-worker: "true"
 

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -408,8 +408,8 @@ func (c *ClusterConverter) installYurtManagerByHelm() error {
 
 	// waiting yurt-manager pod ready
 	if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		podList, err := c.ClientSet.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{
-			LabelSelector: labels.SelectorFromSet(map[string]string{"app.kubernetes.io/name": "yurt-manager"}).String(),
+		podList, err := c.ClientSet.CoreV1().Pods(KubeSystemNamespace).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(map[string]string{"app.kubernetes.io/name": YurtManagerChartName}).String(),
 		})
 		if err != nil {
 			klog.Errorf("failed to list yurt-manager pod, %v", err)
@@ -484,8 +484,8 @@ func imageTag(image string) (string, error) {
 // print logs of yurt-manager
 func (c *ClusterConverter) dumpYurtManagerLog() {
 	// print logs of yurt-manager
-	podList, logErr := c.ClientSet.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{"app.kubernetes.io/name": "yurt-manager"}).String(),
+	podList, logErr := c.ClientSet.CoreV1().Pods(KubeSystemNamespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{"app.kubernetes.io/name": YurtManagerChartName}).String(),
 	})
 	if logErr != nil {
 		klog.Errorf("failed to get yurt-manager pod, %v", logErr)

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -46,6 +46,9 @@ import (
 
 const (
 	conversionConditionType corev1.NodeConditionType = "YurtNodeConversionFailed"
+	YurtManagerChartName                             = "yurt-manager"
+	YurtTunnelChartName                              = "yurt-tunnel"
+	KubeSystemNamespace                              = "kube-system"
 )
 
 type ClusterConverter struct {
@@ -394,7 +397,7 @@ func (c *ClusterConverter) installYurtManagerByHelm() error {
 		return err
 	}
 
-	err = c.installHelmChart("yurt-manager",
+	err = c.installHelmChart(YurtManagerChartName,
 		"--set", fmt.Sprintf("image.tag=%s", managerTag),
 		"--set", fmt.Sprintf("nodeServant.image.tag=%s", nodeServantTag),
 		"--set", "log.level=5",
@@ -442,7 +445,7 @@ func (c *ClusterConverter) installYurtManagerByHelm() error {
 }
 
 func (c *ClusterConverter) installYurtTunnelByHelm() error {
-	return c.installHelmChart("yurt-tunnel")
+	return c.installHelmChart(YurtTunnelChartName)
 }
 
 func (c *ClusterConverter) installHelmChart(chartName string, extraArgs ...string) error {
@@ -454,7 +457,7 @@ func (c *ClusterConverter) installHelmChart(chartName string, extraArgs ...strin
 		chartName,
 		chartPath,
 		"--namespace",
-		"kube-system",
+		KubeSystemNamespace,
 	}
 	args = append(args, extraArgs...)
 

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -385,9 +385,6 @@ func (c *ClusterConverter) dumpNodeJobs(nodeName string) {
 }
 
 func (c *ClusterConverter) installYurtManagerByHelm() error {
-	helmPath := filepath.Join(c.RootDir, "bin", "helm")
-	yurtManagerChartPath := filepath.Join(c.RootDir, "charts", "yurt-manager")
-
 	managerTag, err := imageTag(c.YurtManagerImage)
 	if err != nil {
 		return err
@@ -397,27 +394,14 @@ func (c *ClusterConverter) installYurtManagerByHelm() error {
 		return err
 	}
 
-	cmd := exec.Command(
-		helmPath,
-		"install",
-		"yurt-manager",
-		yurtManagerChartPath,
-		"--namespace",
-		"kube-system",
-		"--set",
-		fmt.Sprintf("image.tag=%s", managerTag),
-		"--set",
-		fmt.Sprintf("nodeServant.image.tag=%s", nodeServantTag),
-		"--set",
-		"log.level=5",
+	err = c.installHelmChart("yurt-manager",
+		"--set", fmt.Sprintf("image.tag=%s", managerTag),
+		"--set", fmt.Sprintf("nodeServant.image.tag=%s", nodeServantTag),
+		"--set", "log.level=5",
 	)
-	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Errorf("couldn't install yurt-manager, %v", err)
-		klog.Errorf("Helm install output: %s", string(output))
 		return err
 	}
-	klog.Infof("start to install yurt-manager, %s", string(output))
 
 	// waiting yurt-manager pod ready
 	if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
@@ -458,24 +442,30 @@ func (c *ClusterConverter) installYurtManagerByHelm() error {
 }
 
 func (c *ClusterConverter) installYurtTunnelByHelm() error {
-	helmPath := filepath.Join(c.RootDir, "bin", "helm")
-	yurtTunnelChartPath := filepath.Join(c.RootDir, "charts", "yurt-tunnel")
+	return c.installHelmChart("yurt-tunnel")
+}
 
-	cmd := exec.Command(
-		helmPath,
+func (c *ClusterConverter) installHelmChart(chartName string, extraArgs ...string) error {
+	helmPath := filepath.Join(c.RootDir, "bin", "helm")
+	chartPath := filepath.Join(c.RootDir, "charts", chartName)
+
+	args := []string{
 		"install",
-		"yurt-tunnel",
-		yurtTunnelChartPath,
+		chartName,
+		chartPath,
 		"--namespace",
 		"kube-system",
-	)
+	}
+	args = append(args, extraArgs...)
+
+	cmd := exec.Command(helmPath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Errorf("couldn't install yurt-tunnel, %v", err)
+		klog.Errorf("couldn't install %s, %v", chartName, err)
 		klog.Errorf("Helm install output: %s", string(output))
 		return err
 	}
-	klog.Infof("start to install yurt-tunnel, %s", string(output))
+	klog.Infof("start to install %s, %s", chartName, string(output))
 	return nil
 }
 

--- a/test/e2e/cmd/init/converter.go
+++ b/test/e2e/cmd/init/converter.go
@@ -82,6 +82,12 @@ func (c *ClusterConverter) Run() error {
 		return err
 	}
 
+	klog.Info("Deploying yurt-tunnel")
+	if err := c.installYurtTunnelByHelm(); err != nil {
+		klog.Errorf("failed to deploy yurt-tunnel, %s", err)
+		return err
+	}
+
 	klog.Infof("Start to initialize default node pools: %+v", DefaultPools)
 	if err := c.createDefaultNodePools(); err != nil {
 		return err
@@ -448,6 +454,28 @@ func (c *ClusterConverter) installYurtManagerByHelm() error {
 		return err
 	}
 
+	return nil
+}
+
+func (c *ClusterConverter) installYurtTunnelByHelm() error {
+	helmPath := filepath.Join(c.RootDir, "bin", "helm")
+	yurtTunnelChartPath := filepath.Join(c.RootDir, "charts", "yurt-tunnel")
+
+	cmd := exec.Command(
+		helmPath,
+		"install",
+		"yurt-tunnel",
+		yurtTunnelChartPath,
+		"--namespace",
+		"kube-system",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Errorf("couldn't install yurt-tunnel, %v", err)
+		klog.Errorf("Helm install output: %s", string(output))
+		return err
+	}
+	klog.Infof("start to install yurt-tunnel, %s", string(output))
 	return nil
 }
 


### PR DESCRIPTION
## Description
This PR resolves [Issue #982](https://github.com/openyurtio/openyurt/issues/982) by introducing a new Helm chart for `yurt-tunnel` and adding it to the end-to-end testing cluster initialization pipeline. This ensures that `yurttunnel-server` and `yurttunnel-agent` can be cleanly installed using Helm and their deployment stability is continuously verified during E2E testing.

Changes Made

- Helm Chart Creation: Scaffolded a brand new chart at charts/yurt-tunnel tailored for OpenYurt's network proxy components.
- yurt-tunnel-server: Added Deployment and Service (`x-tunnel-server-svc`, `x-tunnel-server-internal-svc`) templates along with the necessary ClusterRoles to allow proxying and certificate signing.
- yurt-tunnel-agent: Added a DaemonSet template that automatically selects edge nodes (`openyurt.io/is-edge-worker: "true"`) and connects to the server service.
- E2E Integration: Modified `test/e2e/cmd/init/converter.go` to explicitly run helm install yurt-tunnel during cluster initialization so Helm compatibility is tested automatically.

Manual Testing
What this manual test does: This verifies that the Helm templates render correctly and that no syntactic or structural errors exist in the newly authored chart.

Test Execution & Output:
- Command: 
```bash
helm lint charts/yurt-tunnel
```
- Output:
```bash
alokkumardalei@Aloks-MacBook-Air openyurt % helm lint charts/yurt-tunnel
==> Linting charts/yurt-tunnel
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```
- Command:
```bash
helm template charts/yurt-tunnel
```
- Output:
```bash
alokkumardalei@Aloks-MacBook-Air openyurt % helm template charts/yurt-tunnel
---
# Source: yurt-tunnel/templates/rbac.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: yurt-tunnel-server
  namespace: default
---
# Source: yurt-tunnel/templates/rbac.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: yurt-tunnel-agent
  namespace: default
---
# Source: yurt-tunnel/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: yurt-tunnel-server
rules:
  - apiGroups: [""]
    resources: ["nodes", "endpoints", "services", "pods", "configmaps"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["configmaps"]
    verbs: ["create", "update", "patch"]
  - apiGroups: ["certificates.k8s.io"]
    resources: ["certificatesigningrequests"]
    verbs: ["get", "list", "watch", "create", "update"]
  - apiGroups: ["certificates.k8s.io"]
    resources: ["certificatesigningrequests/approval"]
    verbs: ["update"]
  - apiGroups: ["certificates.k8s.io"]
    resources: ["signers"]
    resourceNames: ["kubernetes.io/kube-apiserver-client", "kubernetes.io/kubelet-serving"]
    verbs: ["approve"]
---
# Source: yurt-tunnel/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: yurt-tunnel-agent
rules:
  - apiGroups: [""]
    resources: ["nodes", "endpoints", "services"]
    verbs: ["get", "list", "watch"]
  - apiGroups: ["certificates.k8s.io"]
    resources: ["certificatesigningrequests"]
    verbs: ["create", "get", "list", "watch"]
---
# Source: yurt-tunnel/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: yurt-tunnel-server
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: yurt-tunnel-server
subjects:
  - kind: ServiceAccount
    name: yurt-tunnel-server
    namespace: default
---
# Source: yurt-tunnel/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: yurt-tunnel-agent
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: yurt-tunnel-agent
subjects:
  - kind: ServiceAccount
    name: yurt-tunnel-agent
    namespace: default
---
# Source: yurt-tunnel/templates/yurt-tunnel-server.yaml
apiVersion: v1
kind: Service
metadata:
  name: x-tunnel-server-svc
  namespace: default
  labels:
    app: yurt-tunnel-server
spec:
  type: ClusterIP
  ports:
    - port: 10262
      targetPort: 10262
      name: https
    - port: 10263
      targetPort: 10263
      name: http
    - port: 10264
      targetPort: 10264
      name: http-insecure
  selector:
    app: yurt-tunnel-server
---
# Source: yurt-tunnel/templates/yurt-tunnel-server.yaml
apiVersion: v1
kind: Service
metadata:
  name: x-tunnel-server-internal-svc
  namespace: default
  labels:
    app: yurt-tunnel-server
spec:
  type: ClusterIP
  ports:
    - port: 10262
      targetPort: 10262
      name: https
    - port: 10263
      targetPort: 10263
      name: http
  selector:
    app: yurt-tunnel-server
---
# Source: yurt-tunnel/templates/yurt-tunnel-agent.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: yurt-tunnel-agent
  namespace: default
  labels:
    app: yurt-tunnel-agent
spec:
  selector:
    matchLabels:
      app: yurt-tunnel-agent
  template:
    metadata:
      labels:
        app: yurt-tunnel-agent
    spec:
      serviceAccountName: yurt-tunnel-agent
      hostNetwork: true
      nodeSelector:
        openyurt.io/is-edge-worker: "true"
      tolerations:
        - operator: Exists
      containers:
        - name: yurt-tunnel-agent
          image: "openyurt/yurt-tunnel-agent:latest"
          imagePullPolicy: IfNotPresent
          command:
            - yurt-tunnel-agent
          args:
            - --tunnelserver-addr=x-tunnel-server-svc.default.svc:10262
          volumeMounts:
            - name: k8s-dir
              mountPath: /etc/kubernetes
      volumes:
        - name: k8s-dir
          hostPath:
            path: /etc/kubernetes
            type: DirectoryOrCreate
---
# Source: yurt-tunnel/templates/yurt-tunnel-server.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: yurt-tunnel-server
  namespace: default
  labels:
    app: yurt-tunnel-server
spec:
  replicas: 1
  selector:
    matchLabels:
      app: yurt-tunnel-server
  template:
    metadata:
      labels:
        app: yurt-tunnel-server
    spec:
      serviceAccountName: yurt-tunnel-server
      hostNetwork: true
      nodeSelector:
        openyurt.io/is-edge-worker: "false"
      tolerations:
        - operator: Exists
      containers:
        - name: yurt-tunnel-server
          image: "openyurt/yurt-tunnel-server:latest"
          imagePullPolicy: IfNotPresent
          command:
            - yurt-tunnel-server
          args:
            - --bind-address=$(POD_IP)
            - --insecure-bind-address=$(POD_IP)
            - --server-count=1
          env:
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
          ports:
            - containerPort: 10262
              name: https
            - containerPort: 10263
              name: http
            - containerPort: 10264
              name: http-insecure
          volumeMounts:
            - name: k8s-dir
              mountPath: /etc/kubernetes
      volumes:
        - name: k8s-dir
          hostPath:
            path: /etc/kubernetes
            type: DirectoryOrCreate
```