### PR TITLE
fix(yurtadm): safely parse kubelet EnvironmentFile path in GetNodeName

### DIFF
--- a/pkg/yurtadm/util/edgenode/edgenode.go
+++ b/pkg/yurtadm/util/edgenode/edgenode.go
@@ -120,7 +120,7 @@ func GetNodeName(kubeadmConfPath string) (string, error) {
 		return "", err
 	}
 	for _, ef := range environmentFiles {
-		ef = strings.Split(ef, "-")[1]
+		ef = parseEnvironmentFilePath(ef)
 		nodeName, err = GetSingleContentFromFile(ef, constants.KubeletHostname)
 		if nodeName != "" {
 			nodeName = strings.Split(nodeName, NodeNameSplit)[1]
@@ -137,6 +137,22 @@ func GetNodeName(kubeadmConfPath string) (string, error) {
 	}
 	nodeName = strings.Trim(string(content), "\n")
 	return nodeName, nil
+}
+
+// parseEnvironmentFilePath extracts the file path from a systemd `EnvironmentFile=`
+// directive, e.g. `EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env`. It strips the
+// `EnvironmentFile=` key and the optional leading `-` (which only tells systemd to ignore
+// the file when it is missing).
+//
+// Using strings.Split(directive, "-")[1] here was unsafe: it panics when the directive
+// contains no "-" (e.g. `EnvironmentFile=/opt/kubelet/config.env`), and it truncates paths
+// that contain a hyphen such as the kubeadm default `kubeadm-flags.env`.
+func parseEnvironmentFilePath(directive string) string {
+	path := directive
+	if i := strings.IndexByte(path, '='); i >= 0 {
+		path = path[i+1:]
+	}
+	return strings.TrimPrefix(strings.TrimSpace(path), "-")
 }
 
 // GetHostname returns OS's hostname if 'hostnameOverride' is empty; otherwise, return 'hostnameOverride'.

--- a/pkg/yurtadm/util/edgenode/edgenode_test.go
+++ b/pkg/yurtadm/util/edgenode/edgenode_test.go
@@ -96,6 +96,43 @@ func Test_GetHostName(t *testing.T) {
 	}
 }
 
+func TestParseEnvironmentFilePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+		expected  string
+	}{
+		{
+			name:      "kubeadm default with ignore-prefix and hyphen in path",
+			directive: "EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env",
+			expected:  "/var/lib/kubelet/kubeadm-flags.env",
+		},
+		{
+			name:      "no ignore-prefix and no hyphen in path",
+			directive: "EnvironmentFile=/opt/kubelet/config.env",
+			expected:  "/opt/kubelet/config.env",
+		},
+		{
+			name:      "ignore-prefix without hyphen in path",
+			directive: "EnvironmentFile=-/etc/default/kubelet",
+			expected:  "/etc/default/kubelet",
+		},
+		{
+			name:      "surrounding whitespace is trimmed",
+			directive: "EnvironmentFile= -/var/lib/kubelet/kubeadm-flags.env ",
+			expected:  "/var/lib/kubelet/kubeadm-flags.env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseEnvironmentFilePath(tt.directive); got != tt.expected {
+				t.Errorf("parseEnvironmentFilePath(%q) = %q, want %q", tt.directive, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestDeployStaticYaml(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`GetNodeName()` in `pkg/yurtadm/util/edgenode/edgenode.go` parses the kubelet systemd drop-in to discover the node name. When it reads the `EnvironmentFile=` directive it used `strings.Split(ef, "-")[1]` to strip the directive down to a file path. That is unsafe:

- **Panic (`index out of range [1]`)** when the directive contains no `-` at all, e.g. `EnvironmentFile=/opt/kubelet/config.env`. systemd allows an `EnvironmentFile=` without the leading `-`, and the path may contain no hyphen. This crashes the caller (`node-servant convert` → `getNodeNameFunc` → `GetNodeName`).
- **Wrong path** when the file path contains a `-`. The kubeadm default is `EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env`; splitting on `-` and taking index `[1]` yields `/var/lib/kubelet/kubeadm` (truncated at the hyphen). The subsequent read fails, so this branch silently never finds `--hostname-override` and `GetNodeName` falls through to `/etc/hostname`, which can return a different name.

This PR replaces the split-on-hyphen heuristic with a small `parseEnvironmentFilePath` helper that strips the `EnvironmentFile=` key and the optional leading systemd `-` (which only means "ignore if missing"), preserving hyphens inside the path and never panicking. It also adds table-driven tests covering the panic case, the truncation case, and the whitespace case.

#### Which issue(s) this PR fixes:

Fixes #2661

#### Special notes for your reviewer:

The change is limited to the `EnvironmentFile` parsing path in `GetNodeName`. New unit test: `TestParseEnvironmentFilePath`. `go build`, `go vet` and `go test ./pkg/yurtadm/util/edgenode/...` pass locally.

#### Does this PR introduce a user-facing change?

```release-note
Fix a panic and incorrect node-name resolution in yurtadm/node-servant when the kubelet `EnvironmentFile=` directive has no hyphen or points to a path containing a hyphen (e.g. the kubeadm default `kubeadm-flags.env`).
```
