### PR TITLE
fix: add mutex locking to cloudAPIServerHealthChecker to prevent data race....

### DIFF
--- a/pkg/yurthub/healthchecker/cloudapiserver/health_checker.go
+++ b/pkg/yurthub/healthchecker/cloudapiserver/health_checker.go
@@ -84,6 +84,8 @@ func (hc *cloudAPIServerHealthChecker) RenewKubeletLeaseTime() {
 }
 
 func (hc *cloudAPIServerHealthChecker) IsHealthy() bool {
+	hc.RLock()
+	defer hc.RUnlock()
 	for _, prober := range hc.probers {
 		if prober.IsHealthy() {
 			return true
@@ -105,6 +107,8 @@ func (hc *cloudAPIServerHealthChecker) PickOneHealthyBackend() *url.URL {
 
 // BackendHealthyStatus returns the healthy stats of specified server
 func (hc *cloudAPIServerHealthChecker) BackendIsHealthy(server *url.URL) bool {
+	hc.RLock()
+	defer hc.RUnlock()
 	if prober, ok := hc.probers[server.String()]; ok {
 		return prober.IsHealthy()
 	}
@@ -139,6 +143,8 @@ func (hc *cloudAPIServerHealthChecker) run(stopCh <-chan struct{}) {
 }
 
 func (hc *cloudAPIServerHealthChecker) setLastNodeLease(lease *coordinationv1.Lease) error {
+	hc.Lock()
+	defer hc.Unlock()
 	if lease == nil {
 		return nil
 	}
@@ -175,6 +181,8 @@ func (hc *cloudAPIServerHealthChecker) setLastNodeLease(lease *coordinationv1.Le
 }
 
 func (hc *cloudAPIServerHealthChecker) getLastNodeLease() *coordinationv1.Lease {
+	hc.Lock()
+	defer hc.Unlock()
 	if hc.latestLease != nil {
 		delete(hc.latestLease.Annotations, DelegateHeartBeat)
 	}
@@ -182,6 +190,8 @@ func (hc *cloudAPIServerHealthChecker) getLastNodeLease() *coordinationv1.Lease 
 }
 
 func (hc *cloudAPIServerHealthChecker) getProber() healthchecker.BackendProber {
+	hc.Lock()
+	defer hc.Unlock()
 	prober := hc.probers[hc.remoteServers[hc.remoteServerIndex].String()]
 	hc.remoteServerIndex = (hc.remoteServerIndex + 1) % len(hc.remoteServers)
 	return prober

--- a/pkg/yurthub/healthchecker/cloudapiserver/health_checker_test.go
+++ b/pkg/yurthub/healthchecker/cloudapiserver/health_checker_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/openyurtio/openyurt/cmd/yurthub/app/config"
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
+	"github.com/openyurtio/openyurt/pkg/yurthub/healthchecker"
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
 	"github.com/openyurtio/openyurt/pkg/yurthub/transport"
 )
@@ -264,5 +265,59 @@ func TestNewCloudAPIServerHealthChecker(t *testing.T) {
 
 	if err := os.RemoveAll(rootDir); err != nil {
 		t.Errorf("Got error %v, unable to remove path %s", err, rootDir)
+	}
+}
+
+func TestCloudAPIServerHealthCheckerConcurrency(t *testing.T) {
+	testDir := "/tmp/healthz_concurrent"
+	store, err := disk.NewDiskStorage(testDir)
+	if err != nil {
+		t.Fatalf("failed to create disk storage: %v", err)
+	}
+	defer os.RemoveAll(testDir)
+
+	hc := &cloudAPIServerHealthChecker{
+		probers:           make(map[string]healthchecker.BackendProber),
+		remoteServers:     []*url.URL{{Host: "127.0.0.1:18080"}},
+		remoteServerIndex: 0,
+		sw:                cachemanager.NewStorageWrapper(store),
+		heartbeatInterval: 3,
+	}
+
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "foo",
+			Namespace:       "kube-node-lease",
+			ResourceVersion: "1",
+			Annotations:     map[string]string{DelegateHeartBeat: "true"},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = hc.setLastNodeLease(lease.DeepCopy())
+		}
+		done <- struct{}{}
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = hc.getLastNodeLease()
+		}
+		done <- struct{}{}
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = hc.IsHealthy()
+			_ = hc.getProber()
+			_ = hc.PickOneHealthyBackend()
+		}
+		done <- struct{}{}
+	}()
+
+	for i := 0; i < 3; i++ {
+		<-done
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
cloudAPIServerHealthChecker embeds sync.RWMutex but never actually used 
it. setLastNodeLease, getLastNodeLease, and getProber all mutate shared 
state (latestLease, latestLease.Annotations, remoteServerIndex) with no 
lock, while IsHealthy/BackendIsHealthy read probers/remoteServers 
without an RLock either.

These run on completely different goroutines — prober callbacks, the 
background health-check ticker, and external calls from yurthub's proxy 
layer — so this is a real race, not just theoretical.

Added locking:
- setLastNodeLease, getLastNodeLease, getProber -> Lock/Unlock (all mutate state)
- IsHealthy, BackendIsHealthy -> RLock/RUnlock

One thing worth flagging for review: PickOneHealthyBackend calls 
BackendIsHealthy in a loop, and BackendIsHealthy takes its own RLock. I 
deliberately did NOT add a lock in PickOneHealthyBackend itself, since 
nested RLock on the same goroutine can deadlock if a writer is queued in 
between. Let me know if there's a cleaner pattern you'd prefer here.

Added TestCloudAPIServerHealthCheckerConcurrency, which spawns multiple 
goroutines hitting setLastNodeLease/getLastNodeLease/IsHealthy/
getProber/PickOneHealthyBackend concurrently.

#### Which issue(s) this PR fixes:
Fixes #2655

#### Special notes for your reviewer:
go test -race -v ./pkg/yurthub/healthchecker/cloudapiserver/... passes 
clean, no races reported (ran on WSL/Linux, ~50s). Also ran go vet and a 
regular go build, both clean.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### other Note