### PR TITLE
fix(yurtmanager): initialize Annotations before setting AdditionalNodepools in platformadmin conversion webhook

### DIFF
--- a/pkg/apis/iot/v1alpha2/platformadmin_conversion.go
+++ b/pkg/apis/iot/v1alpha2/platformadmin_conversion.go
@@ -77,6 +77,9 @@ func (c *PlatformAdmin) ConvertFrom(srcRaw conversion.Hub) error {
 		if err != nil {
 			return err
 		}
+		if c.Annotations == nil {
+			c.Annotations = make(map[string]string)
+		}
 		c.Annotations["AdditionalNodepools"] = string(additionalNodePoolsJSON)
 	}
 	c.Spec.Platform = PlatformAdminPlatformEdgeX

--- a/pkg/apis/iot/v1alpha2/platformadmin_conversion_test.go
+++ b/pkg/apis/iot/v1alpha2/platformadmin_conversion_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an AS IS BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openyurtio/openyurt/pkg/apis/iot/v1beta1"
+)
+
+func TestPlatformAdminConvertFrom(t *testing.T) {
+	cases := map[string]struct {
+		src            *v1beta1.PlatformAdmin
+		wantErr        bool
+		wantPoolName   string
+		wantAdditional []string
+	}{
+		"multiple nodepools with nil annotations": {
+			src: &v1beta1.PlatformAdmin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sample",
+				},
+				Spec: v1beta1.PlatformAdminSpec{
+					NodePools: []string{"nodepool-a", "nodepool-b", "nodepool-c"},
+				},
+			},
+			wantErr:        false,
+			wantPoolName:   "nodepool-a",
+			wantAdditional: []string{"nodepool-b", "nodepool-c"},
+		},
+		"multiple nodepools with existing annotations": {
+			src: &v1beta1.PlatformAdmin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sample",
+					Annotations: map[string]string{
+						"existing": "value",
+					},
+				},
+				Spec: v1beta1.PlatformAdminSpec{
+					NodePools: []string{"nodepool-a", "nodepool-b"},
+				},
+			},
+			wantErr:        false,
+			wantPoolName:   "nodepool-a",
+			wantAdditional: []string{"nodepool-b"},
+		},
+		"single nodepool with nil annotations": {
+			src: &v1beta1.PlatformAdmin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sample",
+				},
+				Spec: v1beta1.PlatformAdminSpec{
+					NodePools: []string{"nodepool-a"},
+				},
+			},
+			wantErr:      false,
+			wantPoolName: "nodepool-a",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dst := &PlatformAdmin{}
+			err := dst.ConvertFrom(tc.src)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if dst.Spec.PoolName != tc.wantPoolName {
+				t.Errorf("PoolName = %q, want %q", dst.Spec.PoolName, tc.wantPoolName)
+			}
+
+			if len(tc.wantAdditional) == 0 {
+				return
+			}
+
+			raw, ok := dst.Annotations["AdditionalNodepools"]
+			if !ok {
+				t.Fatalf("expected AdditionalNodepools annotation to be set")
+			}
+
+			var got []string
+			if err := json.Unmarshal([]byte(raw), &got); err != nil {
+				t.Fatalf("failed to unmarshal AdditionalNodepools annotation: %v", err)
+			}
+
+			if len(got) != len(tc.wantAdditional) {
+				t.Fatalf("AdditionalNodepools = %v, want %v", got, tc.wantAdditional)
+			}
+			for i := range got {
+				if got[i] != tc.wantAdditional[i] {
+					t.Errorf("AdditionalNodepools[%d] = %q, want %q", i, got[i], tc.wantAdditional[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig iot

#### What this PR does / why we need it:

Fixes a potential runtime panic in the `PlatformAdmin` conversion webhook (`pkg/apis/iot/v1alpha2/platformadmin_conversion.go`).

`ConvertFrom` copies `ObjectMeta` straight from the stored `v1beta1.PlatformAdmin` object, then, when `Spec.NodePools` has more than one entry, writes the extra entries into `c.Annotations["AdditionalNodepools"]`:

```go
c.ObjectMeta = srcRawV1beta1.ObjectMeta
...
if len(srcRawV1beta1.Spec.NodePools) > 1 {
    additionalNodePools := srcRawV1beta1.Spec.NodePools[1:]
    additionalNodePoolsJSON, err := json.Marshal(additionalNodePools)
    if err != nil {
        return err
    }
    c.Annotations["AdditionalNodepools"] = string(additionalNodePoolsJSON) // <-- PANIC if c.Annotations is nil
}
```

If the stored `v1beta1.PlatformAdmin` has no annotations, `c.Annotations` is `nil`, and writing to a nil map panics with `panic: assignment to entry in nil map`. This conversion runs on a normal, unprivileged read path (e.g. `kubectl get platformadmin.v1alpha2.iot.openyurt.io`), so any multi-nodepool `PlatformAdmin` created without annotations triggers this every time it's read at v1alpha2.

The sibling `NodePool` conversion webhooks (`pkg/apis/apps/v1alpha1/nodepool_conversion.go`, `pkg/apis/apps/v1beta1/nodepool_conversion.go`) already guard the identical pattern with a nil-check before writing into `Annotations`; this webhook was missed when that guard was applied elsewhere.

This PR initializes `c.Annotations` before the write, mirroring the guard used in those webhooks.

#### Which issue(s) this PR fixes:

Fixes #2691

#### Special notes for your reviewer:

- Added `platformadmin_conversion_test.go` covering `ConvertFrom` for: multiple nodepools with nil annotations (the panic case), multiple nodepools with existing annotations, and a single nodepool with nil annotations.
- All unit tests pass.

#### Does this PR introduce a user-facing change?

```release-note
Fix PlatformAdmin conversion webhook to initialize the Annotations map before setting the AdditionalNodepools annotation, preventing a runtime panic when converting a multi-nodepool PlatformAdmin object with no existing annotations.
```
