### PR TITLE
Bugfix: make multiplexer request scopes subresource-aware

### DIFF
--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +54,7 @@ type multiplexerProxy struct {
 func init() {
 	// When parsing the FieldSelector in list/watch requests, the corresponding resource's conversion functions need to be used.
 	// Here, the primary action is to introduce the conversion functions registered in the core/v1 resources into the scheme.
+	autoscalingv1.AddToScheme(scheme.Scheme)
 	v1.AddToScheme(scheme.Scheme)
 }
 
@@ -83,7 +85,7 @@ func (sp *multiplexerProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		util.Err(errors.Wrapf(err, "failed to get rest storage"), w, r)
 	}
 
-	reqScope, err := sp.getReqScope(gvr)
+	reqScope, err := sp.getReqScope(gvr, reqInfo.Subresource)
 	if err != nil {
 		util.Err(errors.Wrapf(err, "failed tp get req scope"), w, r)
 	}
@@ -94,10 +96,19 @@ func (sp *multiplexerProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	handlers.ListResource(lister, watcher, reqScope, forceWatch, minRequestTimeout).ServeHTTP(w, r)
 }
 
-func (sp *multiplexerProxy) getReqScope(gvr *schema.GroupVersionResource) (*handlers.RequestScope, error) {
+func (sp *multiplexerProxy) getReqScope(gvr *schema.GroupVersionResource, subresource string) (*handlers.RequestScope, error) {
 	_, fqKindToRegister := sp.restMapperManager.KindFor(*gvr)
 	if fqKindToRegister.Empty() {
 		return nil, fmt.Errorf("gvk is not found for gvr: %v", *gvr)
+	}
+
+	equivalentResourceRegistry := runtime.NewEquivalentResourceRegistry()
+	equivalentResourceRegistry.RegisterKindFor(*gvr, "", fqKindToRegister)
+
+	reqKind := fqKindToRegister
+	if len(subresource) > 0 {
+		reqKind = reqScopeKindForSubresource(fqKindToRegister, subresource)
+		equivalentResourceRegistry.RegisterKindFor(*gvr, subresource, reqKind)
 	}
 
 	return &handlers.RequestScope{
@@ -109,16 +120,16 @@ func (sp *multiplexerProxy) getReqScope(gvr *schema.GroupVersionResource) (*hand
 		UnsafeConvertor: runtime.UnsafeObjectConvertor(scheme.Scheme),
 		Authorizer:      authorizerfactory.NewAlwaysAllowAuthorizer(),
 
-		EquivalentResourceMapper: runtime.NewEquivalentResourceRegistry(),
+		EquivalentResourceMapper: equivalentResourceRegistry,
 
 		// TODO: Check for the interface on storage
 		TableConvertor: rest.NewDefaultTableConvertor(gvr.GroupResource()),
 
-		// TODO: This seems wrong for cross-group subresources. It makes an assumption that a subresource and its parent are in the same group version. Revisit this.
-		Resource: *gvr,
-		Kind:     fqKindToRegister,
+		Resource:    *gvr,
+		Kind:        reqKind,
+		Subresource: subresource,
 
-		HubGroupVersion: schema.GroupVersion{Group: fqKindToRegister.Group, Version: runtime.APIVersionInternal},
+		HubGroupVersion: schema.GroupVersion{Group: reqKind.Group, Version: runtime.APIVersionInternal},
 
 		MetaGroupVersion: metav1.SchemeGroupVersion,
 
@@ -127,4 +138,13 @@ func (sp *multiplexerProxy) getReqScope(gvr *schema.GroupVersionResource) (*hand
 			Namer: runtime.Namer(meta.NewAccessor()),
 		},
 	}, nil
+}
+
+func reqScopeKindForSubresource(parentKind schema.GroupVersionKind, subresource string) schema.GroupVersionKind {
+	switch subresource {
+	case "scale":
+		return autoscalingv1.SchemeGroupVersion.WithKind("Scale")
+	default:
+		return parentKind
+	}
 }

--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -517,4 +518,46 @@ func endpointSliceKey(slice discovery.EndpointSlice) string {
 	}
 	sort.Strings(keys)
 	return fmt.Sprint(keys)
+}
+
+func TestMultiplexerProxyGetReqScope_Subresource(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatalf("failed to make temp dir, %v", err)
+	}
+	restMapperManager, err := meta.NewRESTMapperManager(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to make rest mapper manager, %v", err)
+	}
+
+	sp := &multiplexerProxy{
+		restMapperManager: restMapperManager,
+	}
+
+	t.Run("scale subresource uses scale kind", func(t *testing.T) {
+		gvr := &schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+		reqScope, err := sp.getReqScope(gvr, "scale")
+		if err != nil {
+			t.Fatalf("failed to get request scope, %v", err)
+		}
+
+		assert.Equal(t, "scale", reqScope.Subresource)
+		assert.Equal(t, autoscalingv1.SchemeGroupVersion.WithKind("Scale"), reqScope.Kind)
+		assert.Equal(t, schema.GroupVersion{Group: "autoscaling", Version: runtime.APIVersionInternal}, reqScope.HubGroupVersion)
+		assert.Equal(t, autoscalingv1.SchemeGroupVersion.WithKind("Scale"), reqScope.EquivalentResourceMapper.KindFor(*gvr, "scale"))
+	})
+
+	t.Run("main resource keeps parent kind", func(t *testing.T) {
+		gvr := &schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+		reqScope, err := sp.getReqScope(gvr, "")
+		if err != nil {
+			t.Fatalf("failed to get request scope, %v", err)
+		}
+
+		assert.Empty(t, reqScope.Subresource)
+		assert.Equal(t, schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, reqScope.Kind)
+		assert.Equal(t, schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, reqScope.EquivalentResourceMapper.KindFor(*gvr, ""))
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
## Summary
- preserve `RequestInfo.Subresource` when building multiplexer request scopes
- register the correct subresource kind for `scale` requests and keep parent resource behavior unchanged
- add regression coverage for subresource and non-subresource request scopes

#### Which issue(s) this PR fixes:
Fixes #2615

#### Special notes for your reviewer:
- Scope is limited to `pkg/yurthub/proxy/multiplexer`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### other Note
## What Changed
- pass `reqInfo.Subresource` into `getReqScope`
- populate `RequestScope.Subresource`, `Kind`, `HubGroupVersion`, and `EquivalentResourceMapper` with subresource-aware values
- add a deployment `/scale` regression test and a main-resource control test

## Verification
- `go test ./pkg/yurthub/proxy/multiplexer -run 'TestMultiplexerProxyGetReqScope_Subresource|TestShareProxy' -count=1` — passed\n- `go test ./pkg/yurthub/proxy/multiplexer -run TestMultiplexerProxyGetReqScope_Subresource -count=1` — passed\n- `make verify` — passed\n- `make test` — passed\n- `make lint` — passed\n\n## Scope\n- Only `pkg/yurthub/proxy/multiplexer/multiplexerproxy.go` and `pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go` were changed; unrelated files were not modified.