### PR TITLE
test: add unit test for TransformStripManagedFields

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -19,6 +19,8 @@ package util
 import (
 	"errors"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsNil(t *testing.T) {
@@ -54,5 +56,32 @@ func TestIsNil(t *testing.T) {
 				t.Errorf("expect bool result is %v, but got %v", tt.result, got)
 			}
 		})
+	}
+}
+
+func TestTransformStripManagedFields(t *testing.T) {
+	tf := TransformStripManagedFields()
+
+	obj := &metav1.ObjectMeta{
+		Name: "test",
+		ManagedFields: []metav1.ManagedFieldsEntry{
+			{
+				Manager: "test-manager",
+			},
+		},
+	}
+
+	out, err := tf(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	outObj, ok := out.(*metav1.ObjectMeta)
+	if !ok {
+		t.Fatalf("expected *metav1.ObjectMeta, got %T", out)
+	}
+
+	if len(outObj.ManagedFields) != 0 {
+		t.Errorf("expected managed fields to be stripped, got %v", outObj.ManagedFields)
 	}
 }


### PR DESCRIPTION
## Description
This PR adds missing unit test coverage for the `TransformStripManagedFields` utility function in the `pkg/util` package.

## Motivation
The `TransformStripManagedFields` function strips managed fields to improve memory usage, but previously lacked a unit test. Adding a test ensures it behaves correctly and prevents regressions during future modifications.

## Changes
- `pkg/util/util_test.go`: Added `TestTransformStripManagedFields` test function and necessary `metav1` import.

## Testing
- [x] Added unit test cases.
- [x] Ran `go test` and verified the new test passes locally.

## Checklist
- [x] Commits are signed off (DCO).
- [x] Follows project's code style and contributing guidelines.
- [x] One logical change per commit.

Signed-off-by: saiashok103@gmail.com
