### PR TITLE
bug: fix missing return after WriteErr in getPodList

### DIFF
--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -146,6 +146,7 @@ func getPodList(sharedFactory informers.SharedInformerFactory) http.Handler {
 		if err != nil {
 			klog.Errorf("Encode pod list failed, %v", err)
 			otautil.WriteErr(w, "Encode pod list failed", http.StatusInternalServerError)
+			return
 		}
 		otautil.WriteJSONResponse(w, data)
 	})


### PR DESCRIPTION
fixes #2693

added the missing `return` after `otautil.WriteErr` in the `EncodePods` error block. without this, execution was falling through and double-writing to the `ResponseWriter` with a nil body.

matches the behavior of the `podLister.List` error block above it.