### PR TITLE
Bugfix: return after error in multiplexer proxy handler

### DIFF
--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
@@ -86,7 +86,7 @@ func (sp *multiplexerProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	reqScope, err := sp.getReqScope(gvr)
 	if err != nil {
-		util.Err(errors.Wrapf(err, "failed tp get req scope"), w, r)
+		util.Err(errors.Wrapf(err, "failed to get req scope"), w, r)
 		return
 	}
 

--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
@@ -44,8 +44,13 @@ const (
 	minRequestTimeout = 300 * time.Second
 )
 
+type resourceMultiplexer interface {
+	Ready(gvr *schema.GroupVersionResource) bool
+	ResourceStore(gvr *schema.GroupVersionResource) (rest.Storage, error)
+}
+
 type multiplexerProxy struct {
-	requestsMultiplexerManager *multiplexer.MultiplexerManager
+	requestsMultiplexerManager resourceMultiplexer
 	restMapperManager          *hubmeta.RESTMapperManager
 	stop                       <-chan struct{}
 }

--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
@@ -81,11 +81,13 @@ func (sp *multiplexerProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	restStore, err := sp.requestsMultiplexerManager.ResourceStore(gvr)
 	if err != nil {
 		util.Err(errors.Wrapf(err, "failed to get rest storage"), w, r)
+		return
 	}
 
 	reqScope, err := sp.getReqScope(gvr)
 	if err != nil {
 		util.Err(errors.Wrapf(err, "failed tp get req scope"), w, r)
+		return
 	}
 
 	lister := restStore.(rest.Lister)

--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
@@ -20,6 +20,7 @@ package multiplexer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/client-go/informers"
@@ -112,6 +114,23 @@ func (wr *wrapResponse) Write(buf []byte) (int, error) {
 	return l, err
 }
 
+type fakeResourceMultiplexer struct {
+	ready    bool
+	store    rest.Storage
+	storeErr error
+}
+
+func (f *fakeResourceMultiplexer) Ready(gvr *schema.GroupVersionResource) bool {
+	return f.ready
+}
+
+func (f *fakeResourceMultiplexer) ResourceStore(gvr *schema.GroupVersionResource) (rest.Storage, error) {
+	if f.storeErr != nil {
+		return nil, f.storeErr
+	}
+	return f.store, nil
+}
+
 func TestGetReqScopeReturnsErrorForUnknownGVR(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "multiplexer-req-scope")
 	if err != nil {
@@ -130,6 +149,40 @@ func TestGetReqScopeReturnsErrorForUnknownGVR(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMultiplexerProxyServeHTTPReturnsOnResourceStoreError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "multiplexer-resource-store")
+	if err != nil {
+		t.Fatalf("failed to make temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	restMapperManager, err := meta.NewRESTMapperManager(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create REST mapper manager: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	sp := &multiplexerProxy{
+		requestsMultiplexerManager: &fakeResourceMultiplexer{
+			ready:    true,
+			storeErr: errors.New("storage unavailable"),
+		},
+		restMapperManager: restMapperManager,
+		stop:              stopCh,
+	}
+
+	w := httptest.NewRecorder()
+	req := newEndpointSliceListRequest("/apis/discovery.k8s.io/v1/endpointslices", nil)
+
+	assert.NotPanics(t, func() {
+		sp.ServeHTTP(w, req)
+	})
+	assert.GreaterOrEqual(t, w.Code, http.StatusBadRequest)
+	assert.Contains(t, w.Body.String(), "failed to get rest storage")
+}
+
 func TestMultiplexerProxyServeHTTPReturnsOnGetReqScopeError(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "multiplexer-serve-http")
 	if err != nil {
@@ -137,43 +190,28 @@ func TestMultiplexerProxyServeHTTPReturnsOnGetReqScopeError(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	cfgRESTMapper, err := meta.NewRESTMapperManager(tmpDir)
+	restMapperManager, err := meta.NewRESTMapperManager(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to create REST mapper manager: %v", err)
 	}
-	proxyRESTMapper, err := meta.NewRESTMapperManager(tmpDir)
-	if err != nil {
-		t.Fatalf("failed to create proxy REST mapper manager: %v", err)
-	}
-
-	clientset := fake.NewSimpleClientset()
-	factory := informers.NewSharedInformerFactory(clientset, 0)
-	poolScopeResources := []schema.GroupVersionResource{endpointSliceGVR}
-
-	healthChecker := fakeHealthChecker.NewFakeChecker(map[*url.URL]bool{})
-	loadBalancer := remote.NewLoadBalancer("round-robin", []*url.URL{}, nil, nil, healthChecker, nil, context.Background().Done())
-	dsm := multiplexerstorage.NewDummyStorageManager(mockCacheMap())
-	cfg := &config.YurtHubConfiguration{
-		PoolScopeResources:       poolScopeResources,
-		RESTMapperManager:        cfgRESTMapper,
-		SharedFactory:            factory,
-		LoadBalancerForLeaderHub: loadBalancer,
-	}
-	rmm := multiplexer.NewRequestMultiplexerManager(cfg, dsm, healthChecker)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	if ok := cache.WaitForCacheSync(stopCh, func() bool { return rmm.Ready(&endpointSliceGVR) }); !ok {
-		t.Fatal("multiplexer manager is not ready")
+
+	sp := &multiplexerProxy{
+		requestsMultiplexerManager: &fakeResourceMultiplexer{ready: true},
+		restMapperManager:          restMapperManager,
+		stop:                       stopCh,
 	}
 
-	sp := NewMultiplexerProxy(rmm, proxyRESTMapper, stopCh)
 	w := httptest.NewRecorder()
-	req := newEndpointSliceListRequest("/apis/discovery.k8s.io/v1/endpointslices", nil)
+	req := newEndpointSliceListRequest("/apis/unknown.example.com/v1/widgets", nil)
 
 	assert.NotPanics(t, func() {
 		sp.ServeHTTP(w, req)
 	})
+	assert.GreaterOrEqual(t, w.Code, http.StatusBadRequest)
+	assert.Contains(t, w.Body.String(), "failed to get req scope")
 }
 
 func TestShareProxy_ServeHTTP_LIST(t *testing.T) {

--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
@@ -112,6 +112,69 @@ func (wr *wrapResponse) Write(buf []byte) (int, error) {
 	return l, err
 }
 
+func TestGetReqScopeReturnsErrorForUnknownGVR(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "multiplexer-req-scope")
+	if err != nil {
+		t.Fatalf("failed to make temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	restMapperManager, err := meta.NewRESTMapperManager(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create REST mapper manager: %v", err)
+	}
+
+	sp := &multiplexerProxy{restMapperManager: restMapperManager}
+	unknownGVR := schema.GroupVersionResource{Group: "unknown.example.com", Version: "v1", Resource: "widgets"}
+	_, err = sp.getReqScope(&unknownGVR)
+	assert.Error(t, err)
+}
+
+func TestMultiplexerProxyServeHTTPReturnsOnGetReqScopeError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "multiplexer-serve-http")
+	if err != nil {
+		t.Fatalf("failed to make temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cfgRESTMapper, err := meta.NewRESTMapperManager(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create REST mapper manager: %v", err)
+	}
+	proxyRESTMapper, err := meta.NewRESTMapperManager(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create proxy REST mapper manager: %v", err)
+	}
+
+	clientset := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	poolScopeResources := []schema.GroupVersionResource{endpointSliceGVR}
+
+	healthChecker := fakeHealthChecker.NewFakeChecker(map[*url.URL]bool{})
+	loadBalancer := remote.NewLoadBalancer("round-robin", []*url.URL{}, nil, nil, healthChecker, nil, context.Background().Done())
+	dsm := multiplexerstorage.NewDummyStorageManager(mockCacheMap())
+	cfg := &config.YurtHubConfiguration{
+		PoolScopeResources:       poolScopeResources,
+		RESTMapperManager:        cfgRESTMapper,
+		SharedFactory:            factory,
+		LoadBalancerForLeaderHub: loadBalancer,
+	}
+	rmm := multiplexer.NewRequestMultiplexerManager(cfg, dsm, healthChecker)
+
+	stopCh := make(chan struct{})
+	if ok := cache.WaitForCacheSync(stopCh, func() bool { return rmm.Ready(&endpointSliceGVR) }); !ok {
+		t.Fatal("multiplexer manager is not ready")
+	}
+
+	sp := NewMultiplexerProxy(rmm, proxyRESTMapper, make(<-chan struct{}))
+	w := httptest.NewRecorder()
+	req := newEndpointSliceListRequest("/apis/discovery.k8s.io/v1/endpointslices", nil)
+
+	assert.NotPanics(t, func() {
+		sp.ServeHTTP(w, req)
+	})
+}
+
 func TestShareProxy_ServeHTTP_LIST(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "test")
 	if err != nil {

--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
@@ -162,11 +162,12 @@ func TestMultiplexerProxyServeHTTPReturnsOnGetReqScopeError(t *testing.T) {
 	rmm := multiplexer.NewRequestMultiplexerManager(cfg, dsm, healthChecker)
 
 	stopCh := make(chan struct{})
+	defer close(stopCh)
 	if ok := cache.WaitForCacheSync(stopCh, func() bool { return rmm.Ready(&endpointSliceGVR) }); !ok {
 		t.Fatal("multiplexer manager is not ready")
 	}
 
-	sp := NewMultiplexerProxy(rmm, proxyRESTMapper, make(<-chan struct{}))
+	sp := NewMultiplexerProxy(rmm, proxyRESTMapper, stopCh)
 	w := httptest.NewRecorder()
 	req := newEndpointSliceListRequest("/apis/discovery.k8s.io/v1/endpointslices", nil)
 


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes a panic in `MultiplexerProxy.ServeHTTP` when `ResourceStore()` or `getReqScope()` returns an error.

Previously, the handler called `util.Err()` to write an error response but did not return. Execution continued and type-asserted a nil `restStore`, causing YurtHub to panic instead of returning a proper HTTP error.

This PR adds the missing `return` statements, matching the existing pattern used for the `Ready()` check in the same function (lines 75-78).

#### Which issue(s) this PR fixes:
Fixes #2614

#### Special notes for your reviewer:
- Two-line fix in `pkg/yurthub/proxy/multiplexer/multiplexerproxy.go`
- Adds unit tests:
  - `TestGetReqScopeReturnsErrorForUnknownGVR`
  - `TestMultiplexerProxyServeHTTPReturnsOnGetReqScopeError`

**Verification performed locally:**
```bash
go test ./pkg/yurthub/proxy/multiplexer/... -count=1 -v
```
All tests pass.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


