### PR TITLE
fix(yurt-manager): fix infinite node conversion loop caused by premature Job deletion

### DIFF
--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -62,7 +63,8 @@ const (
 	reasonConvertFailed = "ConvertFailed"
 	reasonRevertFailed  = "RevertFailed"
 
-	zoneLabel = constants.KubernetesTopologyZoneLabel
+	zoneLabel              = constants.KubernetesTopologyZoneLabel
+	conversionJobFinalizer = "openyurt.io/node-conversion"
 )
 
 type ReconcileYurtNodeConversion struct {
@@ -163,7 +165,7 @@ func (r *ReconcileYurtNodeConversion) Reconcile(ctx context.Context, req reconci
 	// but the controller's finalization was interrupted after the Job's disappearance
 	if action := interruptedFinalizationAction(node, cond); action != actionNone {
 		klog.V(4).Info(Format("node(%s) resumes interrupted %s finalization without an active job", node.Name, action))
-		return reconcile.Result{}, r.handleSuccessfulAction(ctx, node.Name, action)
+		return reconcile.Result{}, r.handleSuccessfulAction(ctx, node.Name, action, nil)
 	}
 
 	if desiredAction == actionNone {
@@ -193,12 +195,18 @@ func (r *ReconcileYurtNodeConversion) reconcileExistingJob(
 			newConversionCondition(currentJobAction, failedReasonForAction(currentJobAction), failedMessage(job, currentJobAction))); err != nil {
 			return reconcile.Result{}, fmt.Errorf("set failed conversion condition for node %s: %w", node.Name, err)
 		}
+		if controllerutil.ContainsFinalizer(job, conversionJobFinalizer) {
+			controllerutil.RemoveFinalizer(job, conversionJobFinalizer)
+			if err := r.Update(ctx, job); err != nil {
+				return reconcile.Result{}, fmt.Errorf("remove finalizer from failed job %s: %w", job.Name, err)
+			}
+		}
 		return reconcile.Result{}, nil
 	}
 
 	if isJobSucceeded(job) {
 		klog.Info(Format("node(%s) observed succeeded %s job %s", node.Name, currentJobAction, job.Name))
-		return reconcile.Result{}, r.handleSuccessfulAction(ctx, node.Name, currentJobAction)
+		return reconcile.Result{}, r.handleSuccessfulAction(ctx, node.Name, currentJobAction, job)
 	}
 
 	// Job is still running — keep the node cordoned and update the in-progress condition
@@ -221,6 +229,14 @@ func (r *ReconcileYurtNodeConversion) handleStaleJob(
 	if isJobFinished(job) {
 		klog.V(4).Info(Format("node(%s) deleting stale job %s, desiredAction=%s currentJobAction=%s",
 			node.Name, job.Name, desiredAction, currentJobAction))
+
+		if controllerutil.ContainsFinalizer(job, conversionJobFinalizer) {
+			controllerutil.RemoveFinalizer(job, conversionJobFinalizer)
+			if err := r.Update(ctx, job); err != nil {
+				return reconcile.Result{}, fmt.Errorf("remove finalizer from stale job %s: %w", job.Name, err)
+			}
+		}
+
 		if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, fmt.Errorf("delete stale conversion job %s for node %s: %w", job.Name, node.Name, err)
 		}
@@ -319,13 +335,14 @@ func (r *ReconcileYurtNodeConversion) createConversionJob(ctx context.Context, n
 	if err != nil {
 		return err
 	}
+	job.Finalizers = append(job.Finalizers, conversionJobFinalizer)
 	klog.Info(Format("create %s job %s for node %s", action, job.Name, nodeName))
 	return r.Create(ctx, job)
 }
 
 // handleSuccessfulAction completes the control-plane side of a successful round
 // after node-servant already finished the host-level operations on the node
-func (r *ReconcileYurtNodeConversion) handleSuccessfulAction(ctx context.Context, nodeName, action string) error {
+func (r *ReconcileYurtNodeConversion) handleSuccessfulAction(ctx context.Context, nodeName, action string, job *batchv1.Job) error {
 	klog.V(4).Info(Format("finalize successful %s round for node(%s)", action, nodeName))
 	node := &corev1.Node{}
 	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
@@ -346,6 +363,13 @@ func (r *ReconcileYurtNodeConversion) handleSuccessfulAction(ctx context.Context
 		if err := r.ensureNodeConversionCondition(ctx, nodeName,
 			newConversionCondition(action, succeededReasonForAction(action), succeededMessage(action))); err != nil {
 			return err
+		}
+	}
+
+	if job != nil && controllerutil.ContainsFinalizer(job, conversionJobFinalizer) {
+		controllerutil.RemoveFinalizer(job, conversionJobFinalizer)
+		if err := r.Update(ctx, job); err != nil {
+			return fmt.Errorf("remove finalizer from successful job %s: %w", job.Name, err)
 		}
 	}
 

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -366,6 +366,10 @@ func (r *ReconcileYurtNodeConversion) handleSuccessfulAction(ctx context.Context
 		}
 	}
 
+	if err := r.ensureNodeUnschedulable(ctx, nodeName, false); err != nil {
+		return err
+	}
+
 	if job != nil && controllerutil.ContainsFinalizer(job, conversionJobFinalizer) {
 		controllerutil.RemoveFinalizer(job, conversionJobFinalizer)
 		if err := r.Update(ctx, job); err != nil {
@@ -373,7 +377,7 @@ func (r *ReconcileYurtNodeConversion) handleSuccessfulAction(ctx context.Context
 		}
 	}
 
-	return r.ensureNodeUnschedulable(ctx, nodeName, false)
+	return nil
 }
 
 // ensureNodeUnschedulable keeps the node cordon state aligned with the current

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -335,7 +335,7 @@ func (r *ReconcileYurtNodeConversion) createConversionJob(ctx context.Context, n
 	if err != nil {
 		return err
 	}
-	job.Finalizers = append(job.Finalizers, conversionJobFinalizer)
+	controllerutil.AddFinalizer(job, conversionJobFinalizer)
 	klog.Info(Format("create %s job %s for node %s", action, job.Name, nodeName))
 	return r.Create(ctx, job)
 }

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
@@ -67,6 +67,7 @@ func TestReconcileCreateConvertJob(t *testing.T) {
 	assert.Equal(t, "node-a", job.Labels[nodeservant.ConversionNodeLabelKey])
 	assert.Contains(t, job.Spec.Template.Spec.Containers[0].Args[0], "convert")
 	assert.Contains(t, job.Spec.Template.Spec.Containers[0].Args[0], "--nodepool-name=pool-a")
+	assert.Contains(t, job.Finalizers, conversionJobFinalizer)
 }
 
 func TestReconcileConvertSuccess(t *testing.T) {
@@ -175,6 +176,7 @@ func TestReconcileCreateRevertJob(t *testing.T) {
 		Name:      conversionJobName("node-a"),
 	}, job))
 	assert.Equal(t, "/usr/local/bin/entry.sh revert --node-name=node-a", job.Spec.Template.Spec.Containers[0].Args[0])
+	assert.Contains(t, job.Finalizers, conversionJobFinalizer)
 }
 
 func TestReconcileRevertSuccess(t *testing.T) {
@@ -588,6 +590,7 @@ func newConversionJobForTest(t *testing.T, action, nodeName string) *batchv1.Job
 
 	job, err := nodeservant.RenderNodeServantJob(action, renderCtx, nodeName)
 	require.NoError(t, err)
+	job.Finalizers = append(job.Finalizers, conversionJobFinalizer)
 	return job
 }
 


### PR DESCRIPTION
Fixes #2644

### What this PR does / why we need it:
The `YurtNodeConversionController` orchestrates node conversions via `node-servant` Jobs. Currently, if a successful Job is deleted (e.g., by a TTL controller or autonomous AI agents aggressively cleaning up cluster state) before the controller applies the `openyurt.io/is-edge-worker` label, the controller's `interruptedFinalizationAction` logic assumes the host-level conversion failed and spawns a brand new Job, creating an infinite loop of kubelet restarts.

This PR fixes the race condition by introducing a Kubernetes Finalizer (`openyurt.io/node-conversion`) to the `node-servant` Job.

**Key Changes:**
- **Create:** Adds the `openyurt.io/node-conversion` finalizer when the conversion Job is created.
- **Success/Failure/Stale:** Removes the finalizer only *after* the controller finishes its finalization logic (such as labeling the node) or determines the Job is stale.

This ensures the Job object persists long enough for the Reconcile loop to verify and finalize the conversion, making OpenYurt resilient to autonomous agent deployments and aggressive garbage collection.

### Which issue(s) this PR fixes:
Fixes #2644

### Special notes for your reviewer:
N/A