### PR TITLE
fix: remove redundant validate(oldSP) in YurtStaticSet ValidateUpdate webhook

### DIFF
--- a/pkg/yurtmanager/webhook/yurtstaticset/v1alpha1/yurtstaticset_validation.go
+++ b/pkg/yurtmanager/webhook/yurtstaticset/v1alpha1/yurtstaticset_validation.go
@@ -53,16 +53,12 @@ func (webhook *YurtStaticSetHandler) ValidateUpdate(ctx context.Context, oldObj,
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a YurtStaticSet but got a %T", newObj))
 	}
-	oldSP, ok := oldObj.(*v1alpha1.YurtStaticSet)
+	_, ok = oldObj.(*v1alpha1.YurtStaticSet)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a YurtStaticSet but got a %T", oldObj))
 	}
 
 	if err := validate(newSP); err != nil {
-		return nil, err
-	}
-
-	if err := validate(oldSP); err != nil {
 		return nil, err
 	}
 

--- a/pkg/yurtmanager/webhook/yurtstaticset/v1alpha1/yurtstaticset_validation_test.go
+++ b/pkg/yurtmanager/webhook/yurtstaticset/v1alpha1/yurtstaticset_validation_test.go
@@ -154,7 +154,7 @@ func TestYurtStaticSetHandler_ValidateUpdate(t *testing.T) {
 			errorMsg:    "StaticPodManifest is required",
 		},
 		{
-			name: "should fail when old YurtStaticSet has invalid StaticPodManifest",
+			name: "should pass when old YurtStaticSet is invalid but new one is valid",
 			newObj: &v1alpha1.YurtStaticSet{
 				Spec: v1alpha1.YurtStaticSetSpec{
 					StaticPodManifest: "newManifest",
@@ -170,8 +170,7 @@ func TestYurtStaticSetHandler_ValidateUpdate(t *testing.T) {
 			oldObj: &v1alpha1.YurtStaticSet{
 				Spec: v1alpha1.YurtStaticSetSpec{},
 			},
-			expectError: true,
-			errorMsg:    "StaticPodManifest is required",
+			expectError: false,
 		},
 		{
 			name: "should pass when updating YurtStaticSet with valid changes",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

`ValidateUpdate` in the `YurtStaticSet` admission webhook validates both
the incoming new object (`newSP`) **and** the existing old object
(`oldSP`). Validating the old object is incorrect:

- The old object was already accepted by the API server when it was
  created. Re-validating it on every update serves no purpose.
- If validation rules were tightened after an object was created, all
  subsequent update requests on that object will be permanently rejected
  by the webhook — even when the new spec is completely valid.
- This is inconsistent with how Kubernetes admission webhooks are
  expected to behave; only the desired state (new object) should be
  validated during an update.

This PR removes the `validate(oldSP)` call so that `ValidateUpdate` only
validates `newSP`, matching the correct semantic for admission webhooks.

**Which issue(s) this PR fixes:**

Fixes #2643

**Special notes for your reviewer:**

The change is in
`pkg/yurtmanager/webhook/yurtstaticset/v1alpha1/yurtstaticset_validation.go`.
The corresponding test case that previously expected an error when
`oldSP` was invalid has been updated to expect success, since a valid
`newSP` should always be accepted regardless of the state of `oldSP`.

**Does this PR introduce a user-facing change?**

```release-note
Fix YurtStaticSet webhook ValidateUpdate to only validate the new object,
preventing legitimate updates from being incorrectly rejected when the
existing object does not satisfy current validation rules.
```

**Additional documentation:**

N/A
