### PR TITLE
Feature: implement blocking lock mechanism in yurthub disk storage

### DIFF
--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -43,10 +43,10 @@ const (
 	tmpPrefix    = "tmp_"
 )
 
-// TODO: lock should block, and also add comment about it
-// TODO: should optimize the efficiency of the lock mechanism
+// diskStorage implements key-level blocking locking to prevent concurrent access conflicts.
 type diskStorage struct {
 	sync.Mutex
+	cond             *sync.Cond
 	baseDir          string
 	keyPendingStatus map[string]struct{}
 	serializer       runtime.Serializer
@@ -76,6 +76,7 @@ func NewDiskStorage(dir string) (storage.Store, error) {
 		serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, json.SerializerOptions{}),
 		fsOperator:       fsOperator,
 	}
+	ds.cond = sync.NewCond(&ds.Mutex)
 
 	enhancementMode, err := ifEnhancement(ds.baseDir, *ds.fsOperator)
 	if err != nil {
@@ -559,24 +560,42 @@ func (ds *diskStorage) lockKey(key storageKey) bool {
 	keyStr := key.Key()
 	ds.Lock()
 	defer ds.Unlock()
-	if _, ok := ds.keyPendingStatus[keyStr]; ok {
-		klog.Infof("key(%s) storage is pending, just skip it", keyStr)
-		return false
+
+	if ds.cond == nil {
+		ds.cond = sync.NewCond(&ds.Mutex)
+	}
+	if ds.keyPendingStatus == nil {
+		ds.keyPendingStatus = make(map[string]struct{})
 	}
 
-	for pendingKey := range ds.keyPendingStatus {
-		if len(keyStr) > len(pendingKey) {
-			if strings.Contains(keyStr, fmt.Sprintf("%s/", pendingKey)) {
-				klog.Infof("key(%s) storage is pending, skip to store key(%s)", pendingKey, keyStr)
-				return false
-			}
+	for {
+		conflict := false
+		if _, ok := ds.keyPendingStatus[keyStr]; ok {
+			conflict = true
 		} else {
-			if strings.Contains(pendingKey, fmt.Sprintf("%s/", keyStr)) {
-				klog.Infof("key(%s) storage is pending, skip to store key(%s)", pendingKey, keyStr)
-				return false
+			for pendingKey := range ds.keyPendingStatus {
+				if len(keyStr) > len(pendingKey) {
+					if strings.Contains(keyStr, fmt.Sprintf("%s/", pendingKey)) {
+						conflict = true
+						break
+					}
+				} else {
+					if strings.Contains(pendingKey, fmt.Sprintf("%s/", keyStr)) {
+						conflict = true
+						break
+					}
+				}
 			}
 		}
+
+		if !conflict {
+			break
+		}
+
+		klog.V(4).Infof("key(%s) storage is pending, waiting for lock", keyStr)
+		ds.cond.Wait()
 	}
+
 	ds.keyPendingStatus[keyStr] = struct{}{}
 	return true
 }
@@ -601,7 +620,13 @@ func (ds *diskStorage) ifFresherThan(oldObj []byte, newRV uint64) (bool, error) 
 func (ds *diskStorage) unLockKey(key storageKey) {
 	ds.Lock()
 	defer ds.Unlock()
-	delete(ds.keyPendingStatus, key.Key())
+
+	if ds.keyPendingStatus != nil {
+		delete(ds.keyPendingStatus, key.Key())
+	}
+	if ds.cond != nil {
+		ds.cond.Broadcast()
+	}
 }
 
 func ifEnhancement(baseDir string, fsOperator fs.FileSystemOperator) (bool, error) {

--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -43,7 +43,7 @@ const (
 	tmpPrefix    = "tmp_"
 )
 
-// diskStorage implements key-level blocking locking to prevent concurrent access conflicts.
+// diskStorage implements a key-level blocking lock mechanism to prevent concurrent access conflicts.
 type diskStorage struct {
 	sync.Mutex
 	cond             *sync.Cond
@@ -114,9 +114,7 @@ func (ds *diskStorage) Create(key storage.Key, content []byte) error {
 		return storage.ErrKeyHasNoContent
 	}
 
-	if !ds.lockKey(storageKey) {
-		return storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(storageKey)
 	defer ds.unLockKey(storageKey)
 
 	path := filepath.Join(ds.baseDir, storageKey.Key())
@@ -141,9 +139,7 @@ func (ds *diskStorage) Delete(key storage.Key) error {
 	}
 	storageKey := key.(storageKey)
 
-	if !ds.lockKey(storageKey) {
-		return storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(storageKey)
 	defer ds.unLockKey(storageKey)
 
 	path := filepath.Join(ds.baseDir, storageKey.Key())
@@ -166,9 +162,7 @@ func (ds *diskStorage) Get(key storage.Key) ([]byte, error) {
 	}
 	storageKey := key.(storageKey)
 
-	if !ds.lockKey(storageKey) {
-		return nil, storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(storageKey)
 	defer ds.unLockKey(storageKey)
 
 	path := filepath.Join(ds.baseDir, storageKey.Key())
@@ -193,9 +187,7 @@ func (ds *diskStorage) List(key storage.Key) ([][]byte, error) {
 	}
 	storageKey := key.(storageKey)
 
-	if !ds.lockKey(storageKey) {
-		return nil, storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(storageKey)
 	defer ds.unLockKey(storageKey)
 
 	bb := make([][]byte, 0)
@@ -243,9 +235,7 @@ func (ds *diskStorage) Update(key storage.Key, content []byte, rv uint64) ([]byt
 		return nil, storage.ErrIsNotObjectKey
 	}
 
-	if !ds.lockKey(storageKey) {
-		return nil, storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(storageKey)
 	defer ds.unLockKey(storageKey)
 
 	absPath := filepath.Join(ds.baseDir, storageKey.Key())
@@ -295,9 +285,7 @@ func (ds *diskStorage) ListResourceKeysOfComponent(component string, gvr schema.
 	}
 	storageKey := rootKey.(storageKey)
 
-	if !ds.lockKey(storageKey) {
-		return nil, storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(storageKey)
 	defer ds.unLockKey(storageKey)
 
 	absPath := filepath.Join(ds.baseDir, storageKey.Key())
@@ -354,9 +342,7 @@ func (ds *diskStorage) ReplaceComponentList(component string, gvr schema.GroupVe
 		}
 	}
 
-	if !ds.lockKey(storageKey) {
-		return storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(storageKey)
 	defer ds.unLockKey(storageKey)
 
 	// 1. mv old dir into tmp_dir when rootKey dir already exists
@@ -414,9 +400,7 @@ func (ds *diskStorage) DeleteComponentResources(component string) error {
 		path:    component,
 		rootKey: true,
 	}
-	if !ds.lockKey(rootKey) {
-		return storage.ErrStorageAccessConflict
-	}
+	ds.lockKey(rootKey)
 	defer ds.unLockKey(rootKey)
 
 	absKey := filepath.Join(ds.baseDir, rootKey.Key())
@@ -556,7 +540,7 @@ func (ds *diskStorage) restoreReplaceFromBackup(tmpPath, absPath string, restore
 	return restoreErr
 }
 
-func (ds *diskStorage) lockKey(key storageKey) bool {
+func (ds *diskStorage) lockKey(key storageKey) {
 	keyStr := key.Key()
 	ds.Lock()
 	defer ds.Unlock()
@@ -574,16 +558,9 @@ func (ds *diskStorage) lockKey(key storageKey) bool {
 			conflict = true
 		} else {
 			for pendingKey := range ds.keyPendingStatus {
-				if len(keyStr) > len(pendingKey) {
-					if strings.Contains(keyStr, fmt.Sprintf("%s/", pendingKey)) {
-						conflict = true
-						break
-					}
-				} else {
-					if strings.Contains(pendingKey, fmt.Sprintf("%s/", keyStr)) {
-						conflict = true
-						break
-					}
+				if strings.HasPrefix(keyStr, pendingKey+"/") || strings.HasPrefix(pendingKey, keyStr+"/") {
+					conflict = true
+					break
 				}
 			}
 		}
@@ -597,7 +574,6 @@ func (ds *diskStorage) lockKey(key storageKey) bool {
 	}
 
 	ds.keyPendingStatus[keyStr] = struct{}{}
-	return true
 }
 
 func (ds *diskStorage) ifFresherThan(oldObj []byte, newRV uint64) (bool, error) {
@@ -678,6 +654,8 @@ func getKey(tmpKey string) string {
 }
 
 func extractInfoFromPath(baseDir, path string, isRoot bool) (component, gvr, namespace, name string, err error) {
+	baseDir = filepath.ToSlash(baseDir)
+	path = filepath.ToSlash(path)
 	if !strings.HasPrefix(path, baseDir) {
 		err = fmt.Errorf("path %s does not under %s", path, baseDir)
 		return

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -750,15 +750,16 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 			Expect(err).To(BeNil())
 
 			// We will launch multiple concurrent reads and writes on the same key.
-			// With blocking locks, they should block and eventually execute,
-			// without returning ErrStorageAccessConflict.
+			// With blocking locks, they should block and eventually execute without errors.
 			errCh := make(chan error, 5)
+			startCh := make(chan struct{})
 			var wg sync.WaitGroup
 			wg.Add(3)
 
 			// 1. First Create
 			go func() {
 				defer wg.Done()
+				<-startCh
 				err := store.Create(podKey, podBytes)
 				if err != nil && err != storage.ErrKeyExists {
 					errCh <- err
@@ -770,6 +771,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 			// 2. Concurrent Get
 			go func() {
 				defer wg.Done()
+				<-startCh
 				_, err := store.Get(podKey)
 				if err != nil && err != storage.ErrStorageNotFound {
 					errCh <- err
@@ -781,6 +783,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 			// 3. Concurrent Update
 			go func() {
 				defer wg.Done()
+				<-startCh
 				_, err := store.Update(podKey, podBytes, 200)
 				if err != nil && err != storage.ErrStorageNotFound && err != storage.ErrUpdateConflict {
 					errCh <- err
@@ -789,11 +792,12 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 				}
 			}()
 
+			close(startCh)
 			wg.Wait()
 			close(errCh)
 
 			for e := range errCh {
-				Expect(e).NotTo(Equal(storage.ErrStorageAccessConflict))
+				Expect(e).To(BeNil())
 			}
 		})
 	})

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -728,6 +729,72 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 			buf, err := store.Update(podKey, comingPodBytes, comingPodRvUint64)
 			Expect(err).To(Equal(storage.ErrUpdateConflict))
 			Expect(buf).To(Equal(existingPodBytes))
+		})
+	})
+
+	Context("Test Concurrent Key Locking", func() {
+		It("should block and allow concurrent operations without ErrStorageAccessConflict", func() {
+			podKeyInfo := storage.KeyBuildInfo{
+				Component: "kubelet",
+				Resources: "pods",
+				Namespace: "default",
+				Group:     "",
+				Version:   "v1",
+				Name:      "concurrent-pod",
+			}
+			podKey, err := store.KeyFunc(podKeyInfo)
+			Expect(err).To(BeNil())
+			pod, _, err := generatePod(store.KeyFunc, &podObj, podKeyInfo)
+			Expect(err).To(BeNil())
+			podBytes, err := marshalObj(pod)
+			Expect(err).To(BeNil())
+
+			// We will launch multiple concurrent reads and writes on the same key.
+			// With blocking locks, they should block and eventually execute,
+			// without returning ErrStorageAccessConflict.
+			errCh := make(chan error, 5)
+			var wg sync.WaitGroup
+			wg.Add(3)
+
+			// 1. First Create
+			go func() {
+				defer wg.Done()
+				err := store.Create(podKey, podBytes)
+				if err != nil && err != storage.ErrKeyExists {
+					errCh <- err
+				} else {
+					errCh <- nil
+				}
+			}()
+
+			// 2. Concurrent Get
+			go func() {
+				defer wg.Done()
+				_, err := store.Get(podKey)
+				if err != nil && err != storage.ErrStorageNotFound {
+					errCh <- err
+				} else {
+					errCh <- nil
+				}
+			}()
+
+			// 3. Concurrent Update
+			go func() {
+				defer wg.Done()
+				_, err := store.Update(podKey, podBytes, 200)
+				if err != nil && err != storage.ErrStorageNotFound && err != storage.ErrUpdateConflict {
+					errCh <- err
+				} else {
+					errCh <- nil
+				}
+			}()
+
+			wg.Wait()
+			close(errCh)
+
+			for e := range errCh {
+				Expect(e).NotTo(Equal(storage.ErrStorageAccessConflict))
+			}
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?

/kind feature
/sig storage

#### What this PR does / why we need it:
This PR implements a key-level blocking lock mechanism using `sync.Cond` in YurtHub's local disk storage component (`pkg/yurthub/storage/disk/storage.go`). 

Previously, when a key or prefix was locked for a pending read/write operation, any concurrent request attempting to access it would immediately fail and return a `storage.ErrStorageAccessConflict` error. By modifying the locking logic to block, concurrent requests now wait safely until the lock is released. This resolves open TODOs regarding non-blocking locks and access conflicts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2638

#### Special notes for your reviewer:
We added a new concurrent lock verification test (`Test Concurrent Key Locking` in `storage_test.go`) to simulate multiple concurrent goroutines accessing the same key and ensuring no conflict errors are returned.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
