### PR TITLE
fix(node-servant): add fallback search paths for crictl to support restricted environments

### DIFF
--- a/pkg/node-servant/components/runtime.go
+++ b/pkg/node-servant/components/runtime.go
@@ -94,7 +94,17 @@ func NewContainerRuntimeForImage(execer utilsexec.Interface, criSocket string) (
 	}
 
 	if _, err := execer.LookPath(toolName); err != nil {
-		return nil, errors.Wrapf(err, "%s is required for container runtime", toolName)
+		// Fallback for restricted Job $PATH (common on kubeadm/k3s)
+		for _, dir := range []string{"/usr/local/bin", "/opt/bin", "/opt/cni/bin", "/usr/bin"} {
+			if _, statErr := os.Stat(filepath.Join(dir, toolName)); statErr == nil {
+				os.Setenv("PATH", os.Getenv("PATH")+string(os.PathListSeparator)+dir)
+				break
+			}
+		}
+		// Try again after potentially updating PATH
+		if _, err := execer.LookPath(toolName); err != nil {
+			return nil, errors.Wrapf(err, "%s is required for container runtime", toolName)
+		}
 	}
 	return runtime, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR addresses a silent failure in `node-servant` where `YurtNodeConversion` jobs fail on standard kubeadm and k3s nodes. 

Currently, `NewContainerRuntimeForImage` relies on `exec.LookPath("crictl")`. However, the restricted `$PATH` of the `YurtNodeConversion` Job pod prevents `LookPath` from finding the binary even if it exists in common host directories like `/usr/local/bin` or `/opt/cni/bin`. This results in the conversion job exiting early without a clear failure state.

By adding a robust fallback search, the container runtime component now dynamically checks standard binary paths and injects the correct directory into the environment. This ensures `crictl` executes successfully without requiring manual user intervention or band-aid documentation updates.

This provides the robust foundational fix required for the automated AI skills discussed in #2559.

#### Which issue(s) this PR fixes:
Part of #2559

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a bug in node-servant where YurtNodeConversion jobs failed due to crictl not being found in restricted $PATH environments.
```
