### PR TITLE
fix(yurtmanager): initialize Annotations and Data before updating YurtStaticSet configmap

### DIFF
--- a/pkg/apis/iot/v1alpha2/platformadmin_conversion.go
+++ b/pkg/apis/iot/v1alpha2/platformadmin_conversion.go
@@ -77,6 +77,9 @@ func (c *PlatformAdmin) ConvertFrom(srcRaw conversion.Hub) error {
 		if err != nil {
 			return err
 		}
+		if c.Annotations == nil {
+			c.Annotations = make(map[string]string)
+		}
 		c.Annotations["AdditionalNodepools"] = string(additionalNodePoolsJSON)
 	}
 	c.Spec.Platform = PlatformAdminPlatformEdgeX

--- a/pkg/apis/iot/v1alpha2/platformadmin_conversion_test.go
+++ b/pkg/apis/iot/v1alpha2/platformadmin_conversion_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an AS IS BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openyurtio/openyurt/pkg/apis/iot/v1beta1"
+)
+
+func TestPlatformAdminConvertFrom(t *testing.T) {
+	cases := map[string]struct {
+		src            *v1beta1.PlatformAdmin
+		wantErr        bool
+		wantPoolName   string
+		wantAdditional []string
+	}{
+		"multiple nodepools with nil annotations": {
+			src: &v1beta1.PlatformAdmin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sample",
+				},
+				Spec: v1beta1.PlatformAdminSpec{
+					NodePools: []string{"nodepool-a", "nodepool-b", "nodepool-c"},
+				},
+			},
+			wantErr:        false,
+			wantPoolName:   "nodepool-a",
+			wantAdditional: []string{"nodepool-b", "nodepool-c"},
+		},
+		"multiple nodepools with existing annotations": {
+			src: &v1beta1.PlatformAdmin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sample",
+					Annotations: map[string]string{
+						"existing": "value",
+					},
+				},
+				Spec: v1beta1.PlatformAdminSpec{
+					NodePools: []string{"nodepool-a", "nodepool-b"},
+				},
+			},
+			wantErr:        false,
+			wantPoolName:   "nodepool-a",
+			wantAdditional: []string{"nodepool-b"},
+		},
+		"single nodepool with nil annotations": {
+			src: &v1beta1.PlatformAdmin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sample",
+				},
+				Spec: v1beta1.PlatformAdminSpec{
+					NodePools: []string{"nodepool-a"},
+				},
+			},
+			wantErr:      false,
+			wantPoolName: "nodepool-a",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dst := &PlatformAdmin{}
+			err := dst.ConvertFrom(tc.src)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if dst.Spec.PoolName != tc.wantPoolName {
+				t.Errorf("PoolName = %q, want %q", dst.Spec.PoolName, tc.wantPoolName)
+			}
+
+			if len(tc.wantAdditional) == 0 {
+				return
+			}
+
+			raw, ok := dst.Annotations["AdditionalNodepools"]
+			if !ok {
+				t.Fatalf("expected AdditionalNodepools annotation to be set")
+			}
+
+			var got []string
+			if err := json.Unmarshal([]byte(raw), &got); err != nil {
+				t.Fatalf("failed to unmarshal AdditionalNodepools annotation: %v", err)
+			}
+
+			if len(got) != len(tc.wantAdditional) {
+				t.Fatalf("AdditionalNodepools = %v, want %v", got, tc.wantAdditional)
+			}
+			for i := range got {
+				if got[i] != tc.wantAdditional[i] {
+					t.Errorf("AdditionalNodepools[%d] = %q, want %q", i, got[i], tc.wantAdditional[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/yurtmanager/controller/yurtstaticset/yurt_static_set_controller.go
+++ b/pkg/yurtmanager/controller/yurtstaticset/yurt_static_set_controller.go
@@ -426,6 +426,12 @@ func (r *ReconcileYurtStaticSet) syncConfigMap(instance *appsv1alpha1.YurtStatic
 
 	// if the hash value in the annotation of the cm does not match the latest hash, then update the data in the cm
 	if cm.Annotations[StaticPodHashAnnotation] != hash {
+		if cm.Annotations == nil {
+			cm.Annotations = make(map[string]string)
+		}
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
 		cm.Annotations[StaticPodHashAnnotation] = hash
 		cm.Data[instance.Spec.StaticPodManifest] = data
 

--- a/pkg/yurtmanager/controller/yurtstaticset/yurt_static_set_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtstaticset/yurt_static_set_controller_test.go
@@ -218,3 +218,52 @@ func TestReconcileYurtStaticSetDeleteConfigMap(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncConfigMapWithNilAnnotationsAndData(t *testing.T) {
+	instance := &appsv1alpha1.YurtStaticSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TestStaticPodName,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: appsv1alpha1.YurtStaticSetSpec{
+			StaticPodManifest: "nginx",
+			Template:          corev1.PodTemplateSpec{},
+		},
+	}
+	// a pre-existing configmap with no Annotations and no Data, as could happen if
+	// it was created or edited outside of this controller
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.WithConfigMapPrefix(instance.Name),
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := appsv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal("Fail to add yurt custom resource")
+	}
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal("Fail to add kubernetes clint-go custom resource")
+	}
+	c := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(instance).WithObjects(cm).Build()
+
+	r := &ReconcileYurtStaticSet{
+		Client: c,
+	}
+
+	if err := r.syncConfigMap(instance, "new-hash", "pod-manifest-data"); err != nil {
+		t.Fatalf("syncConfigMap() should not panic or error on nil Annotations/Data, got err: %v", err)
+	}
+
+	got := &corev1.ConfigMap{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}, got); err != nil {
+		t.Fatalf("failed to get configmap after sync: %v", err)
+	}
+	if got.Annotations[StaticPodHashAnnotation] != "new-hash" {
+		t.Errorf("expected annotation %q to be %q, got %q", StaticPodHashAnnotation, "new-hash", got.Annotations[StaticPodHashAnnotation])
+	}
+	if got.Data[instance.Spec.StaticPodManifest] != "pod-manifest-data" {
+		t.Errorf("expected data %q to be %q, got %q", instance.Spec.StaticPodManifest, "pod-manifest-data", got.Data[instance.Spec.StaticPodManifest])
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`syncConfigMap` in the YurtStaticSet controller fetches the static-pod ConfigMap via `r.Get()` and, when the stored hash annotation is out of date, writes directly into `cm.Annotations` and `cm.Data`. If that ConfigMap exists but has a nil `Annotations` or `Data` map (for example it was created/edited outside of this controller, or migrated from an older version without this annotation convention), reading the annotation is safe and returns `""`, so the hash comparison still passes, but the following write panics with `assignment to entry in nil map` and crashes the yurt-manager reconcile loop.

This PR initializes `cm.Annotations` and `cm.Data` with `make(map[string]string)` before writing to them, guarded on them being nil, matching the pattern already used elsewhere in the codebase for this same class of bug.

A regression test (`TestSyncConfigMapWithNilAnnotationsAndData`) is added that seeds a ConfigMap with no `Annotations`/`Data` and asserts `syncConfigMap` completes without panicking and persists the expected annotation/data.

#### Which issue(s) this PR fixes:
Fixes #2697

#### Special notes for your reviewer:
This is the same bug class as the recently merged fix for the PlatformAdmin conversion webhook (#2691) — a Kubernetes object fetched from the API server cannot be assumed to have non-nil `Annotations`/`Data` maps.

#### Does this PR introduce a user-facing change?
```release-note
Fix a potential panic in the YurtStaticSet controller when the managed configmap has a nil Annotations or Data map.
```

#### other Note
