### PR TITLE
fix(yurthub): eliminate data race on addrConns map in connrotation di…

### DIFF
--- a/pkg/yurthub/util/connrotation.go
+++ b/pkg/yurthub/util/connrotation.go
@@ -86,15 +86,17 @@ func (d *Dialer) CloseAll() {
 	d.mu.Lock()
 	addrConns := d.addrConns
 	d.addrConns = make(map[string]map[*closableConn]struct{})
+	var allConns []*closableConn
+	for _, conns := range addrConns {
+		for conn := range conns {
+			allConns = append(allConns, conn)
+		}
+	}
 	d.mu.Unlock()
 
-	for addr, conns := range addrConns {
-		for conn := range conns {
-			conn.Conn.Close()
-			delete(conns, conn)
-			metrics.Metrics.DecClosableConns(addr)
-		}
-		delete(addrConns, addr)
+	for _, conn := range allConns {
+		conn.Conn.Close()
+		metrics.Metrics.DecClosableConns(conn.addr)
 	}
 }
 
@@ -105,12 +107,15 @@ func (d *Dialer) Close(address string) {
 	d.mu.Lock()
 	conns := d.addrConns[address]
 	delete(d.addrConns, address)
+	var targetConns []*closableConn
+	for conn := range conns {
+		targetConns = append(targetConns, conn)
+	}
 	d.mu.Unlock()
 
-	klog.Infof("forcibly close %d connections on %s for %s dialer", len(conns), address, d.name)
-	for conn := range conns {
+	klog.Infof("forcibly close %d connections on %s for %s dialer", len(targetConns), address, d.name)
+	for _, conn := range targetConns {
 		conn.Conn.Close()
-		delete(conns, conn)
 		metrics.Metrics.DecClosableConns(address)
 	}
 }

--- a/pkg/yurthub/util/connrotation.go
+++ b/pkg/yurthub/util/connrotation.go
@@ -107,11 +107,12 @@ func (d *Dialer) Close(address string) {
 	d.mu.Lock()
 	conns := d.addrConns[address]
 	delete(d.addrConns, address)
+	d.mu.Unlock()
+
 	var targetConns []*closableConn
 	for conn := range conns {
 		targetConns = append(targetConns, conn)
 	}
-	d.mu.Unlock()
 
 	klog.Infof("forcibly close %d connections on %s for %s dialer", len(targetConns), address, d.name)
 	for _, conn := range targetConns {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig network
#### What this PR does / why we need it:
In `connrotation.Dialer`, `CloseAll()` and `Close(address)` iterate over and delete elements from connection tracking maps outside of `d.mu.Lock()`. Meanwhile, `closableConn.Close()` mutates `d.addrConns[c.addr]` under `d.mu.Lock()`. Under concurrent connection activity and rotation, this causes a data race (`concurrent map iteration and map write`), which can lead to YurtHub panics/crashes.
This PR fixes the data race by snapshotting the tracked connections into local slices inside `d.mu.Lock()` and closing the connection handles outside the critical section without mutating shared maps.
#### Which issue(s) this PR fixes:
Fixes #
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
```release-note
Fixed a concurrent map access data race in YurtHub connection rotation dialer.