### PR TITLE
docs: fix unmarshaler typos

### DIFF
--- a/docs/proposals/20240529-node-level-traffic-reuse-capability.md
+++ b/docs/proposals/20240529-node-level-traffic-reuse-capability.md
@@ -63,7 +63,7 @@ type Interface interface {
 	Watch(ctx context.Context, key string, opts ListOptions) (watch.Interface, error)
 
 
-	// GetList unmarshalls objects found at key into a *List api object (an object
+	// GetList unmarshals objects found at key into a *List api object (an object
 	// that satisfies runtime.IsList definition).
 	// If 'opts.Recursive' is false, 'key' is used as an exact match. If `opts.Recursive'
 	// is true, 'key' is used as a prefix.

--- a/pkg/util/kubernetes/kubeadm/app/apis/bootstraptoken/v1/utils.go
+++ b/pkg/util/kubernetes/kubeadm/app/apis/bootstraptoken/v1/utils.go
@@ -35,7 +35,7 @@ func (bts BootstrapTokenString) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%s"`, bts.String())), nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface.
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (bts *BootstrapTokenString) UnmarshalJSON(b []byte) error {
 	// If the token is represented as "", just return quickly without an error
 	if len(b) == 0 {


### PR DESCRIPTION
## Description
This PR corrects spelling errors of the word "unmarshaler" in the node-level traffic reuse proposal documentation and the bootstraptoken API utilities. 

## Motivation
Maintaining correct spelling in proposals and documentation ensures professional quality and improves readability for contributors and users.

## Changes
- `docs/proposals/20240529-node-level-traffic-reuse-capability.md`: Fixed "unmarshalls" to "unmarshals"
- `pkg/util/kubernetes/kubeadm/app/apis/bootstraptoken/v1/utils.go`: Fixed "Unmarshaller" to "Unmarshaler" in comments

## Testing
- [x] Verified changes locally.
- [x] Ensure markdown renders correctly.

## Checklist
- [x] Commits are signed off (DCO).
- [x] Follows project's code style and contributing guidelines.
- [x] One logical change per commit.

Signed-off-by: saiashok103@gmail.com
