### PR TITLE
fix: prevent watch response goroutine leak when client disconnects

### DIFF
--- a/pkg/yurthub/filter/responsefilter/filter.go
+++ b/pkg/yurthub/filter/responsefilter/filter.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,6 +47,8 @@ type filterReadCloser struct {
 	isList       bool
 	ownerName    string
 	stopCh       <-chan struct{}
+	closeCh      chan struct{}
+	closeOnce    sync.Once
 }
 
 // newFilterReadCloser create an filterReadCloser object
@@ -75,6 +78,7 @@ func newFilterReadCloser(
 		isList:       info.Verb == "list",
 		ownerName:    ownerName,
 		stopCh:       stopCh,
+		closeCh:      make(chan struct{}),
 	}
 
 	if frc.isWatch {
@@ -113,6 +117,9 @@ func (frc *filterReadCloser) Read(p []byte) (int, error) {
 
 // Close will close readers
 func (frc *filterReadCloser) Close() error {
+	frc.closeOnce.Do(func() {
+		close(frc.closeCh)
+	})
 	if frc.filterCache != nil {
 		frc.filterCache.Reset()
 	}
@@ -198,7 +205,13 @@ func (frc *filterReadCloser) streamResponseFilter(rc io.ReadCloser, ch chan *byt
 			klog.Errorf("could not encode resource in StreamResponseFilter of %s, %v", frc.ownerName, err)
 			return err
 		}
-		ch <- buf
+		select {
+		case ch <- buf:
+		case <-frc.stopCh:
+			return nil
+		case <-frc.closeCh:
+			return nil
+		}
 	}
 }
 

--- a/pkg/yurthub/filter/responsefilter/filter_leak_test.go
+++ b/pkg/yurthub/filter/responsefilter/filter_leak_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsefilter
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
+)
+
+func encodeWatchEvents(t *testing.T, s *serializer.Serializer, n int) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	for i := 0; i < n; i++ {
+		event := &watch.Event{
+			Type: watch.Added,
+			Object: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+			},
+		}
+		if _, err := s.WatchEncode(buf, event); err != nil {
+			t.Fatalf("failed to encode watch event: %v", err)
+		}
+	}
+	return buf
+}
+
+func newWatchFilterReadCloser(rc io.ReadCloser, s *serializer.Serializer, stopCh <-chan struct{}) *filterReadCloser {
+	return &filterReadCloser{
+		rc:           rc,
+		watchDataCh:  make(chan *bytes.Buffer),
+		filterCache:  new(bytes.Buffer),
+		serializer:   s,
+		objectFilter: &nopObjectHandler{},
+		isWatch:      true,
+		ownerName:    "foo",
+		stopCh:       stopCh,
+		closeCh:      make(chan struct{}),
+	}
+}
+
+func TestStreamResponseFilterExitsOnClose(t *testing.T) {
+	sm := serializer.NewSerializerManager()
+	s := sm.CreateSerializer("application/json", "", "v1", "services")
+	if s == nil {
+		t.Fatal("failed to create serializer")
+	}
+
+	frc := newWatchFilterReadCloser(io.NopCloser(encodeWatchEvents(t, s, 5)), s, make(chan struct{}))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- frc.streamResponseFilter(frc.rc, frc.watchDataCh)
+	}()
+
+	<-frc.watchDataCh
+
+	if err := frc.Close(); err != nil {
+		t.Fatalf("failed to close filter read closer: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil error after Close, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamResponseFilter goroutine leaked: still blocked after Close")
+	}
+}
+
+func TestStreamResponseFilterExitsOnStopCh(t *testing.T) {
+	sm := serializer.NewSerializerManager()
+	s := sm.CreateSerializer("application/json", "", "v1", "services")
+	if s == nil {
+		t.Fatal("failed to create serializer")
+	}
+
+	stopCh := make(chan struct{})
+	frc := newWatchFilterReadCloser(io.NopCloser(encodeWatchEvents(t, s, 5)), s, stopCh)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- frc.streamResponseFilter(frc.rc, frc.watchDataCh)
+	}()
+
+	<-frc.watchDataCh
+	close(stopCh)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil error after stopCh closed, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamResponseFilter goroutine leaked: still blocked after stopCh closed")
+	}
+}
+
+func TestStreamResponseFilterDeliversAllEventsThenEOF(t *testing.T) {
+	sm := serializer.NewSerializerManager()
+	s := sm.CreateSerializer("application/json", "", "v1", "services")
+	if s == nil {
+		t.Fatal("failed to create serializer")
+	}
+
+	frc := newWatchFilterReadCloser(io.NopCloser(encodeWatchEvents(t, s, 3)), s, make(chan struct{}))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- frc.streamResponseFilter(frc.rc, frc.watchDataCh)
+	}()
+
+	count := 0
+	for range frc.watchDataCh {
+		count++
+	}
+
+	if count != 3 {
+		t.Fatalf("expected 3 watch events delivered, got %d", count)
+	}
+
+	select {
+	case err := <-done:
+		if err != io.EOF {
+			t.Fatalf("expected io.EOF after stream ends, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamResponseFilter did not return after normal stream end")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`streamResponseFilter` runs in a background goroutine per watch request. For every decoded event it does an unconditional `ch <- buf` on the unbuffered `watchDataCh`. When a watch client disconnects mid-stream, `Read()` stops draining the channel, so the goroutine parks on that send and never comes back. That is one leaked goroutine per disconnect, and in edge setups where clients reconnect often it grows without bound.

The only cancellation signal wired near the send site is `frc.stopCh`, but that is the load balancer's stop channel (`loadbalancer.go:390` passes `lb.stopCh`). It closes when yurthub shuts down, not when a single client goes away, so selecting on it alone does not release the goroutine on the disconnect path.

The reverse proxy sets `resp.Body = filterRc` and calls `Close()` on it when the client disconnects. So this PR makes `Close()` the disconnect signal: it closes a per-request channel, and the send site selects on both `stopCh` and that channel. Either a shutdown or a client disconnect now unblocks the goroutine and it returns cleanly.

#### Which issue(s) this PR fixes:
Fixes #2671

#### Special notes for your reviewer:
- The send in `streamResponseFilter` is the only place the goroutine can block, so guarding just that site is enough.
- `closeCh` is closed via `sync.Once`, so repeated `Close()` calls stay safe.
- Added `filter_leak_test.go` with three cases: the goroutine exits when the consumer stops reading and `Close()` is called, it exits when `stopCh` is closed, and normal streaming still delivers every event and ends with `io.EOF`. I checked that the disconnect test blocks and fails on the unpatched code and passes with the fix.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
