### PR TITLE
refactor: replace interface{} with any in util package

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func IsNil(i interface{}) bool {
+func IsNil(i any) bool {
 	if i == nil {
 		return true
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -26,7 +26,7 @@ func TestIsNil(t *testing.T) {
 	realErr := errors.New("test")
 
 	testcases := map[string]struct {
-		inputInterface interface{}
+		inputInterface any
 		result         bool
 	}{
 		"input nil": {


### PR DESCRIPTION
## Description
This PR replaces the deprecated `interface{}` type alias with the newer `any` type in the `pkg/util` package. 

## Motivation
With the adoption of Go 1.18+, using `any` instead of `interface{}` is the standard and recommended practice. It makes the code cleaner, more concise, and easier to read.

## Changes
- `pkg/util/util.go`: Updated `IsNil` function signature to use `any`.
- `pkg/util/util_test.go`: Updated the `inputInterface` struct field to use `any`.

## Testing
- [x] Code compiles successfully.
- [x] Existing tests pass (`go test ./pkg/util/...`).

## Checklist
- [x] Commits are signed off (DCO).
- [x] Follows project's code style and contributing guidelines.
- [x] One logical change per commit.

Signed-off-by: saiashok103@gmail.com
