### PR TITLE
docs: clarify Raven L7 proxy replaces Yurt-Tunnel for kubectl exec/logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The above figure demonstrates the core OpenYurt architecture. The major componen
 
 - **[YurtHub](https://openyurt.io/docs/next/core-concepts/yurthub)**: YurtHub runs on worker nodes as static pod and serves as a node sidecar to handle requests that come from components (like Kubelet, Kubeproxy, etc.) on worker nodes to kube-apiserver.
 - **[Yurt-Manager](https://openyurt.io/docs/core-concepts/yurt-manager/)**: includes all controllers and webhooks for edge.
-- **[Raven-Agent](https://openyurt.io/docs/next/core-concepts/raven)**: It is focused on edge-edge and edge-cloud communication in OpenYurt, and provides layer 3 network connectivity among pods in different physical regions, as in a vanilla Kubernetes cluster.
+- **[Raven-Agent](https://openyurt.io/docs/next/core-concepts/raven)**: It is focused on edge-edge and edge-cloud communication in OpenYurt. It provides Layer 3 network connectivity among pods in different physical regions (as in a vanilla Kubernetes cluster), and Layer 7 reverse proxying (replacing Yurt-Tunnel) for native Kubernetes O&M commands like `kubectl exec` and `kubectl logs`.
 - **[YurtIoTDock](https://openyurt.io/docs/next/core-concepts/yurt-iot-dock)**: One instance of YurtIoTDock is deployed in every edge NodePool, for bridging EdgeX Foundry platform and uses Kubernetes CRD to manage edge devices.
 
 In addition, OpenYurt also includes auxiliary controllers for integration and customization purposes.


### PR DESCRIPTION
### Description
Fixes Issue: https://github.com/openyurtio/openyurt/issues/2545
This PR addresses the confusion raised in Issue 2545 where users (and even maintainers) assumed that yurt-tunnel was simply removed without a replacement.

While OpenYurt 1.4+ migrated cross-edge communication to Raven, the documentation in `README.md` only mentioned Raven's Layer 3 (pod-to-pod) capabilities. It failed to mention that the Raven project also absorbed Yurt-Tunnel's functionality via the Raven L7 Proxy (`raven-l7-server` and `raven-l7-agent`).

This PR updates the main README.md to explicitly state that Raven-Agent provides the L7 reverse proxying required for native Kubernetes O&M commands (like `kubectl exec` and `kubectl logs`), officially replacing the legacy `Yurt-Tunnel`.