### PR TITLE
fix(yurthub): synchronize shared state in cachemanager errorKeys

### DIFF
--- a/pkg/yurthub/cachemanager/error_keys.go
+++ b/pkg/yurthub/cachemanager/error_keys.go
@@ -118,6 +118,15 @@ func (ek *errorKeys) length() int {
 	return len(ek.keys)
 }
 
+// errorCount returns the number of persisted operations recorded so far. It
+// takes the same lock that guards ek.count and ek.keys so it can be read
+// safely while sync() and compress() are running concurrently.
+func (ek *errorKeys) errorCount() int {
+	ek.RLock()
+	defer ek.RUnlock()
+	return ek.count
+}
+
 func (ek *errorKeys) sync() {
 	for ek.processNextOperator() {
 	}
@@ -135,9 +144,13 @@ func (ek *errorKeys) processNextOperator() bool {
 		klog.Errorf("failed to serialize and persist operation: %v", op)
 		return false
 	}
+
+	ek.Lock()
 	ek.file.Write(append(data, '\n'))
 	ek.file.Sync()
 	ek.count++
+	ek.Unlock()
+
 	return true
 }
 
@@ -145,7 +158,10 @@ func (ek *errorKeys) compress() {
 	ticker := time.NewTicker(30 * time.Second)
 	for range ticker.C {
 		if !ek.queue.ShuttingDown() {
-			if ek.count > len(ek.keys)+CompressThresh {
+			ek.RLock()
+			needRewrite := ek.count > len(ek.keys)+CompressThresh
+			ek.RUnlock()
+			if needRewrite {
 				ek.rewrite()
 			}
 		} else {
@@ -154,9 +170,14 @@ func (ek *errorKeys) compress() {
 	}
 }
 
+// rewrite compacts the AOF file to only the current set of keys. It takes
+// the full write lock, rather than a read lock, because it reassigns
+// ek.file and ek.count, both of which are also written by
+// processNextOperator() from the sync() goroutine; using a read lock here
+// would race with those writes.
 func (ek *errorKeys) rewrite() {
-	ek.RLock()
-	defer ek.RUnlock()
+	ek.Lock()
+	defer ek.Unlock()
 	count := 0
 	file, err := os.OpenFile(filepath.Join(ek.aofPath, "tmp_aof"), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
 	if err != nil {

--- a/pkg/yurthub/cachemanager/error_keys_test.go
+++ b/pkg/yurthub/cachemanager/error_keys_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -133,7 +134,7 @@ func TestCompress(t *testing.T) {
 	}
 	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
 		func(ctx context.Context) (bool, error) {
-			if keys.count == 50 {
+			if keys.errorCount() == 50 {
 				return true, nil
 			}
 			return false, nil
@@ -141,4 +142,63 @@ func TestCompress(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to sync")
 	}
+}
+
+// TestErrorKeysConcurrentAccessRace drives put()/del() (which feed the
+// sync() goroutine started by NewErrorKeys) concurrently with direct calls
+// to rewrite() and with a reader that repeats compress()'s threshold check.
+// This is the same access pattern compress()'s 30-second ticker eventually
+// produces in production; compress() itself isn't invoked here because its
+// hardcoded ticker makes it impractical to trigger from a fast unit test.
+//
+// Before the fix, sync() wrote ek.count/ek.file with no lock at all while
+// compress()'s check read them unlocked and rewrite() reassigned them under
+// only a read lock, so this test reliably tripped `go test -race`.
+func TestErrorKeysConcurrentAccessRace(t *testing.T) {
+	aofPath, err := os.MkdirTemp("", "errorkeys")
+	if err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	defer os.RemoveAll(aofPath)
+
+	ek := NewErrorKeys(aofPath)
+	defer ek.queue.ShutDown()
+
+	var workers sync.WaitGroup
+	workers.Add(2)
+
+	go func() {
+		defer workers.Done()
+		for i := 0; i < 500; i++ {
+			key := fmt.Sprintf("key-%d", i)
+			ek.put(key, "value")
+			ek.del(key)
+		}
+	}()
+
+	go func() {
+		defer workers.Done()
+		for i := 0; i < 5; i++ {
+			ek.rewrite()
+		}
+	}()
+
+	stop := make(chan struct{})
+	var reader sync.WaitGroup
+	reader.Add(1)
+	go func() {
+		defer reader.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = ek.errorCount() > ek.length()+CompressThresh
+			}
+		}
+	}()
+
+	workers.Wait()
+	close(stop)
+	reader.Wait()
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`errorKeys` in `pkg/yurthub/cachemanager/error_keys.go` embeds a `sync.RWMutex` to protect its shared fields, but three code paths don't consistently use it:

- `processNextOperator()` (run in the background `sync()` goroutine started by `NewErrorKeys`) writes to `ek.file` and increments `ek.count` with **no lock at all**.
- `compress()` reads `ek.count` and `ek.keys` for its threshold check with **no lock**.
- `rewrite()` reassigns `ek.file` and `ek.count` at the end of compaction while holding only `ek.RLock()` — a read lock does not protect a write.

The result is a genuine data race between the `sync()` goroutine (constantly running for the life of the hub), the periodic `compress()`/`rewrite()` path, and any caller of `put()`/`del()`. In production this can mean the compaction threshold is computed from a torn `count`, and the `sync()` goroutine can write into a file handle that `rewrite()` is concurrently closing and swapping out from under it, risking lost or corrupted AOF writes used to persist yurthub's error-key state across restarts.

This isn't hypothetical: running the *existing* `TestCompress` test with `-race` already reproduces a race today, because that test itself reads `keys.count` directly while `sync()` is concurrently writing it — the accessor added by this PR (`errorCount()`) fixes that too.

#### The fix

- `processNextOperator()`: take `ek.Lock()` around the file write + `ek.count++`.
- `compress()`: take `ek.RLock()` for the `count`/`keys` threshold check.
- `rewrite()`: switch from `ek.RLock()` to `ek.Lock()`, since it mutates `ek.file`/`ek.count`, not just reads them.
- Added `errorCount()`, a locked accessor for `ek.count`, and switched `TestCompress` to use it instead of reading the field directly.

This is intentionally scoped to the synchronization bug itself. `rewrite()` already effectively serialized against `put()`/`del()` before this change (a read lock blocks a writer trying to take the write lock), so switching it to a full write lock does not introduce new blocking behavior on that path; it only removes the race against the unlocked `sync()` goroutine and the unlocked `compress()` read.

#### Which issue(s) this PR fixes:
Fixes #2582

#### Special notes for your reviewer:
- Verified the new test actually catches the regression: temporarily reverted just the locking changes (keeping the new `errorCount()` helper) and confirmed `TestErrorKeysConcurrentAccessRace` fails under `-race` against that old code, then restored the fix and confirmed it passes.
- `go build ./...`, `go vet ./pkg/yurthub/cachemanager/...`, and `gofmt -l` on the changed files are all clean.
- `go test -race -count=1 ./pkg/yurthub/cachemanager/...` passes (includes the pre-existing `TestCompress`, which itself now exercises the race-free path).
- Ran the broader `go test ./pkg/yurthub/...` tree afterward as a sanity check; everything still passes.
- AI assistance (Claude) was used to help implement and verify this change.

#### Does this PR introduce a user-facing change?
```release-note
Fix a data race in YurtHub's cache manager `errorKeys` AOF persistence path where the background sync/compaction goroutines could read and write shared state without holding the protecting lock.
```

#### other Note