### PR TITLE
fix(yurtmanager): prevent ValidateUpdate from re-validating oldObj in platformadmin webhooks

### DIFF
--- a/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation.go
@@ -64,7 +64,7 @@ func (webhook *PlatformAdminHandler) ValidateUpdate(
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a PlatformAdmin but got a %T", newObj))
 	}
-	oldPlatformAdmin, ok := oldObj.(*v1alpha2.PlatformAdmin)
+	_, ok = oldObj.(*v1alpha2.PlatformAdmin)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a PlatformAdmin but got a %T", oldObj))
 	}

--- a/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation.go
@@ -70,9 +70,7 @@ func (webhook *PlatformAdminHandler) ValidateUpdate(
 	}
 
 	// validate
-	newErrorList := webhook.validate(ctx, newPlatformAdmin)
-	oldErrorList := webhook.validate(ctx, oldPlatformAdmin)
-	if allErrs := append(newErrorList, oldErrorList...); len(allErrs) > 0 {
+	if allErrs := webhook.validate(ctx, newPlatformAdmin); len(allErrs) > 0 {
 		return nil, apierrors.NewInvalid(
 			v1alpha2.GroupVersion.WithKind("PlatformAdmin").GroupKind(),
 			newPlatformAdmin.Name,

--- a/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation_test.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1alpha2/platformadmin_validation_test.go
@@ -229,7 +229,7 @@ func TestValidateUpdate(t *testing.T) {
 			errCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:   "should get StatusUnprocessableEntityError when old PlatformAdmin is invalid and old PlatformAdmin is valid",
+			name:   "should pass when old PlatformAdmin is invalid but new PlatformAdmin is valid",
 			client: NewFakeClient(buildClient(buildNodePool(), buildPlatformAdmin())).Build(),
 			oldObj: &v1alpha2.PlatformAdmin{},
 			newObj: &v1alpha2.PlatformAdmin{
@@ -242,7 +242,7 @@ func TestValidateUpdate(t *testing.T) {
 					Version:  "v2",
 				},
 			},
-			errCode: http.StatusUnprocessableEntity,
+			errCode: 0,
 		},
 		{
 			name:   "should no err when new PlatformAdmin and old PlatformAdmin both valid",

--- a/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation.go
@@ -63,7 +63,7 @@ func (webhook *PlatformAdminHandler) ValidateUpdate(
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a PlatformAdmin but got a %T", newObj))
 	}
-	oldPlatformAdmin, ok := oldObj.(*v1beta1.PlatformAdmin)
+	_, ok = oldObj.(*v1beta1.PlatformAdmin)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a PlatformAdmin but got a %T", oldObj))
 	}

--- a/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation.go
@@ -69,9 +69,7 @@ func (webhook *PlatformAdminHandler) ValidateUpdate(
 	}
 
 	// validate
-	newErrorList := webhook.validate(ctx, newPlatformAdmin)
-	oldErrorList := webhook.validate(ctx, oldPlatformAdmin)
-	if allErrs := append(newErrorList, oldErrorList...); len(allErrs) > 0 {
+	if allErrs := webhook.validate(ctx, newPlatformAdmin); len(allErrs) > 0 {
 		return nil, apierrors.NewInvalid(
 			v1beta1.GroupVersion.WithKind("PlatformAdmin").GroupKind(),
 			newPlatformAdmin.Name,

--- a/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation_test.go
+++ b/pkg/yurtmanager/webhook/platformadmin/v1beta1/platformadmin_validation_test.go
@@ -229,7 +229,7 @@ func TestValidateUpdate(t *testing.T) {
 			errCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:   "should get StatusUnprocessableEntityError when old PlatformAdmin is invalid and old PlatformAdmin is valid",
+			name:   "should pass when old PlatformAdmin is invalid but new PlatformAdmin is valid",
 			client: NewFakeClient(buildClient(buildNodePool(), buildPlatformAdmin())).Build(),
 			oldObj: &v1beta1.PlatformAdmin{},
 			newObj: &v1beta1.PlatformAdmin{
@@ -242,7 +242,7 @@ func TestValidateUpdate(t *testing.T) {
 					Version:   "v2",
 				},
 			},
-			errCode: http.StatusUnprocessableEntity,
+			errCode: 0,
 		},
 		{
 			name:   "should no err when new PlatformAdmin and old PlatformAdmin both valid",


### PR DESCRIPTION
/kind bug
/sig iot

#### What this PR does / why we need it:

Fixes an issue in the `PlatformAdmin` admission webhooks (`ValidateUpdate`) where `webhook.validate(ctx, oldPlatformAdmin)` was being executed alongside `newPlatformAdmin`.

Validating `oldPlatformAdmin` (the existing stored object) against current cluster state caused update requests to fail whenever underlying cluster resources (e.g., NodePools) were deleted or updated after `oldPlatformAdmin` was created. This effectively locked out operators from updating or repairing `PlatformAdmin` resources.

This PR removes the redundant validation of `oldPlatformAdmin` in `ValidateUpdate` for both `v1alpha2` and `v1beta1` webhooks, ensuring only `newPlatformAdmin` is validated against cluster state, and updates unit test assertions accordingly.

#### Which issue(s) this PR fixes:
Fixes #2640

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
