### PR TITLE
fix: don't re-validate old object on update and skip validation on delete for Gateway v1alpha1 webhook

### DIFF
--- a/pkg/yurtmanager/webhook/gateway/v1alpha1/gateway_validation.go
+++ b/pkg/yurtmanager/webhook/gateway/v1alpha1/gateway_validation.go
@@ -47,29 +47,17 @@ func (webhook *GatewayHandler) ValidateUpdate(ctx context.Context, oldObj, newOb
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a Gateway but got a %T", newObj))
 	}
-	oldGw, ok := oldObj.(*v1alpha1.Gateway)
-	if !ok {
+	if _, ok := oldObj.(*v1alpha1.Gateway); !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a Gateway but got a %T", oldObj))
 	}
 
-	if err := validate(oldGw); err != nil {
-		return nil, err
-	}
-
-	if err := validate(newGw); err != nil {
-		return nil, err
-	}
-
-	return nil, nil
+	return nil, validate(newGw)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
 func (webhook *GatewayHandler) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	gw, ok := obj.(*v1alpha1.Gateway)
-	if !ok {
-		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a Gateway but got a %T", obj))
-	}
-	return nil, validate(gw)
+	return nil, nil
+
 }
 
 func validate(g *v1alpha1.Gateway) error {

--- a/pkg/yurtmanager/webhook/gateway/v1alpha1/gateway_validation_test.go
+++ b/pkg/yurtmanager/webhook/gateway/v1alpha1/gateway_validation_test.go
@@ -124,10 +124,10 @@ func TestGatewayHandler_ValidateUpdate(t *testing.T) {
 			expectedErrMsg: "missing required field 'endpoints'",
 		},
 		{
-			name:           "should return error when old Gateway is invalid",
+			name:           "should succeed when old Gateway is invalid but new Gateway is valid",
 			oldObj:         mockGatewayWithMissingEndpoints(),
 			newObj:         mockGatewayWithEndpoints(),
-			expectedErrMsg: "missing required field 'endpoints'",
+			expectedErrMsg: "",
 		},
 		{
 			name:           "should validate Gateway when new and old objects are valid",
@@ -154,19 +154,20 @@ func TestGatewayHandler_ValidateUpdate(t *testing.T) {
 
 func TestGatewayHandler_ValidateDelete(t *testing.T) {
 	cases := []struct {
-		name        string
-		obj         runtime.Object
-		expectError bool
+		name string
+		obj  runtime.Object
 	}{
 		{
-			name:        "should return error when obj is not Gateway",
-			obj:         &runtime.Unknown{},
-			expectError: true,
+			name: "should always allow deletion even when obj is not a Gateway",
+			obj:  &runtime.Unknown{},
 		},
 		{
-			name:        "should validate Gateway deletion when obj is valid",
-			obj:         mockGatewayWithEndpoints(),
-			expectError: false,
+			name: "should always allow deletion of a valid Gateway",
+			obj:  mockGatewayWithEndpoints(),
+		},
+		{
+			name: "should always allow deletion of an invalid Gateway",
+			obj:  mockGatewayWithMissingEndpoints(),
 		},
 	}
 
@@ -175,15 +176,10 @@ func TestGatewayHandler_ValidateDelete(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := handler.ValidateDelete(context.Background(), tc.obj)
-			if tc.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
-
 func mockGatewayWithEndpoints() *v1alpha1.Gateway {
 	return &v1alpha1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
This PR fixes incorrect admission control behavior in the Gateway v1alpha1 validating webhook (`pkg/yurtmanager/webhook/gateway/v1alpha1/gateway_validation.go`).

**Problem 1: `ValidateUpdate` re-validates the old object**

`ValidateUpdate` was calling `validate(oldGw)` in addition to `validate(newGw)`. Since `oldGw` represents an object that was already admitted and persisted in etcd, re-validating it on every update is incorrect. If validation rules are tightened later, or if the existing object somehow ends up in an invalid state, every subsequent update to that Gateway is permanently rejected by the webhook — even when the incoming update itself is valid.

**Problem 2: `ValidateDelete` runs full validation before allowing deletion**

`ValidateDelete` was calling `validate(gw)` before allowing the delete to proceed. This means a Gateway with invalid state (e.g. missing endpoints) can never be deleted, since delete requests get rejected by the same validation rules used for create/update. This creates a deadlock: the object can't be fixed (update also validates) and can't be removed either.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2648 

#### Special notes for your reviewer:
- This aligns the `v1alpha1` Gateway webhook behavior with the already-correct `v1beta1` implementation.
- No changes were made to the `validate()` function itself — only to how/when it's invoked in `ValidateUpdate` and `ValidateDelete`.

#### Does this PR introduce a user-facing change?
```release-note
Fixed the Gateway (v1alpha1) admission webhook so that updates no longer re-validate the existing (old) object, and deletions are no longer blocked by validation errors. This resolves an issue where Gateway resources with invalid state could become permanently stuck and unable to be updated or deleted.
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
