### PR TITLE
fix: acquire dnsctl.lock in addOrUpdateNode to prevent data race with syncDNSRecordAsWhole

### DIFF
--- a/pkg/yurttunnel/trafficforward/dns/handler.go
+++ b/pkg/yurttunnel/trafficforward/dns/handler.go
@@ -173,6 +173,9 @@ func (dnsctl *coreDNSRecordController) onNodeUpdate(node *corev1.Node) error {
 }
 
 func (dnsctl *coreDNSRecordController) addOrUpdateNode(node *corev1.Node) error {
+	dnsctl.lock.Lock()
+	defer dnsctl.lock.Unlock()
+
 	ip, err := getNodeHostIP(node)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

**Background**

`coreDNSRecordController` (`pkg/yurttunnel/trafficforward/dns/`) manages 
CoreDNS records for edge/cloud nodes. `addOrUpdateNode` in `handler.go` 
handles `NodeAdd`/`NodeUpdate` events, calling `getTunnelServerIP(true)`, 
`getCurrentDNSRecords()`, and `updateDNSRecords(...)`.

**The Bug**

`addOrUpdateNode` did **not** acquire `dnsctl.lock`, while two other 
methods on the same controller correctly did:
- `onNodeDelete` (`handler.go`) acquires `dnsctl.lock.Lock()`
- `syncDNSRecordAsWhole` (`dns.go`) acquires `dnsctl.lock.Lock()` and runs 
  periodically on a background ticker goroutine

Since the event-handler worker goroutine running `addOrUpdateNode` 
executes concurrently with the ticker goroutine running 
`syncDNSRecordAsWhole`, this created:
1. A data race on `dnsctl.tunnelServerIP`, mutated inside 
   `getTunnelServerIP` without synchronization
2. A race between the CoreDNS ConfigMap read-modify-write sequence in 
   `addOrUpdateNode` (`getCurrentDNSRecords` → `updateDNSRecords`) and 
   `syncDNSRecordAsWhole`, risking lost or conflicting DNS record updates

**The Fix**

Added `dnsctl.lock.Lock()` / `defer dnsctl.lock.Unlock()` at the start of 
`addOrUpdateNode`, matching the exact pattern already used in 
`onNodeDelete`.

**Deadlock Check**

Traced every function called inside `addOrUpdateNode` 
(`getNodeHostIP`, `getTunnelServerIP`, `getCurrentDNSRecords`, 
`addOrUpdateRecord`, `updateDNSRecords`) — none of them acquire 
`dnsctl.lock` internally, so holding the lock for the duration of 
`addOrUpdateNode` introduces no self-deadlock risk.

#### Which issue(s) this PR fixes:
Fixes #2656

#### Special notes for your reviewer:
- `go test -v ./pkg/yurttunnel/trafficforward/dns/...` — all existing tests pass (including `TestAddNode`, `TestUpdateNode`, `TestDeleteNode`), no hangs/deadlocks observed
- `GOOS=linux go build ./...` — builds cleanly
- `go vet ./pkg/yurttunnel/trafficforward/dns/...` — zero warnings
- **Note:** I was unable to run `go test -race` locally due to a 32-bit GCC toolchain limitation on my Windows dev environment (cgo/race detector requires a 64-bit C compiler). I've traced the race condition and locking discipline manually and am confident in the fix, but would appreciate if CI or a reviewer could confirm with `go test -race -v ./pkg/yurttunnel/trafficforward/dns/...` on Linux.
- `addOrUpdateNode` is called only from `onNodeAdd` and `onNodeUpdate` — both are unaffected by this change since neither already holds `dnsctl.lock`
- No exported function signatures changed; single, minimal, scoped fix

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### other Note