### PR TITLE
fix(yurthub): prevent nil keys and skip tmp backups in ListResourceKeysOfComponent

### DIFF
--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -308,8 +308,11 @@ func (ds *diskStorage) ListResourceKeysOfComponent(component string, gvr schema.
 		return nil, fmt.Errorf("could not list files at %s, %v", filepath.Join(ds.baseDir, storageKey.Key()), err)
 	}
 
-	keys := make([]storage.Key, len(files))
-	for i, filePath := range files {
+	keys := make([]storage.Key, 0, len(files))
+	for _, filePath := range files {
+		if isTmpFile(filePath) {
+			continue
+		}
 		_, _, ns, n, err := extractInfoFromPath(ds.baseDir, filePath, false)
 		if err != nil {
 			klog.Errorf("failed when list keys of resource %s of component %s, %v", component, gvr, err)
@@ -325,7 +328,7 @@ func (ds *diskStorage) ListResourceKeysOfComponent(component string, gvr schema.
 			Namespace: ns,
 			Name:      n,
 		})
-		keys[i] = key
+		keys = append(keys, key)
 	}
 	return keys, nil
 }

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -1494,3 +1494,50 @@ func TestIfEnhancement(t *testing.T) {
 		})
 	}
 }
+
+func TestListResourceKeysOfComponent_SkipTmpAndInvalid(t *testing.T) {
+	dir, err := os.MkdirTemp("", "nil-keys-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	store, err := NewDiskStorage(dir)
+	if err != nil {
+		t.Fatalf("failed to create disk storage: %v", err)
+	}
+
+	// Create valid, invalid (too deep), and tmp backup files
+	paths := []string{
+		filepath.Join(dir, "kubelet", "pods.v1.core", "default", "pod-a"),
+		filepath.Join(dir, "kubelet", "pods.v1.core", "default", "extra", "pod-b"),
+		filepath.Join(dir, "kubelet", "pods.v1.core", "default", "tmp_pod-c"),
+	}
+
+	for _, p := range paths {
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatalf("failed to mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("{}"), 0644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+	}
+
+	keys, err := store.ListResourceKeysOfComponent("kubelet", schema.GroupVersionResource{Version: "v1", Resource: "pods"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d keys: %v", len(keys), keys)
+	}
+
+	if keys[0] == nil {
+		t.Fatalf("expected non-nil key, got nil at index 0")
+	}
+
+	if keys[0].Key() != "kubelet/pods.v1.core/default/pod-a" {
+		t.Errorf("expected 'kubelet/pods.v1.core/default/pod-a', got '%s'", keys[0].Key())
+	}
+}
+


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes a panic in YurtHub during `gcPodsWhenRestart` where `ListResourceKeysOfComponent` returned a slice containing `nil` entries and `tmp_*` backup files. 

Previously, the slice was pre-allocated with `make([]storage.Key, len(files))`. If `extractInfoFromPath` failed (e.g., for a corrupt or too-deep cache path), the loop used `continue` without assigning the index, leaving `nil` entries in the returned slice. Furthermore, `tmp_*` backup files were not skipped, unlike in `Recover()`.

This PR fixes both issues by:
1. Using `keys = append(keys, key)` instead of index assignment to dynamically size the returned slice with only valid keys.
2. Checking `isTmpFile(filePath)` at the beginning of the loop to skip backup files.

Added `TestListResourceKeysOfComponent_SkipTmpAndInvalid` to prove the fix correctly filters out invalid cache paths and `tmp_` backups while strictly returning valid `storage.Key` objects.

#### Which issue(s) this PR fixes:
Fixes #2624

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug in YurtHub where corrupted disk cache paths or tmp backups caused a restart panic during pod garbage collection.
```
