### PR TITLE
fix(yurt-iot-dock): stop syncer goroutine on shutdown

### DIFF
--- a/pkg/yurtiotdock/controllers/device_syncer.go
+++ b/pkg/yurtiotdock/controllers/device_syncer.go
@@ -72,44 +72,44 @@ func (ds *DeviceSyncer) NewDeviceSyncerRunnable() ctrlmgr.RunnableFunc {
 
 func (ds *DeviceSyncer) Run(stop <-chan struct{}) {
 	klog.V(1).Info("[Device] Starting the syncer...")
-	go func() {
-		for {
-			<-time.After(ds.syncPeriod)
-			klog.V(2).Info("[Device] Start a round of synchronization.")
-			// 1. get device on edge platform and OpenYurt
-			edgeDevices, kubeDevices, err := ds.getAllDevices()
-			if err != nil {
-				klog.V(3).ErrorS(err, "could not list the devices")
-				continue
-			}
-
-			// 2. find the device that need to be synchronized
-			redundantEdgeDevices, redundantKubeDevices, syncedDevices := ds.findDiffDevice(edgeDevices, kubeDevices)
-			klog.V(2).Infof("[Device] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
-				"Edge device should be added to OpenYurt", len(redundantEdgeDevices),
-				"OpenYurt device that should be deleted", len(redundantKubeDevices),
-				"Devices that should be synchronized", len(syncedDevices))
-
-			// 3. create device on OpenYurt which are exists in edge platform but not in OpenYurt
-			if err := ds.syncEdgeToKube(redundantEdgeDevices); err != nil {
-				klog.V(3).ErrorS(err, "could not create devices on OpenYurt")
-			}
-
-			// 4. delete redundant device on OpenYurt
-			if err := ds.deleteDevices(redundantKubeDevices); err != nil {
-				klog.V(3).ErrorS(err, "could not delete redundant devices on OpenYurt")
-			}
-
-			// 5. update device status on OpenYurt
-			if err := ds.updateDevices(syncedDevices); err != nil {
-				klog.V(3).ErrorS(err, "could not update devices status")
-			}
-			klog.V(2).Info("[Device] One round of synchronization is complete")
+	for {
+		select {
+		case <-stop:
+			klog.V(1).Info("[Device] Stopping the syncer")
+			return
+		case <-time.After(ds.syncPeriod):
 		}
-	}()
+		klog.V(2).Info("[Device] Start a round of synchronization.")
+		// 1. get device on edge platform and OpenYurt
+		edgeDevices, kubeDevices, err := ds.getAllDevices()
+		if err != nil {
+			klog.V(3).ErrorS(err, "could not list the devices")
+			continue
+		}
 
-	<-stop
-	klog.V(1).Info("[Device] Stopping the syncer")
+		// 2. find the device that need to be synchronized
+		redundantEdgeDevices, redundantKubeDevices, syncedDevices := ds.findDiffDevice(edgeDevices, kubeDevices)
+		klog.V(2).Infof("[Device] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
+			"Edge device should be added to OpenYurt", len(redundantEdgeDevices),
+			"OpenYurt device that should be deleted", len(redundantKubeDevices),
+			"Devices that should be synchronized", len(syncedDevices))
+
+		// 3. create device on OpenYurt which are exists in edge platform but not in OpenYurt
+		if err := ds.syncEdgeToKube(redundantEdgeDevices); err != nil {
+			klog.V(3).ErrorS(err, "could not create devices on OpenYurt")
+		}
+
+		// 4. delete redundant device on OpenYurt
+		if err := ds.deleteDevices(redundantKubeDevices); err != nil {
+			klog.V(3).ErrorS(err, "could not delete redundant devices on OpenYurt")
+		}
+
+		// 5. update device status on OpenYurt
+		if err := ds.updateDevices(syncedDevices); err != nil {
+			klog.V(3).ErrorS(err, "could not update devices status")
+		}
+		klog.V(2).Info("[Device] One round of synchronization is complete")
+	}
 }
 
 // Get the existing Device on the Edge platform, as well as OpenYurt existing Device

--- a/pkg/yurtiotdock/controllers/deviceprofile_syncer.go
+++ b/pkg/yurtiotdock/controllers/deviceprofile_syncer.go
@@ -71,43 +71,43 @@ func (dps *DeviceProfileSyncer) NewDeviceProfileSyncerRunnable() ctrlmgr.Runnabl
 
 func (dps *DeviceProfileSyncer) Run(stop <-chan struct{}) {
 	klog.V(1).Info("[DeviceProfile] Starting the syncer...")
-	go func() {
-		for {
-			<-time.After(dps.syncPeriod)
-			klog.V(2).Info("[DeviceProfile] Start a round of synchronization.")
-
-			// 1. get deviceProfiles on edge platform and OpenYurt
-			edgeDeviceProfiles, kubeDeviceProfiles, err := dps.getAllDeviceProfiles()
-			if err != nil {
-				klog.V(3).ErrorS(err, "could not list the deviceProfiles")
-				continue
-			}
-
-			// 2. find the deviceProfiles that need to be synchronized
-			redundantEdgeDeviceProfiles, redundantKubeDeviceProfiles, syncedDeviceProfiles :=
-				dps.findDiffDeviceProfiles(edgeDeviceProfiles, kubeDeviceProfiles)
-			klog.V(2).Infof("[DeviceProfile] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
-				"Edge deviceProfiles should be added to OpenYurt", len(redundantEdgeDeviceProfiles),
-				"OpenYurt deviceProfiles that should be deleted", len(redundantKubeDeviceProfiles),
-				"DeviceProfiles that should be synchronized", len(syncedDeviceProfiles))
-
-			// 3. create deviceProfiles on OpenYurt which are exists in edge platform but not in OpenYurt
-			if err := dps.syncEdgeToKube(redundantEdgeDeviceProfiles); err != nil {
-				klog.V(3).ErrorS(err, "could not create deviceProfiles on OpenYurt")
-			}
-
-			// 4. delete redundant deviceProfiles on OpenYurt
-			if err := dps.deleteDeviceProfiles(redundantKubeDeviceProfiles); err != nil {
-				klog.V(3).ErrorS(err, "could not delete redundant deviceProfiles on OpenYurt")
-			}
-
-			// 5. update deviceProfiles on OpenYurt
-			// TODO
+	for {
+		select {
+		case <-stop:
+			klog.V(1).Info("[DeviceProfile] Stopping the syncer")
+			return
+		case <-time.After(dps.syncPeriod):
 		}
-	}()
+		klog.V(2).Info("[DeviceProfile] Start a round of synchronization.")
 
-	<-stop
-	klog.V(1).Info("[DeviceProfile] Stopping the syncer")
+		// 1. get deviceProfiles on edge platform and OpenYurt
+		edgeDeviceProfiles, kubeDeviceProfiles, err := dps.getAllDeviceProfiles()
+		if err != nil {
+			klog.V(3).ErrorS(err, "could not list the deviceProfiles")
+			continue
+		}
+
+		// 2. find the deviceProfiles that need to be synchronized
+		redundantEdgeDeviceProfiles, redundantKubeDeviceProfiles, syncedDeviceProfiles :=
+			dps.findDiffDeviceProfiles(edgeDeviceProfiles, kubeDeviceProfiles)
+		klog.V(2).Infof("[DeviceProfile] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
+			"Edge deviceProfiles should be added to OpenYurt", len(redundantEdgeDeviceProfiles),
+			"OpenYurt deviceProfiles that should be deleted", len(redundantKubeDeviceProfiles),
+			"DeviceProfiles that should be synchronized", len(syncedDeviceProfiles))
+
+		// 3. create deviceProfiles on OpenYurt which are exists in edge platform but not in OpenYurt
+		if err := dps.syncEdgeToKube(redundantEdgeDeviceProfiles); err != nil {
+			klog.V(3).ErrorS(err, "could not create deviceProfiles on OpenYurt")
+		}
+
+		// 4. delete redundant deviceProfiles on OpenYurt
+		if err := dps.deleteDeviceProfiles(redundantKubeDeviceProfiles); err != nil {
+			klog.V(3).ErrorS(err, "could not delete redundant deviceProfiles on OpenYurt")
+		}
+
+		// 5. update deviceProfiles on OpenYurt
+		// TODO
+	}
 }
 
 // Get the existing DeviceProfile on the Edge platform, as well as OpenYurt existing DeviceProfile

--- a/pkg/yurtiotdock/controllers/deviceservice_syncer.go
+++ b/pkg/yurtiotdock/controllers/deviceservice_syncer.go
@@ -67,45 +67,45 @@ func (ds *DeviceServiceSyncer) NewDeviceServiceSyncerRunnable() ctrlmgr.Runnable
 
 func (ds *DeviceServiceSyncer) Run(stop <-chan struct{}) {
 	klog.V(1).Info("[DeviceService] Starting the syncer...")
-	go func() {
-		for {
-			<-time.After(ds.syncPeriod)
-			klog.V(2).Info("[DeviceService] Start a round of synchronization.")
-			// 1. get deviceServices on edge platform and OpenYurt
-			edgeDeviceServices, kubeDeviceServices, err := ds.getAllDeviceServices()
-			if err != nil {
-				klog.V(3).ErrorS(err, "could not list the deviceServices")
-				continue
-			}
-
-			// 2. find the deviceServices that need to be synchronized
-			redundantEdgeDeviceServices, redundantKubeDeviceServices, syncedDeviceServices :=
-				ds.findDiffDeviceServices(edgeDeviceServices, kubeDeviceServices)
-			klog.V(2).Infof("[DeviceService] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
-				"Edge deviceServices should be added to OpenYurt", len(redundantEdgeDeviceServices),
-				"OpenYurt deviceServices that should be deleted", len(redundantKubeDeviceServices),
-				"DeviceServices that should be synchronized", len(syncedDeviceServices))
-
-			// 3. create deviceServices on OpenYurt which are exists in edge platform but not in OpenYurt
-			if err := ds.syncEdgeToKube(redundantEdgeDeviceServices); err != nil {
-				klog.V(3).ErrorS(err, "could not create deviceServices on OpenYurt")
-			}
-
-			// 4. delete redundant deviceServices on OpenYurt
-			if err := ds.deleteDeviceServices(redundantKubeDeviceServices); err != nil {
-				klog.V(3).ErrorS(err, "could not delete redundant deviceServices on OpenYurt")
-			}
-
-			// 5. update deviceService status on OpenYurt
-			if err := ds.updateDeviceServices(syncedDeviceServices); err != nil {
-				klog.V(3).ErrorS(err, "could not update deviceServices")
-			}
-			klog.V(2).Info("[DeviceService] One round of synchronization is complete")
+	for {
+		select {
+		case <-stop:
+			klog.V(1).Info("[DeviceService] Stopping the syncer")
+			return
+		case <-time.After(ds.syncPeriod):
 		}
-	}()
+		klog.V(2).Info("[DeviceService] Start a round of synchronization.")
+		// 1. get deviceServices on edge platform and OpenYurt
+		edgeDeviceServices, kubeDeviceServices, err := ds.getAllDeviceServices()
+		if err != nil {
+			klog.V(3).ErrorS(err, "could not list the deviceServices")
+			continue
+		}
 
-	<-stop
-	klog.V(1).Info("[DeviceService] Stopping the syncer")
+		// 2. find the deviceServices that need to be synchronized
+		redundantEdgeDeviceServices, redundantKubeDeviceServices, syncedDeviceServices :=
+			ds.findDiffDeviceServices(edgeDeviceServices, kubeDeviceServices)
+		klog.V(2).Infof("[DeviceService] The number of objects waiting for synchronization { %s:%d, %s:%d, %s:%d }",
+			"Edge deviceServices should be added to OpenYurt", len(redundantEdgeDeviceServices),
+			"OpenYurt deviceServices that should be deleted", len(redundantKubeDeviceServices),
+			"DeviceServices that should be synchronized", len(syncedDeviceServices))
+
+		// 3. create deviceServices on OpenYurt which are exists in edge platform but not in OpenYurt
+		if err := ds.syncEdgeToKube(redundantEdgeDeviceServices); err != nil {
+			klog.V(3).ErrorS(err, "could not create deviceServices on OpenYurt")
+		}
+
+		// 4. delete redundant deviceServices on OpenYurt
+		if err := ds.deleteDeviceServices(redundantKubeDeviceServices); err != nil {
+			klog.V(3).ErrorS(err, "could not delete redundant deviceServices on OpenYurt")
+		}
+
+		// 5. update deviceService status on OpenYurt
+		if err := ds.updateDeviceServices(syncedDeviceServices); err != nil {
+			klog.V(3).ErrorS(err, "could not update deviceServices")
+		}
+		klog.V(2).Info("[DeviceService] One round of synchronization is complete")
+	}
 }
 
 // Get the existing DeviceService on the Edge platform, as well as OpenYurt existing DeviceService

--- a/pkg/yurtiotdock/controllers/syncer_shutdown_test.go
+++ b/pkg/yurtiotdock/controllers/syncer_shutdown_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// assertRunStopsOnSignal starts run in a goroutine and verifies that, once the
+// stop channel is closed, run returns promptly and does not leave a background
+// goroutine behind.
+//
+// The syncers are registered as controller-runtime runnables; on manager
+// shutdown their stop channel is closed and Run must return so its goroutine
+// terminates. A previous implementation ran the sync loop in a detached inner
+// goroutine that never observed stop, so it leaked and kept hitting the edge
+// platform and the API server after shutdown.
+//
+// A large syncPeriod keeps the loop parked in its select, so no real sync round
+// runs (no edge/kube clients are required) and the test isolates the shutdown
+// behaviour.
+func assertRunStopsOnSignal(t *testing.T, name string, run func(stop <-chan struct{})) {
+	t.Helper()
+
+	// Warm up klog's background flush daemon so it is not mistaken for a leaked
+	// goroutine when we snapshot the baseline below.
+	klog.V(1).Info("warming up klog before goroutine snapshot")
+	klog.Flush()
+	time.Sleep(50 * time.Millisecond)
+
+	baseline := runtime.NumGoroutine()
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		run(stop)
+		close(done)
+	}()
+
+	close(stop)
+
+	select {
+	case <-done:
+		// Run returned after stop was closed, as expected.
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s.Run did not return after stop was closed; the sync goroutine leaked", name)
+	}
+
+	// After Run returns, the sync loop must not have left a goroutine running.
+	// Poll, because the runtime may take a moment to reap the finished goroutine.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("%s.Run leaked a goroutine after stop was closed: baseline=%d, still running=%d",
+		name, baseline, runtime.NumGoroutine())
+}
+
+func TestDeviceSyncerRunStopsOnSignal(t *testing.T) {
+	ds := &DeviceSyncer{syncPeriod: time.Hour}
+	assertRunStopsOnSignal(t, "DeviceSyncer", ds.Run)
+}
+
+func TestDeviceServiceSyncerRunStopsOnSignal(t *testing.T) {
+	dss := &DeviceServiceSyncer{syncPeriod: time.Hour}
+	assertRunStopsOnSignal(t, "DeviceServiceSyncer", dss.Run)
+}
+
+func TestDeviceProfileSyncerRunStopsOnSignal(t *testing.T) {
+	dps := &DeviceProfileSyncer{syncPeriod: time.Hour}
+	assertRunStopsOnSignal(t, "DeviceProfileSyncer", dps.Run)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig iot

#### What this PR does / why we need it:

The three yurt-iot-dock syncers — `DeviceSyncer`, `DeviceServiceSyncer` and `DeviceProfileSyncer` — are registered as controller-runtime runnables and start their sync loop in a **detached inner goroutine that never observes `stop`**:

```go
func (ds *DeviceSyncer) Run(stop <-chan struct{}) {
	klog.V(1).Info("[Device] Starting the syncer...")
	go func() {
		for {
			<-time.After(ds.syncPeriod)   // only waits on the timer, never on stop
			// ... list/create/delete/update against EdgeX and the API server ...
		}
	}()

	<-stop
	klog.V(1).Info("[Device] Stopping the syncer")
}
```

When the manager shuts down, `ctx` is cancelled so `stop` closes and `Run` returns — but the inner goroutine keeps looping forever and continues issuing List/Create/Delete/Update calls against the EdgeX platform and the API server after the component has "stopped". All three syncers share this pattern.

Since `Run` already blocks on `<-stop`, the inner goroutine is redundant. This PR runs the loop directly in `Run` and selects on both the timer and `stop`, returning when `stop` is closed. This stops the leak and makes shutdown deterministic: because controller-runtime waits for the runnable to return, an in-flight sync round now completes before the process exits instead of racing with it.

> Note for reviewers: most of the diff is re-indentation caused by removing the `go func()` wrapper. Reviewing with whitespace hidden (append `?w=1` to the Files-changed URL) shows the change is small: the wrapper is removed and `<-time.After(...)` becomes a `select { case <-stop: return; case <-time.After(...): }`.

#### Which issue(s) this PR fixes:

Fixes #2663

#### Special notes for your reviewer:

New test `syncer_shutdown_test.go` snapshots the goroutine count, runs each syncer with a large `syncPeriod` (so the loop stays parked and no edge/kube clients are needed), closes `stop`, and asserts no goroutine is left running. I verified the test **fails against the current code** (`leaked a goroutine ... baseline=2, still running=3`) and passes with this fix. `go build`, `go vet`, `gofmt` and `go test ./pkg/yurtiotdock/controllers/...` all pass locally.

#### Does this PR introduce a user-facing change?

```release-note
Fix a goroutine leak in yurt-iot-dock: the Device, DeviceService and DeviceProfile syncers now stop their sync loop when the manager shuts down instead of continuing to call the EdgeX platform and the API server.
```
