### PR TITLE
Bugfix: return error from YurtAppSet reconcile to engage exponential …

### DIFF
--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -260,17 +259,14 @@ func (r *ReconcileYurtAppSet) Reconcile(
 	// this may infect yas appdispatched/appupdated/appdeleted condition
 	expectedNps, curWorkloads, nErr := r.conciliateWorkloads(yas, expectedRevision, yasStatus)
 	if nErr != nil {
-		res.RequeueAfter = 1 * time.Second
 		klog.Warningf("YurtAppSet[%s/%s] conciliate workloads error: %v", yas.Namespace, yas.Name, nErr)
-		return
+		return reconcile.Result{}, nErr
 	}
 
 	// Concilaiate yas, update yas status and clean yas related revisions
 	if nErr := r.conciliateYurtAppSet(yas, curWorkloads, allRevisions, expectedRevision, expectedNps, yasStatus); nErr != nil {
-		// if err, retry after 1s to wait for latest updates synced
-		res.RequeueAfter = 1 * time.Second
 		klog.Warningf("YurtAppSet[%s/%s] conciliate yurtappset error: %v", yas.GetNamespace(), yas.GetName(), nErr)
-		return
+		return reconcile.Result{}, nErr
 	}
 
 	return

--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller_test.go
@@ -412,3 +412,65 @@ func TestReconcile(t *testing.T) {
 		})
 	}
 }
+
+// TestReconcile_ReturnsErrorOnConciliationFailure verifies that errors from
+// conciliateYurtAppSet are propagated back to the caller instead of being
+// swallowed by the named return variable. Previously, the function returned
+// (Result{RequeueAfter: 1s}, nil) which bypassed exponential backoff.
+func TestReconcile_ReturnsErrorOnConciliationFailure(t *testing.T) {
+	// Create a YurtAppSet that will succeed through conciliateWorkloads
+	// (valid template + matching NodePool) but fail in conciliateYurtAppSet
+	// because the fake client's status subresource is not configured.
+	yas := &v1beta1.YurtAppSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-yas-error",
+			Namespace: "default",
+		},
+		Spec: v1beta1.YurtAppSetSpec{
+			Pools: []string{"test-np"},
+			Workload: v1beta1.Workload{
+				WorkloadTemplate: v1beta1.WorkloadTemplate{
+					DeploymentTemplate: &v1beta1.DeploymentTemplateSpec{
+						Spec: appsv1.DeploymentSpec{
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "test-yas-error",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	np := &v1beta2.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-np",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(yas, np).Build()
+	r := &ReconcileYurtAppSet{
+		scheme:   fakeScheme,
+		Client:   fakeClient,
+		recorder: &fakeEventRecorder{},
+		workloadManagers: map[workloadmanager.TemplateType]workloadmanager.WorkloadManager{
+			workloadmanager.DeploymentTemplateType: &workloadmanager.DeploymentManager{
+				Client: fakeClient,
+				Scheme: fakeScheme,
+			},
+		},
+	}
+
+	_, err := r.Reconcile(context.TODO(), reconcile.Request{
+		NamespacedName: client.ObjectKey{
+			Name:      "test-yas-error",
+			Namespace: "default",
+		},
+	})
+
+	// The reconcile should return an error (from conciliateYurtAppSet failing
+	// to update status) rather than swallowing it with RequeueAfter + nil error.
+	// This ensures controller-runtime engages exponential backoff.
+	assert.NotNil(t, err, "Reconcile should return error on conciliation failure, not nil")
+}


### PR DESCRIPTION
fixes #2667 
## Problem

`Reconcile()` in `yurt_app_set_controller.go` uses named return variables `(res Result, err error)` but captures conciliation errors in a local `nErr` variable. Bare `return` statements send `(Result{RequeueAfter: 1s}, nil)` back to `controller-runtime`. 

In `controller-runtime` (v0.19.5), returning a `nil` error with `RequeueAfter` resets the workqueue rate limiter history (`Forget()`), causing an aggressive 1-second polling loop during persistent failures.

## Solution

1. Replace bare `return` statements and `RequeueAfter` overrides with explicit `return reconcile.Result{}, nErr`.
2. Returning `nErr` allows `controller-runtime` to trigger `AddRateLimited()`, properly engaging exponential backoff.
3. Removed unused `time` import.

## Verification

1. Added `TestReconcile_ReturnsErrorOnConciliationFailure` to `yurt_app_set_controller_test.go` to verify error propagation.
2. Ran package tests: `go test ./pkg/yurtmanager/controller/yurtappset/...` (**PASS**).
3. Ran code analysis: `go vet ./pkg/yurtmanager/controller/yurtappset/...` (**PASS**).

/kind bug