### PR TITLE
fix: propagate conciliateWorkloads/conciliateYurtAppSet errors in YurtAppSet Reconcile

### DIFF
--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller.go
@@ -258,18 +258,18 @@ func (r *ReconcileYurtAppSet) Reconcile(
 
 	// Conciliate workloads, update yas related workloads (deploy/sts)
 	// this may infect yas appdispatched/appupdated/appdeleted condition
-	expectedNps, curWorkloads, nErr := r.conciliateWorkloads(yas, expectedRevision, yasStatus)
-	if nErr != nil {
+	expectedNps, curWorkloads, err := r.conciliateWorkloads(yas, expectedRevision, yasStatus)
+	if err != nil {
 		res.RequeueAfter = 1 * time.Second
-		klog.Warningf("YurtAppSet[%s/%s] conciliate workloads error: %v", yas.Namespace, yas.Name, nErr)
+		klog.Warningf("YurtAppSet[%s/%s] conciliate workloads error: %v", yas.Namespace, yas.Name, err)
 		return
 	}
 
 	// Concilaiate yas, update yas status and clean yas related revisions
-	if nErr := r.conciliateYurtAppSet(yas, curWorkloads, allRevisions, expectedRevision, expectedNps, yasStatus); nErr != nil {
+	if err = r.conciliateYurtAppSet(yas, curWorkloads, allRevisions, expectedRevision, expectedNps, yasStatus); err != nil {
 		// if err, retry after 1s to wait for latest updates synced
 		res.RequeueAfter = 1 * time.Second
-		klog.Warningf("YurtAppSet[%s/%s] conciliate yurtappset error: %v", yas.GetNamespace(), yas.GetName(), nErr)
+		klog.Warningf("YurtAppSet[%s/%s] conciliate yurtappset error: %v", yas.GetNamespace(), yas.GetName(), err)
 		return
 	}
 

--- a/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtappset/yurt_app_set_controller_test.go
@@ -19,6 +19,7 @@ package yurtappset
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -411,4 +412,49 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReconcile_PropagatesConciliateWorkloadsError guards against a regression
+// where the named return err was shadowed by a local nErr inside Reconcile.
+// A bare "return" after only setting res.RequeueAfter sent (Result{RequeueAfter},
+// nil) to controller-runtime, which resets the rate limiter's backoff on every
+// retry instead of backing off exponentially.
+func TestReconcile_PropagatesConciliateWorkloadsError(t *testing.T) {
+	yas := &v1beta1.YurtAppSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-yurtappset",
+			Namespace: "default",
+		},
+		Spec: v1beta1.YurtAppSetSpec{
+			Pools: []string{"test-np1"},
+			// Neither DeploymentTemplate nor StatefulSetTemplate is set, so
+			// getWorkloadManagerFromYurtAppSet fails deterministically and
+			// conciliateWorkloads returns a non-nil error.
+		},
+	}
+	np := &v1beta2.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-np1",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(yas, np).Build()
+	r := &ReconcileYurtAppSet{
+		scheme:   fakeScheme,
+		Client:   fakeClient,
+		recorder: &fakeEventRecorder{},
+		workloadManagers: map[workloadmanager.TemplateType]workloadmanager.WorkloadManager{
+			workloadmanager.DeploymentTemplateType: &workloadmanager.DeploymentManager{
+				Client: fakeClient,
+				Scheme: fakeScheme,
+			},
+		},
+	}
+
+	res, err := r.Reconcile(context.TODO(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: "test-yurtappset", Namespace: "default"},
+	})
+
+	assert.Error(t, err, "conciliateWorkloads error must be propagated as the Reconcile error, not swallowed")
+	assert.Greater(t, res.RequeueAfter, time.Duration(0), "RequeueAfter should still be set alongside the error")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`ReconcileYurtAppSet.Reconcile` uses named return values `(res reconcile.Result, err error)`. When `conciliateWorkloads` or `conciliateYurtAppSet` fails, the error was captured into a local `nErr` instead of the named `err`, then only `res.RequeueAfter` was set before the bare `return`. That sends `(Result{RequeueAfter: 1s}, nil)` to controller-runtime, and a nil error with `RequeueAfter` set calls `Forget()` on the rate limiter, resetting exponential backoff to zero on every retry. Under a persistent failure this turns into a tight 1 second retry loop that never backs off.

Renamed both `nErr` locals to `err` so they assign the named return, matching the pattern already used by the other bare returns in the same function.

Added a regression test (`TestReconcile_PropagatesConciliateWorkloadsError`) that forces `conciliateWorkloads` to fail by using a YurtAppSet with neither `DeploymentTemplate` nor `StatefulSetTemplate` set, and asserts `Reconcile`'s error is non-nil. Confirmed it fails on the old code and passes with the fix.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where YurtAppSet controller retries on conciliation failure used a fixed 1 second interval instead of exponential backoff, since the error was not actually propagated to controller-runtime.
```

#### other Note
