### PR TITLE
fix: report correct replica value instead of ExposeType in Gateway we…

### DIFF
--- a/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_validation.go
+++ b/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_validation.go
@@ -83,7 +83,7 @@ func validate(g *v1beta1.Gateway) (admission.Warnings, error) {
 
 	if g.Spec.TunnelConfig.Replicas > 1 {
 		fldPath := field.NewPath("spec").Child("tunnelConfig.Replicas")
-		errList = append(errList, field.Invalid(fldPath, g.Spec.ExposeType, "the 'Replicas' field  can not be greater than 1"))
+		errList = append(errList, field.Invalid(fldPath, g.Spec.TunnelConfig.Replicas, "the 'Replicas' field  can not be greater than 1"))
 	}
 
 	if g.Spec.ProxyConfig.Replicas > 1 {
@@ -95,7 +95,7 @@ func validate(g *v1beta1.Gateway) (admission.Warnings, error) {
 		}
 		if g.Spec.ProxyConfig.Replicas > num {
 			fldPath := field.NewPath("spec").Child("endpoints")
-			errList = append(errList, field.Invalid(fldPath, g.Spec.ExposeType,
+			errList = append(errList, field.Invalid(fldPath, g.Spec.ProxyConfig.Replicas,
 				fmt.Sprintf("the 'endpoints' field available proxy endpoints %d is less than the 'proxyConfig.Replicas'%d", num, g.Spec.ProxyConfig.Replicas)))
 		}
 

--- a/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_validation_test.go
+++ b/pkg/yurtmanager/webhook/gateway/v1beta1/gateway_validation_test.go
@@ -233,3 +233,14 @@ func mockGatewayWithReplicas(Replicas int) *v1beta1.Gateway {
 	g.Spec.TunnelConfig.Replicas = Replicas
 	return g
 }
+
+func TestGatewayHandler_ValidateCreate_ReplicasBadValue(t *testing.T) {
+	handler := &GatewayHandler{}
+	g := mockGatewayWithReplicas(2)
+	g.Spec.ExposeType = v1beta1.ExposeTypeLoadBalancer
+	_, err := handler.ValidateCreate(context.Background(), g)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "spec.tunnelConfig.Replicas: Invalid value: 2")
+	assert.Contains(t, err.Error(), "spec.endpoints: Invalid value: 2")
+	assert.NotContains(t, err.Error(), "Invalid value: \"LoadBalancer\"")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

**Background**

`pkg/yurtmanager/webhook/gateway/v1beta1/gateway_validation.go` contains 
the `validate()` function, which is invoked by the Gateway admission 
webhook's `ValidateCreate` and `ValidateUpdate` handlers to enforce 
constraints on `v1beta1.Gateway` resources before they are persisted to 
the cluster.

Two of these constraints check replica counts:
- `g.Spec.TunnelConfig.Replicas` must not exceed `1`
- `g.Spec.ProxyConfig.Replicas` must not exceed the number of available 
  proxy-type endpoints (`num`)

**The Bug**

When either constraint is violated, the code builds a 
`field.Invalid(fldPath, badValue, detail)` error, which is part of the 
standard Kubernetes `apimachinery` validation error format. This error 
type is designed to report exactly which value on the resource was 
invalid, so that clients (kubectl, controllers, other API consumers) can 
surface a precise, actionable error message.

However, both call sites incorrectly passed `g.Spec.ExposeType` (a 
string field, e.g. `"LoadBalancer"` or `"PublicIP"`) as the `badValue` 
argument, instead of the actual replica count that failed validation:

```go
// Before (line ~86)
if g.Spec.TunnelConfig.Replicas > 1 {
    fldPath := field.NewPath("spec").Child("tunnelConfig.Replicas")
    errList = append(errList, field.Invalid(fldPath, g.Spec.ExposeType, "the 'Replicas' field can not be greater than 1"))
}

// Before (line ~98)
if g.Spec.ProxyConfig.Replicas > num {
    fldPath := field.NewPath("spec").Child("endpoints")
    errList = append(errList, field.Invalid(fldPath, g.Spec.ExposeType,
        fmt.Sprintf("the 'endpoints' field available proxy endpoints %d is less than the 'proxyConfig.Replicas'%d", num, g.Spec.ProxyConfig.Replicas)))
}
```

**Impact**

Submitting a Gateway with, for example, `tunnelConfig.replicas: 2` would 
correctly be rejected, but the returned API error would misreport the 
"bad value" as the Gateway's `ExposeType` string (e.g. `"LoadBalancer"`) 
rather than the actual invalid replica count (`2`). This is purely a 
diagnostics/error-message correctness issue — the resource is still 
correctly rejected — but it actively misleads users and operators trying 
to understand and fix a rejected manifest, since the field path 
(`spec.tunnelConfig.Replicas`) and the reported bad value 
(`"LoadBalancer"`) don't correspond to each other at all.

**The Fix**

Both `field.Invalid()` calls now pass the correct, actually-invalid 
field value:

```go
// After (line ~86)
errList = append(errList, field.Invalid(fldPath, g.Spec.TunnelConfig.Replicas, "the 'Replicas' field can not be greater than 1"))

// After (line ~98)
errList = append(errList, field.Invalid(fldPath, g.Spec.ProxyConfig.Replicas,
    fmt.Sprintf("the 'endpoints' field available proxy endpoints %d is less than the 'proxyConfig.Replicas'%d", num, g.Spec.ProxyConfig.Replicas)))
```

This is a minimal, surgical change — only the two value arguments passed 
into `field.Invalid()` were modified. No validation logic, control flow, 
or error messages were altered.

**Test Coverage**

Added `TestGatewayHandler_ValidateCreate_ReplicasBadValue` to 
`gateway_validation_test.go`, which submits a Gateway with 
`TunnelConfig.Replicas = 2` and `ExposeType = LoadBalancer`, and asserts:
- the returned error contains `spec.tunnelConfig.Replicas: Invalid value: 2`
- the returned error contains `spec.endpoints: Invalid value: 2`
- the returned error does **not** contain `Invalid value: "LoadBalancer"`

This directly guards against regression of this specific bug.

#### Which issue(s) this PR fixes:
Fixes #2637

#### Special notes for your reviewer:
- `go test -v ./pkg/yurtmanager/webhook/gateway/v1beta1/...` — all existing tests pass unchanged, plus the new regression test
- `GOOS=linux go build ./...` — builds cleanly
- `go vet ./pkg/yurtmanager/webhook/gateway/v1beta1/...` — zero warnings
- Confirmed `validate()` is only called from `ValidateCreate` and `ValidateUpdate` — no other call sites affected
- No exported function signatures changed; this is a scoped, non-behavioral-logic fix limited to the reported field values in two error messages
- This is my second PR to OpenYurt (see also #2646) — happy to address any feedback

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### other Note