### PR TITLE
fix: handle StatefulSet workloads in YurtAppSet status reconciliation

### DIFF
--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
@@ -627,13 +627,23 @@ func (r *ReconcileYurtAppSet) conciliateYurtAppSetStatus(
 	// calculate yas current status
 	readyWorkloads, updatedWorkloads := 0, 0
 	for _, workload := range curWorkloads {
-		workloadObj := workload.(*appsv1.Deployment)
-		if workloadObj.Status.Replicas > 0 && workloadObj.Status.ReadyReplicas == workloadObj.Status.Replicas {
-			readyWorkloads++
-		}
-		if workloadmanager.GetWorkloadHash(workloadObj) == expectedRevision.GetName() &&
-			workloadObj.Status.UpdatedReplicas == workloadObj.Status.Replicas {
-			updatedWorkloads++
+		switch w := workload.(type) {
+		case *appsv1.Deployment:
+			if w.Status.Replicas > 0 && w.Status.ReadyReplicas == w.Status.Replicas {
+				readyWorkloads++
+			}
+			if workloadmanager.GetWorkloadHash(w) == expectedRevision.GetName() &&
+				w.Status.UpdatedReplicas == w.Status.Replicas {
+				updatedWorkloads++
+			}
+		case *appsv1.StatefulSet:
+			if w.Status.Replicas > 0 && w.Status.ReadyReplicas == w.Status.Replicas {
+				readyWorkloads++
+			}
+			if workloadmanager.GetWorkloadHash(w) == expectedRevision.GetName() &&
+				w.Status.UpdatedReplicas == w.Status.Replicas {
+				updatedWorkloads++
+			}
 		}
 	}
 

--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
@@ -627,21 +627,23 @@ func (r *ReconcileYurtAppSet) conciliateYurtAppSetStatus(
 	// calculate yas current status
 	readyWorkloads, updatedWorkloads := 0, 0
 	for _, workload := range curWorkloads {
+		var replicas, readyReplicas, updatedReplicas int32
+		var workloadHash string
+
 		switch w := workload.(type) {
 		case *appsv1.Deployment:
-			if isWorkloadReady(w.Status.Replicas, w.Status.ReadyReplicas) {
-				readyWorkloads++
-			}
-			if isWorkloadUpdated(workloadmanager.GetWorkloadHash(w), expectedRevision.GetName(), w.Status.UpdatedReplicas, w.Status.Replicas) {
-				updatedWorkloads++
-			}
+			replicas, readyReplicas, updatedReplicas = w.Status.Replicas, w.Status.ReadyReplicas, w.Status.UpdatedReplicas
+			workloadHash = workloadmanager.GetWorkloadHash(w)
 		case *appsv1.StatefulSet:
-			if isWorkloadReady(w.Status.Replicas, w.Status.ReadyReplicas) {
-				readyWorkloads++
-			}
-			if isWorkloadUpdated(workloadmanager.GetWorkloadHash(w), expectedRevision.GetName(), w.Status.UpdatedReplicas, w.Status.Replicas) {
-				updatedWorkloads++
-			}
+			replicas, readyReplicas, updatedReplicas = w.Status.Replicas, w.Status.ReadyReplicas, w.Status.UpdatedReplicas
+			workloadHash = workloadmanager.GetWorkloadHash(w)
+		}
+
+		if isWorkloadReady(replicas, readyReplicas) {
+			readyWorkloads++
+		}
+		if isWorkloadUpdated(workloadHash, expectedRevision.GetName(), updatedReplicas, replicas) {
+			updatedWorkloads++
 		}
 	}
 

--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
@@ -629,19 +629,17 @@ func (r *ReconcileYurtAppSet) conciliateYurtAppSetStatus(
 	for _, workload := range curWorkloads {
 		switch w := workload.(type) {
 		case *appsv1.Deployment:
-			if w.Status.Replicas > 0 && w.Status.ReadyReplicas == w.Status.Replicas {
+			if isWorkloadReady(w.Status.Replicas, w.Status.ReadyReplicas) {
 				readyWorkloads++
 			}
-			if workloadmanager.GetWorkloadHash(w) == expectedRevision.GetName() &&
-				w.Status.UpdatedReplicas == w.Status.Replicas {
+			if isWorkloadUpdated(workloadmanager.GetWorkloadHash(w), expectedRevision.GetName(), w.Status.UpdatedReplicas, w.Status.Replicas) {
 				updatedWorkloads++
 			}
 		case *appsv1.StatefulSet:
-			if w.Status.Replicas > 0 && w.Status.ReadyReplicas == w.Status.Replicas {
+			if isWorkloadReady(w.Status.Replicas, w.Status.ReadyReplicas) {
 				readyWorkloads++
 			}
-			if workloadmanager.GetWorkloadHash(w) == expectedRevision.GetName() &&
-				w.Status.UpdatedReplicas == w.Status.Replicas {
+			if isWorkloadUpdated(workloadmanager.GetWorkloadHash(w), expectedRevision.GetName(), w.Status.UpdatedReplicas, w.Status.Replicas) {
 				updatedWorkloads++
 			}
 		}
@@ -692,4 +690,12 @@ func (r *ReconcileYurtAppSet) conciliateYurtAppSetStatus(
 	klog.Infof("YurtAppSet[%s/%s] update status success.", yas.Namespace, yas.Name)
 
 	return nil
+}
+
+func isWorkloadReady(replicas, readyReplicas int32) bool {
+	return replicas > 0 && readyReplicas == replicas
+}
+
+func isWorkloadUpdated(workloadHash string, expectedRevisionName string, updatedReplicas, replicas int32) bool {
+	return workloadHash == expectedRevisionName && updatedReplicas == replicas
 }

--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller_test.go
@@ -412,3 +412,62 @@ func TestReconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestConciliateYurtAppSetStatusWithStatefulSet(t *testing.T) {
+	yas := &v1beta1.YurtAppSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-yas",
+			Namespace: "default",
+		},
+	}
+
+	expectedRevision := &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rev-1",
+		},
+	}
+
+	sts1 := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				apps.ControllerRevisionHashLabelKey: "rev-1",
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        2,
+			ReadyReplicas:   2,
+			UpdatedReplicas: 2,
+		},
+	}
+
+	sts2 := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sts-2",
+			Namespace: "default",
+			Labels: map[string]string{
+				apps.ControllerRevisionHashLabelKey: "rev-0",
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        2,
+			ReadyReplicas:   1,
+			UpdatedReplicas: 1,
+		},
+	}
+
+	curWorkloads := []metav1.Object{sts1, sts2}
+	newStatus := &v1beta1.YurtAppSetStatus{}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(yas).WithStatusSubresource(&v1beta1.YurtAppSet{}).Build()
+	r := &ReconcileYurtAppSet{
+		Client: fakeClient,
+	}
+
+	err := r.conciliateYurtAppSetStatus(yas, curWorkloads, expectedRevision, nil, newStatus)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), newStatus.TotalWorkloads)
+	assert.Equal(t, int32(1), newStatus.ReadyWorkloads)
+	assert.Equal(t, int32(1), newStatus.UpdatedWorkloads)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`conciliateYurtAppSetStatus` in 
`pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go` 
performed an unchecked type assertion `workload.(*appsv1.Deployment)` on 
items from `curWorkloads` (`[]metav1.Object`). Since `YurtAppSet` supports 
both `DeploymentTemplate` and `StatefulSetTemplate` (defined in 
`pkg/apis/apps/v1alpha1` and `v1beta1`), when a `YurtAppSet` is created 
with `spec.workload.statefulSetTemplate` instead of `deploymentTemplate`, 
`curWorkloads` contains `*appsv1.StatefulSet` objects instead of 
`*appsv1.Deployment`.

Because the assertion used the single-value form with no `, ok` check, 
asserting a `*appsv1.StatefulSet` to `*appsv1.Deployment` triggered an 
unrecoverable Go runtime panic:
This crashed the entire `yurt-manager` controller process, not just the 
reconciliation of that one resource, and could cause a crash-loop for as 
long as any `StatefulSetTemplate`-based `YurtAppSet` existed in the 
cluster.

This PR replaces the unchecked assertion with a type switch that handles 
both `*appsv1.Deployment` and `*appsv1.StatefulSet`, computing 
`readyWorkloads`/`updatedWorkloads` for each type using their respective 
status fields (`Status.Replicas`, `Status.ReadyReplicas`, 
`Status.UpdatedReplicas`).

A new test, `TestConciliateYurtAppSetStatusWithStatefulSet`, verifies 
status reconciliation works correctly for StatefulSet-based workloads 
without panicking.

#### Which issue(s) this PR fixes:
Fixes #2636

#### Special notes for your reviewer:
- `go test -v ./pkg/yurtmanager/controller/yurtappset/...` — all existing tests pass, including the new StatefulSet test case
- `GOOS=linux go build ./...` — builds cleanly
- `go vet ./pkg/yurtmanager/controller/yurtappset/...` — zero warnings
- No exported function signatures changed
- `conciliateYurtAppSetStatus` has a single call site (in `conciliateYurtAppSet`), confirmed unaffected by this change
- This is my first contribution to OpenYurt — happy to make any changes requested

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### other Note