### PR TITLE
fix: prevent silent cache corruption when AOF json unmarshal fails

### DIFF
--- a/pkg/yurthub/cachemanager/error_keys.go
+++ b/pkg/yurthub/cachemanager/error_keys.go
@@ -225,7 +225,10 @@ func (ek *errorKeys) recover() {
 	for scanner.Scan() {
 		bytes := scanner.Bytes()
 		var operation operation
-		json.Unmarshal(bytes, &operation)
+		if err := json.Unmarshal(bytes, &operation); err != nil {
+			klog.Errorf("failed to unmarshal AOF operation, skipping corrupted entry: %v", err)
+			continue
+		}
 		operations = append(operations, operation)
 	}
 	for _, op := range operations {

--- a/pkg/yurthub/cachemanager/error_keys_test.go
+++ b/pkg/yurthub/cachemanager/error_keys_test.go
@@ -142,3 +142,40 @@ func TestCompress(t *testing.T) {
 		t.Errorf("failed to sync")
 	}
 }
+
+func TestRecoverCorruptedJSON(t *testing.T) {
+	aofPath, err := os.MkdirTemp("", "errorkeys")
+	if err != nil {
+		t.Errorf("failed to create dir: %v", err)
+	}
+	defer os.RemoveAll(aofPath)
+	file, err := os.OpenFile(filepath.Join(aofPath, "aof"), os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Errorf("failed to open file: %v", err)
+	}
+	corruptedData := []byte(`{"key":"kubelet", "val":"fail to xxx", "operator":`)
+	file.Write(corruptedData)
+	file.Write([]byte("\n"))
+	op := operation{
+		Key:      "flannel",
+		Val:      "fail to yyy",
+		Operator: PUT,
+	}
+	data, err := json.Marshal(op)
+	if err != nil {
+		t.Errorf("failed to marshal: %v", err)
+	}
+	file.Write(data)
+	file.Write([]byte("\n"))
+	file.Sync()
+	file.Close()
+	ek := NewErrorKeys(aofPath)
+	ek.recover()
+	if _, ok := ek.keys["kubelet"]; ok {
+		t.Errorf("expected corrupted key 'kubelet' to be skipped")
+	}
+	if _, ok := ek.keys["flannel"]; !ok {
+		t.Errorf("expected valid key 'flannel' to be recovered")
+	}
+	ek.queue.ShutDown()
+}


### PR DESCRIPTION
## Description
Fixes #2607
This PR addresses issue #2607 by properly handling `json.Unmarshal` errors during YurtHub's cache state recovery. 
Previously, if a line in the AOF (Append Only File) was corrupted or malformed, the error was ignored, and an empty, zero-value `operation` was appended to the slice. This silently polluted the in-memory cache manager state. With this fix, any corrupted lines are safely caught, logged, and skipped.
## Changes made:
- Added a proper error check on json.Unmarshal(bytes, &operation) inside the recover() loop.
- If the unmarshaling fails (e.g. if the AOF file contains a corrupted or truncated line), the system will now log the error using klog.Errorf and continue to the next line rather than inserting a zero-value operation struct into memory.

## Testing Done
- `go test ./pkg/yurthub/cachemanager/...` passes cleanly.
```bash
alokkumardalei@Aloks-MacBook-Air openyurt % go test ./pkg/yurthub/cachemanager/...
ok      github.com/openyurtio/openyurt/pkg/yurthub/cachemanager (cached)
```
