### PR TITLE
fix(yurtiotdock): handle edge platform errors and fix deletion logs

### DIFF
--- a/pkg/yurtiotdock/controllers/device_controller.go
+++ b/pkg/yurtiotdock/controllers/device_controller.go
@@ -185,7 +185,7 @@ func (r *DeviceReconciler) reconcileCreateDevice(ctx context.Context, d *iotv1al
 	} else {
 		klog.V(4).ErrorS(err, "could not visit the edge platform")
 		util.SetDeviceCondition(deviceStatus, util.NewDeviceCondition(iotv1alpha1.DeviceSyncedCondition, corev1.ConditionFalse, iotv1alpha1.DeviceVisitedCoreMetadataSyncedReason, ""))
-		return nil
+		return err
 	}
 	d.Status = *newDeviceStatus
 	util.SetDeviceCondition(deviceStatus, util.NewDeviceCondition(iotv1alpha1.DeviceSyncedCondition, corev1.ConditionTrue, "", ""))
@@ -321,7 +321,7 @@ func DeleteDevicesOnControllerShutdown(ctx context.Context, cli client.Client, o
 		}
 
 		if err := cli.Delete(ctx, &device); err != nil {
-			klog.Errorf("DeviceName: %s, update device err:%v", device.GetName(), err)
+			klog.Errorf("DeviceName: %s, delete device err:%v", device.GetName(), err)
 			continue
 		}
 	}

--- a/pkg/yurtiotdock/controllers/deviceprofile_controller.go
+++ b/pkg/yurtiotdock/controllers/deviceprofile_controller.go
@@ -147,7 +147,7 @@ func (r *DeviceProfileReconciler) reconcileCreateDeviceProfile(ctx context.Conte
 	if edgeDp, err := r.edgeClient.Get(context.TODO(), actualName, clients.GetOptions{Namespace: r.Namespace}); err != nil {
 		if !clients.IsNotFoundErr(err) {
 			klog.V(4).ErrorS(err, "could not visit the edge platform")
-			return nil
+			return err
 		}
 	} else {
 		// a. If object exists, the status of the deviceProfile on OpenYurt is updated
@@ -184,7 +184,7 @@ func DeleteDeviceProfilesOnControllerShutdown(ctx context.Context, cli client.Cl
 		}
 
 		if err := cli.Delete(ctx, &deviceProfile); err != nil {
-			klog.Errorf("deviceProfileName: %s, update deviceProfile err:%v", deviceProfile.GetName(), err)
+			klog.Errorf("deviceProfileName: %s, delete deviceProfile err:%v", deviceProfile.GetName(), err)
 			continue
 		}
 	}

--- a/pkg/yurtiotdock/controllers/deviceservice_controller.go
+++ b/pkg/yurtiotdock/controllers/deviceservice_controller.go
@@ -171,7 +171,7 @@ func (r *DeviceServiceReconciler) reconcileCreateDeviceService(ctx context.Conte
 	if edgeDs, err := r.deviceServiceCli.Get(context.TODO(), edgeDeviceServiceName, clients.GetOptions{Namespace: r.Namespace}); err != nil {
 		if !clients.IsNotFoundErr(err) {
 			klog.V(4).ErrorS(err, "could not visit the edge platform")
-			return nil
+			return err
 		} else {
 			createdDs, err := r.deviceServiceCli.Create(context.TODO(), ds, clients.CreateOptions{})
 			if err != nil {
@@ -239,7 +239,7 @@ func DeleteDeviceServicesOnControllerShutdown(ctx context.Context, cli client.Cl
 		}
 
 		if err := cli.Delete(ctx, &deviceService); err != nil {
-			klog.Errorf("DeviceServiceName: %s, update deviceservice err:%v", deviceService.GetName(), err)
+			klog.Errorf("DeviceServiceName: %s, delete deviceservice err:%v", deviceService.GetName(), err)
 			continue
 		}
 	}


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes #2625
This PR fixes two bugs in yurtiotdock controllers as reported in #2625.

- Fixes Swallowed Errors (Bug 2): Previously, if the controllers failed to reach the EdgeX platform during reconcileCreate* methods (e.g. due to a network partition), they would log the error and return nil. This swallowed the error and prevented the controller from requeuing the operation, causing the sync to stall permanently. This PR changes those returns to err, ensuring exponential backoff and retry are correctly triggered.
- Fixes Copy-Paste Deletion Logs (Bug 3): In the Delete*OnControllerShutdown methods, if `cli.Delete()` failed, the log incorrectly stated update `<object>` err instead of delete. This PR corrects the log messages to accurately reflect the deletion failure.

(Note: The implementation of bidirectional DeviceProfile updates (Bug 1 from the issue) is complex and requires significant changes to the EdgeX client methods, so it is omitted from this patch and can be tracked as a separate feature).
## Manual Testing Performed:

Verified that the controller logic compiles without errors, and that returning err correctly adheres to the controller-runtime expected behavior for triggering exponential backoff.

### Compilation Proof (yurt-iot-dock):
- Command:
````bash
make build
````
- Output:
```bash
++ local target=yurt-iot-dock
++ [[ yurt-iot-dock =~ ^cmd/.* ]]
++ echo yurt-iot-dock
+ go build -o yurt-iot-dock -ldflags '-s -w -X github.com/openyurtio/openyurt/pkg/projectinfo.projectPrefix=yurt
-X github.com/openyurtio/openyurt/pkg/projectinfo.labelPrefix=openyurt.io
-X github.com/openyurtio/openyurt/pkg/projectinfo.gitVersion=v1.7.0-6d3a958
-X github.com/openyurtio/openyurt/pkg/projectinfo.gitCommit=6d3a95853672f85bfa2a0ff11a08a2c7e76f64d4
-X github.com/openyurtio/openyurt/pkg/projectinfo.buildDate=2026-07-24T01:39:51Z
-X github.com/openyurtio/openyurt/pkg/projectinfo.separator=,
-X github.com/openyurtio/openyurt/pkg/projectinfo.maintainingVersions=v1.7.0,v1.6.0,v1.6.1,v1.5.0,v1.5.1
-X github.com/openyurtio/openyurt/pkg/projectinfo.nodePoolLabelKey=apps.openyurt.io/nodepool' -gcflags '' /Users/alokkumardalei/Desktop/openyurt/openyurt/cmd/yurt-iot-dock

```
### Testing Proof:
```bash
alokkumardalei@Aloks-MacBook-Air openyurt % go test ./pkg/yurtiotdock/controllers/...
?       github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers      [no test files]
ok      github.com/openyurtio/openyurt/pkg/yurtiotdock/controllers/util (cached)
```