### PR TITLE
fix: data race on ek.file and ek.count between sync and compress goroutines

### DIFF
--- a/pkg/yurthub/cachemanager/error_keys.go
+++ b/pkg/yurthub/cachemanager/error_keys.go
@@ -41,6 +41,7 @@ type errorKeys struct {
 	sync.RWMutex
 	keys    map[string]string
 	queue   workqueue.TypedRateLimitingInterface[operation]
+	fileMu  sync.Mutex
 	file    *os.File
 	count   int
 	aofPath string
@@ -135,17 +136,25 @@ func (ek *errorKeys) processNextOperator() bool {
 		klog.Errorf("failed to serialize and persist operation: %v", op)
 		return false
 	}
+	ek.fileMu.Lock()
 	ek.file.Write(append(data, '\n'))
 	ek.file.Sync()
 	ek.count++
+	ek.fileMu.Unlock()
 	return true
+}
+
+func (ek *errorKeys) getCount() int {
+	ek.fileMu.Lock()
+	defer ek.fileMu.Unlock()
+	return ek.count
 }
 
 func (ek *errorKeys) compress() {
 	ticker := time.NewTicker(30 * time.Second)
 	for range ticker.C {
 		if !ek.queue.ShuttingDown() {
-			if ek.count > len(ek.keys)+CompressThresh {
+			if ek.getCount() > ek.length()+CompressThresh {
 				ek.rewrite()
 			}
 		} else {
@@ -192,13 +201,19 @@ func (ek *errorKeys) rewrite() {
 		klog.Errorf("failed to wait for queue to be empty")
 		return
 	}
+	ek.swapAOF(count)
+}
+
+func (ek *errorKeys) swapAOF(count int) {
+	ek.fileMu.Lock()
+	defer ek.fileMu.Unlock()
 	ek.file.Close()
 
-	err = os.Rename(filepath.Join(ek.aofPath, "tmp_aof"), filepath.Join(ek.aofPath, "aof"))
+	err := os.Rename(filepath.Join(ek.aofPath, "tmp_aof"), filepath.Join(ek.aofPath, "aof"))
 	if err != nil {
 		klog.Errorf("failed to rename tmp_aof to aof, %v", err)
 	}
-	file, err = os.OpenFile(filepath.Join(ek.aofPath, "aof"), os.O_RDWR, 0644)
+	file, err := os.OpenFile(filepath.Join(ek.aofPath, "aof"), os.O_RDWR, 0644)
 	if err != nil {
 		klog.ErrorS(err, "failed to open file", "name", filepath.Join(ek.aofPath, "aof"))
 		metrics.Metrics.SetErrorKeysPersistencyStatus(0)

--- a/pkg/yurthub/cachemanager/error_keys.go
+++ b/pkg/yurthub/cachemanager/error_keys.go
@@ -137,10 +137,10 @@ func (ek *errorKeys) processNextOperator() bool {
 		return false
 	}
 	ek.fileMu.Lock()
+	defer ek.fileMu.Unlock()
 	ek.file.Write(append(data, '\n'))
 	ek.file.Sync()
 	ek.count++
-	ek.fileMu.Unlock()
 	return true
 }
 

--- a/pkg/yurthub/cachemanager/error_keys.go
+++ b/pkg/yurthub/cachemanager/error_keys.go
@@ -152,6 +152,7 @@ func (ek *errorKeys) getCount() int {
 
 func (ek *errorKeys) compress() {
 	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
 	for range ticker.C {
 		if !ek.queue.ShuttingDown() {
 			if ek.getCount() > ek.length()+CompressThresh {
@@ -209,13 +210,24 @@ func (ek *errorKeys) swapAOF(count int) {
 	defer ek.fileMu.Unlock()
 	ek.file.Close()
 
-	err := os.Rename(filepath.Join(ek.aofPath, "tmp_aof"), filepath.Join(ek.aofPath, "aof"))
+	aofPath := filepath.Join(ek.aofPath, "aof")
+	err := os.Rename(filepath.Join(ek.aofPath, "tmp_aof"), aofPath)
 	if err != nil {
 		klog.Errorf("failed to rename tmp_aof to aof, %v", err)
+		// Compaction failed: keep serving the unchanged aof and do not update
+		// the count, so ek.count stays in sync with the on-disk file.
+		if file, oerr := os.OpenFile(aofPath, os.O_RDWR|os.O_APPEND, 0644); oerr != nil {
+			klog.ErrorS(oerr, "failed to reopen aof after failed rename", "name", aofPath)
+			metrics.Metrics.SetErrorKeysPersistencyStatus(0)
+			ek.queue.ShutDown()
+		} else {
+			ek.file = file
+		}
+		return
 	}
-	file, err := os.OpenFile(filepath.Join(ek.aofPath, "aof"), os.O_RDWR, 0644)
+	file, err := os.OpenFile(aofPath, os.O_RDWR|os.O_APPEND, 0644)
 	if err != nil {
-		klog.ErrorS(err, "failed to open file", "name", filepath.Join(ek.aofPath, "aof"))
+		klog.ErrorS(err, "failed to open file", "name", aofPath)
 		metrics.Metrics.SetErrorKeysPersistencyStatus(0)
 		ek.queue.ShutDown()
 		return

--- a/pkg/yurthub/cachemanager/error_keys_test.go
+++ b/pkg/yurthub/cachemanager/error_keys_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -133,7 +134,7 @@ func TestCompress(t *testing.T) {
 	}
 	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false,
 		func(ctx context.Context) (bool, error) {
-			if keys.count == 50 {
+			if keys.getCount() == 50 {
 				return true, nil
 			}
 			return false, nil
@@ -141,4 +142,34 @@ func TestCompress(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to sync")
 	}
+	keys.queue.ShutDown()
+}
+
+func TestConcurrentSyncAndRewrite(t *testing.T) {
+	aofPath, err := os.MkdirTemp("", "errorkeys")
+	if err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	defer os.RemoveAll(aofPath)
+
+	ek := NewErrorKeys(aofPath)
+	defer ek.queue.ShutDown()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			ek.put(fmt.Sprintf("key-%d", i), fmt.Sprintf("value-%d", i))
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5; i++ {
+			ek.rewrite()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	wg.Wait()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`NewErrorKeys` starts two goroutines, `sync()` and `compress()`, that both touch `ek.file` and `ek.count`, but access to those fields is not serialized:

- `processNextOperator()` (from `sync()`) writes `ek.file` and does `ek.count++` with no lock held.
- `rewrite()` (from `compress()`) closes and reassigns `ek.file` and sets `ek.count` while holding only a read lock (`RLock`). Since the sync side holds no lock at all, that read lock excludes nothing.
- `compress()` also reads `ek.count` and `len(ek.keys)` with no lock before deciding to compact.

So the sync goroutine can write to the exact `*os.File` that `rewrite()` is closing, and `ek.count++` races with `ek.count = count`. Running the race detector confirms it:

```
$ go test -race ./pkg/yurthub/cachemanager/...
WARNING: DATA RACE
Write at ... by goroutine (sync):
  pkg/yurthub/cachemanager/error_keys.go:140   // ek.count++
Previous read at ... by goroutine (compress)
```

This PR serializes those fields with a dedicated `fileMu`:

- `processNextOperator()` writes the file and increments the count under `fileMu`.
- The file swap in `rewrite()` moves into `swapAOF()`, which closes, renames, reopens and reassigns `ek.file`/`ek.count` under `fileMu`.
- `compress()` now reads the count through `getCount()` and the key count through the existing `length()`, both properly locked.

A note on why a separate mutex rather than just promoting the existing `RLock` to `Lock` in `rewrite()`: `rewrite()` waits up to a minute for the queue to drain, and the queue only drains because `processNextOperator()` keeps running. If `rewrite()` held a lock that `processNextOperator()` also needed, the drain could never make progress and `rewrite()` would block until it timed out. `fileMu` is only taken around the individual file/count operations and is never held across the wait, so the sync goroutine keeps draining while `rewrite()` waits. The keys snapshot in `rewrite()` keeps its original read lock, so writer-blocking behavior during compaction is unchanged. No exported signatures change.

#### Which issue(s) this PR fixes:

Fixes #2619

#### Special notes for your reviewer:

- `go test -race ./pkg/yurthub/cachemanager/...` reports zero data races. Against the current code it fails on `ek.count` and `ek.keys`.
- `go test ./pkg/yurthub/cachemanager/...` all existing tests pass.
- Added `TestConcurrentSyncAndRewrite`, which runs `put`/sync and `rewrite()` concurrently under the race detector to guard this path. `TestCompress` was reading `count` without a lock, so it now reads through `getCount()`.

#### Does this PR introduce a user-facing change?

```release-note
Fix a data race between the yurthub cache manager persistency sync and compress goroutines on the AOF file handle and operation counter.
```

#### other Note