### PR TITLE
fix: add missing return after WriteErr in getPodList (fixes #2693)

### DIFF
--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -35,6 +35,9 @@ import (
 	otautil "github.com/openyurtio/openyurt/pkg/yurthub/otaupdate/util"
 )
 
+// encodePodsFn is a variable for testability — allows overriding EncodePods in tests.
+var encodePodsFn = otautil.EncodePods
+
 // RunYurtHubServers is used to start up all servers for yurthub
 func RunYurtHubServers(cfg *config.YurtHubConfiguration,
 	proxyHandler http.Handler,
@@ -142,7 +145,7 @@ func getPodList(sharedFactory informers.SharedInformerFactory) http.Handler {
 			pl.Items = append(pl.Items, *podList[i])
 		}
 
-		data, err := otautil.EncodePods(pl)
+		data, err := encodePodsFn(pl)
 		if err != nil {
 			klog.Errorf("Encode pod list failed, %v", err)
 			otautil.WriteErr(w, "Encode pod list failed", http.StatusInternalServerError)

--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -127,7 +127,6 @@ func readyz(cfg *config.YurtHubConfiguration) http.Handler {
 		fmt.Fprintf(w, "OK")
 	})
 }
-
 func getPodList(sharedFactory informers.SharedInformerFactory) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		podLister := sharedFactory.Core().V1().Pods().Lister()
@@ -137,6 +136,7 @@ func getPodList(sharedFactory informers.SharedInformerFactory) http.Handler {
 			otautil.WriteErr(w, "Get pods key failed", http.StatusInternalServerError)
 			return
 		}
+
 		pl := new(corev1.PodList)
 		for i := range podList {
 			pl.Items = append(pl.Items, *podList[i])
@@ -146,6 +146,7 @@ func getPodList(sharedFactory informers.SharedInformerFactory) http.Handler {
 		if err != nil {
 			klog.Errorf("Encode pod list failed, %v", err)
 			otautil.WriteErr(w, "Encode pod list failed", http.StatusInternalServerError)
+			return
 		}
 		otautil.WriteJSONResponse(w, data)
 	})

--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -35,7 +35,6 @@ import (
 	otautil "github.com/openyurtio/openyurt/pkg/yurthub/otaupdate/util"
 )
 
-// encodePodsFn is a variable for testability — allows overriding EncodePods in tests.
 var encodePodsFn = otautil.EncodePods
 
 // RunYurtHubServers is used to start up all servers for yurthub

--- a/pkg/yurthub/server/server_test.go
+++ b/pkg/yurthub/server/server_test.go
@@ -1,0 +1,302 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"reflect"
+	"k8s.io/client-go/informers"
+	admissionregistration "k8s.io/client-go/informers/admissionregistration"
+	apiserverinternal "k8s.io/client-go/informers/apiserverinternal"
+	apps "k8s.io/client-go/informers/apps"
+	autoscaling "k8s.io/client-go/informers/autoscaling"
+	batch "k8s.io/client-go/informers/batch"
+	certificates "k8s.io/client-go/informers/certificates"
+	coordination "k8s.io/client-go/informers/coordination"
+	coreinformers "k8s.io/client-go/informers/core"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	discovery "k8s.io/client-go/informers/discovery"
+	events "k8s.io/client-go/informers/events"
+	extensions "k8s.io/client-go/informers/extensions"
+	flowcontrol "k8s.io/client-go/informers/flowcontrol"
+	internalinterfaces "k8s.io/client-go/informers/internalinterfaces"
+	networking "k8s.io/client-go/informers/networking"
+	node "k8s.io/client-go/informers/node"
+	policy "k8s.io/client-go/informers/policy"
+	rbac "k8s.io/client-go/informers/rbac"
+	resource "k8s.io/client-go/informers/resource"
+	scheduling "k8s.io/client-go/informers/scheduling"
+	storage "k8s.io/client-go/informers/storage"
+	storagemigration "k8s.io/client-go/informers/storagemigration"
+	"k8s.io/client-go/kubernetes/fake"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	otautil "github.com/openyurtio/openyurt/pkg/yurthub/otaupdate/util"
+)
+
+// TestGetPodList_Success tests the getPodList handler when listing pods succeeds.
+func TestGetPodList_Success(t *testing.T) {
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+
+	fakeClientset := fake.NewSimpleClientset(pod1, pod2)
+	factory := informers.NewSharedInformerFactory(fakeClientset, 0)
+
+	// Pre-register the pod informer so it's available after Start
+	factory.Core().V1().Pods().Informer()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	handler := getPodList(factory)
+
+	req := httptest.NewRequest(http.MethodGet, "/pods", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	// Decode both expected and actual to compare structurally (order-independent)
+	var got, expected corev1.PodList
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	expectedPodList := &corev1.PodList{}
+	for _, p := range []*corev1.Pod{pod1, pod2} {
+		expectedPodList.Items = append(expectedPodList.Items, *p)
+	}
+	expectedData, err := otautil.EncodePods(expectedPodList)
+	if err != nil {
+		t.Fatalf("Failed to encode expected pod list: %v", err)
+	}
+	if err := json.Unmarshal(expectedData, &expected); err != nil {
+		t.Fatalf("Failed to decode expected: %v", err)
+	}
+
+	if len(got.Items) != len(expected.Items) {
+		t.Errorf("Expected %d pods, got %d", len(expected.Items), len(got.Items))
+	}
+	// Verify each pod from expected appears in response (order-independent)
+	gotByName := make(map[string]bool)
+	for _, p := range got.Items {
+		gotByName[p.Name] = true
+	}
+	for _, p := range expected.Items {
+		if !gotByName[p.Name] {
+			t.Errorf("Expected pod %s not found in response", p.Name)
+		}
+	}
+}
+
+// TestGetPodList_Success_EmptyList tests getPodList when there are no pods.
+
+// TestGetPodList_ListError tests that getPodList returns 500 when listing pods fails.
+func TestGetPodList_ListError(t *testing.T) {
+	factory := &mockFactory{
+		core: &mockCore{
+			v1iface: &mockV1Interface{
+				podInformer: &mockPodInformer{
+					lister: &mockPodLister{
+						err: fmt.Errorf("list error"),
+					},
+				},
+			},
+		},
+	}
+
+	handler := getPodList(factory)
+
+	req := httptest.NewRequest(http.MethodGet, "/pods", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), "Get pods key failed") {
+		t.Errorf("Expected body to contain 'Get pods key failed', got: %s", w.Body.String())
+	}
+}
+
+// TestGetPodList_EncodeError tests that getPodList returns 500 when encoding pods fails.
+func TestGetPodList_EncodeError(t *testing.T) {
+	defer func(old func(*corev1.PodList) ([]byte, error)) {
+		encodePodsFn = old
+	}(encodePodsFn)
+
+	encodePodsFn = func(pl *corev1.PodList) ([]byte, error) {
+		return nil, fmt.Errorf("encode error")
+	}
+
+	factory := &mockFactory{
+		core: &mockCore{
+			v1iface: &mockV1Interface{
+				podInformer: &mockPodInformer{
+					lister: &mockPodLister{
+						pods: []*corev1.Pod{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "pod1",
+									Namespace: "default",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	handler := getPodList(factory)
+	req := httptest.NewRequest(http.MethodGet, "/pods", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), "Encode pod list failed") {
+		t.Errorf("Expected body to contain 'Encode pod list failed', got: %s", w.Body.String())
+	}
+}
+
+// --- Mock implementations ---
+
+// mockPodLister implements listersv1.PodLister
+type mockPodLister struct {
+	pods []*corev1.Pod
+	err  error
+}
+
+func (m *mockPodLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
+	return m.pods, m.err
+}
+
+func (m *mockPodLister) Pods(namespace string) listersv1.PodNamespaceLister {
+	return nil
+}
+
+// mockPodInformer implements corev1informers.PodInformer
+type mockPodInformer struct {
+	lister listersv1.PodLister
+}
+
+func (m *mockPodInformer) Informer() cache.SharedIndexInformer {
+	return nil
+}
+
+func (m *mockPodInformer) Lister() listersv1.PodLister {
+	return m.lister
+}
+
+// mockV1Interface implements corev1informers.Interface
+type mockV1Interface struct {
+	podInformer corev1informers.PodInformer
+}
+
+func (m *mockV1Interface) Pods() corev1informers.PodInformer {
+	return m.podInformer
+}
+func (m *mockV1Interface) ComponentStatuses() corev1informers.ComponentStatusInformer {
+	return nil
+}
+func (m *mockV1Interface) ConfigMaps() corev1informers.ConfigMapInformer     { return nil }
+func (m *mockV1Interface) Endpoints() corev1informers.EndpointsInformer       { return nil }
+func (m *mockV1Interface) Events() corev1informers.EventInformer              { return nil }
+func (m *mockV1Interface) LimitRanges() corev1informers.LimitRangeInformer    { return nil }
+func (m *mockV1Interface) Namespaces() corev1informers.NamespaceInformer      { return nil }
+func (m *mockV1Interface) Nodes() corev1informers.NodeInformer                { return nil }
+func (m *mockV1Interface) PersistentVolumes() corev1informers.PersistentVolumeInformer {
+	return nil
+}
+func (m *mockV1Interface) PersistentVolumeClaims() corev1informers.PersistentVolumeClaimInformer {
+	return nil
+}
+func (m *mockV1Interface) PodTemplates() corev1informers.PodTemplateInformer { return nil }
+func (m *mockV1Interface) ReplicationControllers() corev1informers.ReplicationControllerInformer {
+	return nil
+}
+func (m *mockV1Interface) ResourceQuotas() corev1informers.ResourceQuotaInformer { return nil }
+func (m *mockV1Interface) Secrets() corev1informers.SecretInformer             { return nil }
+func (m *mockV1Interface) Services() corev1informers.ServiceInformer           { return nil }
+func (m *mockV1Interface) ServiceAccounts() corev1informers.ServiceAccountInformer {
+	return nil
+}
+
+// mockCore implements coreinformers.Interface
+type mockCore struct {
+	v1iface corev1informers.Interface
+}
+
+func (m *mockCore) V1() corev1informers.Interface {
+	return m.v1iface
+}
+
+// mockFactory implements informers.SharedInformerFactory
+type mockFactory struct {
+	core coreinformers.Interface
+}
+
+func (m *mockFactory) Core() coreinformers.Interface                  { return m.core }
+func (m *mockFactory) Start(stopCh <-chan struct{})                   {}
+func (m *mockFactory) Shutdown()                                      {}
+func (m *mockFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	return nil
+}
+func (m *mockFactory) ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	return nil, nil
+}
+func (m *mockFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
+	return nil
+}
+func (m *mockFactory) Admissionregistration() admissionregistration.Interface { return nil }
+func (m *mockFactory) Internal() apiserverinternal.Interface                  { return nil }
+func (m *mockFactory) Apps() apps.Interface                                   { return nil }
+func (m *mockFactory) Autoscaling() autoscaling.Interface                     { return nil }
+func (m *mockFactory) Batch() batch.Interface                                 { return nil }
+func (m *mockFactory) Certificates() certificates.Interface                   { return nil }
+func (m *mockFactory) Coordination() coordination.Interface                   { return nil }
+func (m *mockFactory) Discovery() discovery.Interface                         { return nil }
+func (m *mockFactory) Events() events.Interface                               { return nil }
+func (m *mockFactory) Extensions() extensions.Interface                       { return nil }
+func (m *mockFactory) Flowcontrol() flowcontrol.Interface                     { return nil }
+func (m *mockFactory) Networking() networking.Interface                       { return nil }
+func (m *mockFactory) Node() node.Interface                                   { return nil }
+func (m *mockFactory) Policy() policy.Interface                               { return nil }
+func (m *mockFactory) Rbac() rbac.Interface                                   { return nil }
+func (m *mockFactory) Resource() resource.Interface                           { return nil }
+func (m *mockFactory) Scheduling() scheduling.Interface                       { return nil }
+func (m *mockFactory) Storage() storage.Interface                             { return nil }
+func (m *mockFactory) Storagemigration() storagemigration.Interface           { return nil }

--- a/pkg/yurthub/server/server_test.go
+++ b/pkg/yurthub/server/server_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (
@@ -5,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -13,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"reflect"
 	"k8s.io/client-go/informers"
 	admissionregistration "k8s.io/client-go/informers/admissionregistration"
 	apiserverinternal "k8s.io/client-go/informers/apiserverinternal"
@@ -44,7 +60,6 @@ import (
 	otautil "github.com/openyurtio/openyurt/pkg/yurthub/otaupdate/util"
 )
 
-// TestGetPodList_Success tests the getPodList handler when listing pods succeeds.
 func TestGetPodList_Success(t *testing.T) {
 	pod1 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -68,7 +83,6 @@ func TestGetPodList_Success(t *testing.T) {
 	fakeClientset := fake.NewSimpleClientset(pod1, pod2)
 	factory := informers.NewSharedInformerFactory(fakeClientset, 0)
 
-	// Pre-register the pod informer so it's available after Start
 	factory.Core().V1().Pods().Informer()
 
 	stopCh := make(chan struct{})
@@ -86,7 +100,6 @@ func TestGetPodList_Success(t *testing.T) {
 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
 	}
 
-	// Decode both expected and actual to compare structurally (order-independent)
 	var got, expected corev1.PodList
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("Failed to decode response: %v", err)
@@ -106,7 +119,6 @@ func TestGetPodList_Success(t *testing.T) {
 	if len(got.Items) != len(expected.Items) {
 		t.Errorf("Expected %d pods, got %d", len(expected.Items), len(got.Items))
 	}
-	// Verify each pod from expected appears in response (order-independent)
 	gotByName := make(map[string]bool)
 	for _, p := range got.Items {
 		gotByName[p.Name] = true
@@ -118,9 +130,6 @@ func TestGetPodList_Success(t *testing.T) {
 	}
 }
 
-// TestGetPodList_Success_EmptyList tests getPodList when there are no pods.
-
-// TestGetPodList_ListError tests that getPodList returns 500 when listing pods fails.
 func TestGetPodList_ListError(t *testing.T) {
 	factory := &mockFactory{
 		core: &mockCore{
@@ -149,7 +158,6 @@ func TestGetPodList_ListError(t *testing.T) {
 	}
 }
 
-// TestGetPodList_EncodeError tests that getPodList returns 500 when encoding pods fails.
 func TestGetPodList_EncodeError(t *testing.T) {
 	defer func(old func(*corev1.PodList) ([]byte, error)) {
 		encodePodsFn = old
@@ -192,9 +200,6 @@ func TestGetPodList_EncodeError(t *testing.T) {
 	}
 }
 
-// --- Mock implementations ---
-
-// mockPodLister implements listersv1.PodLister
 type mockPodLister struct {
 	pods []*corev1.Pod
 	err  error
@@ -208,7 +213,6 @@ func (m *mockPodLister) Pods(namespace string) listersv1.PodNamespaceLister {
 	return nil
 }
 
-// mockPodInformer implements corev1informers.PodInformer
 type mockPodInformer struct {
 	lister listersv1.PodLister
 }
@@ -221,7 +225,6 @@ func (m *mockPodInformer) Lister() listersv1.PodLister {
 	return m.lister
 }
 
-// mockV1Interface implements corev1informers.Interface
 type mockV1Interface struct {
 	podInformer corev1informers.PodInformer
 }
@@ -232,12 +235,12 @@ func (m *mockV1Interface) Pods() corev1informers.PodInformer {
 func (m *mockV1Interface) ComponentStatuses() corev1informers.ComponentStatusInformer {
 	return nil
 }
-func (m *mockV1Interface) ConfigMaps() corev1informers.ConfigMapInformer     { return nil }
-func (m *mockV1Interface) Endpoints() corev1informers.EndpointsInformer       { return nil }
-func (m *mockV1Interface) Events() corev1informers.EventInformer              { return nil }
-func (m *mockV1Interface) LimitRanges() corev1informers.LimitRangeInformer    { return nil }
-func (m *mockV1Interface) Namespaces() corev1informers.NamespaceInformer      { return nil }
-func (m *mockV1Interface) Nodes() corev1informers.NodeInformer                { return nil }
+func (m *mockV1Interface) ConfigMaps() corev1informers.ConfigMapInformer   { return nil }
+func (m *mockV1Interface) Endpoints() corev1informers.EndpointsInformer    { return nil }
+func (m *mockV1Interface) Events() corev1informers.EventInformer           { return nil }
+func (m *mockV1Interface) LimitRanges() corev1informers.LimitRangeInformer { return nil }
+func (m *mockV1Interface) Namespaces() corev1informers.NamespaceInformer   { return nil }
+func (m *mockV1Interface) Nodes() corev1informers.NodeInformer             { return nil }
 func (m *mockV1Interface) PersistentVolumes() corev1informers.PersistentVolumeInformer {
 	return nil
 }
@@ -249,13 +252,12 @@ func (m *mockV1Interface) ReplicationControllers() corev1informers.ReplicationCo
 	return nil
 }
 func (m *mockV1Interface) ResourceQuotas() corev1informers.ResourceQuotaInformer { return nil }
-func (m *mockV1Interface) Secrets() corev1informers.SecretInformer             { return nil }
-func (m *mockV1Interface) Services() corev1informers.ServiceInformer           { return nil }
+func (m *mockV1Interface) Secrets() corev1informers.SecretInformer               { return nil }
+func (m *mockV1Interface) Services() corev1informers.ServiceInformer             { return nil }
 func (m *mockV1Interface) ServiceAccounts() corev1informers.ServiceAccountInformer {
 	return nil
 }
 
-// mockCore implements coreinformers.Interface
 type mockCore struct {
 	v1iface corev1informers.Interface
 }
@@ -264,14 +266,13 @@ func (m *mockCore) V1() corev1informers.Interface {
 	return m.v1iface
 }
 
-// mockFactory implements informers.SharedInformerFactory
 type mockFactory struct {
 	core coreinformers.Interface
 }
 
-func (m *mockFactory) Core() coreinformers.Interface                  { return m.core }
-func (m *mockFactory) Start(stopCh <-chan struct{})                   {}
-func (m *mockFactory) Shutdown()                                      {}
+func (m *mockFactory) Core() coreinformers.Interface { return m.core }
+func (m *mockFactory) Start(stopCh <-chan struct{})  {}
+func (m *mockFactory) Shutdown()                     {}
 func (m *mockFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:

Fixes a bug in getPodList where the function continued executing after writing an HTTP error response via WriteErr in the encode error path, causing a duplicate header write and incorrect response body. Adds the missing return statement after the encode failure path.

Also introduces an encodePodsFn variable for testability and adds comprehensive unit tests achieving 100% coverage of getPodList.

#### Which issue(s) this PR fixes:

Fixes #2693

#### Special notes for your reviewer:

- The encode error return is tested by temporarily overriding encodePodsFn in the test to return an error.
- The list error path already had its return statement but is also tested via a mock PodLister.
- Tests pass: go test ./pkg/yurthub/server/ -v

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
