### PR TITLE
fix(hack): update ginkgo to v2.28.1 and fix strict flag parsing for e2e build

### DIFF
--- a/hack/make-rules/local-up-openyurt.sh
+++ b/hack/make-rules/local-up-openyurt.sh
@@ -120,8 +120,8 @@ function build_e2e_binary() {
       fi
     done
 
-    ginkgo build $YURT_ROOT/test/e2e \
-    --gcflags "${gcflags:-}" ${goflags} --ldflags "${goldflags}"
+    ginkgo build --gcflags "${gcflags:-}" --ldflags "${goldflags}" $YURT_ROOT/test/e2e
+
 }
 
 function local_up_openyurt {

--- a/hack/make-rules/run-e2e-tests.sh
+++ b/hack/make-rules/run-e2e-tests.sh
@@ -67,8 +67,8 @@ function build_e2e_binary() {
       fi
     done
 
-    ginkgo build $YURT_ROOT/test/e2e \
-    --gcflags "${gcflags:-}" ${goflags} --ldflags "${goldflags}"
+    ginkgo build --gcflags "${gcflags:-}" --ldflags "${goldflags}" $YURT_ROOT/test/e2e
+
 }
 
 # run e2e tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR synchronizes the Ginkgo CLI version used in the build scripts with the version defined in `go.mod` (upgrading from `v2.22.2` to `v2.28.1`). Additionally, it updates the `ginkgo build` command syntax in `local-up-openyurt.sh` and `run-e2e-tests.sh` to move build flags (`--gcflags`, `--ldflags`) before the package path argument. This ensures compatibility with the stricter POSIX flag parsing enforced by newer Ginkgo CLI versions.

#### Which issue(s) this PR fixes:
Fixes #2673 

#### Special notes for your reviewer:
This change was verified locally on a WSL2 environment. Running `make local-up-openyurt` now successfully builds the e2e binary and deploys the test cluster without encountering the previous Ginkgo CLI version mismatch or argument parsing errors.

#### Does this PR introduce a user-facing change?
No
```release-note
fix(hack): update Ginkgo CLI version to v2.28.1 and correct build flag ordering in hack scripts to resolve local build failures.
