### PR TITLE
Bugfix: restrict webhook certificate and private key file permissions

### DIFF
--- a/pkg/yurtmanager/webhook/util/writer/fs.go
+++ b/pkg/yurtmanager/webhook/util/writer/fs.go
@@ -30,6 +30,15 @@ import (
 
 const (
 	FsCertWriter = "fs"
+
+	// keyFileMode is the mode used for private key material. Private keys are
+	// readable and writable by the owner only.
+	keyFileMode int32 = 0600
+	// certFileMode is the mode used for certificates, which are public material.
+	certFileMode int32 = 0644
+	// certDirMode is the mode used for the directory holding the certificates. It
+	// matches the mode the atomic writer already applies to its own data directory.
+	certDirMode os.FileMode = 0755
 )
 
 // fsCertWriter provisions the certificate by reading and writing to the filesystem.
@@ -122,8 +131,7 @@ func prepareToWrite(dir string) error {
 	switch {
 	case os.IsNotExist(err):
 		klog.Info("cert directory doesn't exist, creating", "directory", dir)
-		// TODO: figure out if we can reduce the permission. (Now it's 0777)
-		err = os.MkdirAll(dir, 0777)
+		err = os.MkdirAll(dir, certDirMode)
 		if err != nil {
 			return fmt.Errorf("can't create dir: %v", dir)
 		}
@@ -197,31 +205,30 @@ func ensureExist(dir string) error {
 }
 
 func certToProjectionMap(cert *generator.Artifacts) map[string]atomic.FileProjection {
-	// TODO: figure out if we can reduce the permission. (Now it's 0666)
 	return map[string]atomic.FileProjection{
 		CAKeyName: {
 			Data: cert.CAKey,
-			Mode: 0666,
+			Mode: keyFileMode,
 		},
 		CACertName: {
 			Data: cert.CACert,
-			Mode: 0666,
+			Mode: certFileMode,
 		},
 		ServerCertName: {
 			Data: cert.Cert,
-			Mode: 0666,
+			Mode: certFileMode,
 		},
 		ServerCertName2: {
 			Data: cert.Cert,
-			Mode: 0666,
+			Mode: certFileMode,
 		},
 		ServerKeyName: {
 			Data: cert.Key,
-			Mode: 0666,
+			Mode: keyFileMode,
 		},
 		ServerKeyName2: {
 			Data: cert.Key,
-			Mode: 0666,
+			Mode: keyFileMode,
 		},
 	}
 }

--- a/pkg/yurtmanager/webhook/util/writer/fs_test.go
+++ b/pkg/yurtmanager/webhook/util/writer/fs_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package writer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/util/generator"
+)
+
+func TestCertToProjectionMapModes(t *testing.T) {
+	certs := &generator.Artifacts{
+		CAKey:  []byte("ca-key"),
+		CACert: []byte("ca-cert"),
+		Cert:   []byte("cert"),
+		Key:    []byte("key"),
+	}
+
+	projections := certToProjectionMap(certs)
+
+	tests := []struct {
+		name         string
+		file         string
+		expectedMode int32
+	}{
+		{name: "CA private key is not group or world readable", file: CAKeyName, expectedMode: keyFileMode},
+		{name: "server private key is not group or world readable", file: ServerKeyName, expectedMode: keyFileMode},
+		{name: "server private key alias is not group or world readable", file: ServerKeyName2, expectedMode: keyFileMode},
+		{name: "CA certificate is world readable", file: CACertName, expectedMode: certFileMode},
+		{name: "server certificate is world readable", file: ServerCertName, expectedMode: certFileMode},
+		{name: "server certificate alias is world readable", file: ServerCertName2, expectedMode: certFileMode},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projection, ok := projections[tt.file]
+			require.Truef(t, ok, "no projection for %s", tt.file)
+			require.Equalf(t, tt.expectedMode, projection.Mode, "unexpected mode for %s", tt.file)
+		})
+	}
+
+	// The writer calls os.Chmod with these modes explicitly, so they are applied
+	// regardless of the process umask. No file may be writable by group or other.
+	for file, projection := range projections {
+		require.Zerof(t, projection.Mode&0022, "%s is group or world writable (mode %#o)", file, projection.Mode)
+	}
+}
+
+func TestCertDirModeIsNotWorldWritable(t *testing.T) {
+	require.Zerof(t, certDirMode&0022, "cert directory is group or world writable (mode %#o)", certDirMode)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network

#### What this PR does / why we need it:

`certToProjectionMap` in `pkg/yurtmanager/webhook/util/writer/fs.go` assigned mode `0666` to every file it writes, including private key material:

| File | Contents | Mode before |
|---|---|---|
| `ca-key.pem` | CA private key | `0666` |
| `key.pem` | server private key | `0666` |
| `tls.key` | server private key | `0666` |
| `ca-cert.pem`, `cert.pem`, `tls.crt` | certificates | `0666` |

`0666` makes the private keys readable **and writable** by every user on the host. World-writable key material is the more serious half: anything able to write `tls.key` can substitute the key the webhook serves with.

`prepareToWrite` additionally created the certificate directory with `0777`.

These modes are not softened by the process umask. `atomic_writer.go` calls `os.Chmod` explicitly after each write, with a comment stating the intent is to apply the requested mode "no matter what the umask is":

```go
// Chmod is needed because ioutil.WriteFile() ends up calling
// open(2) to create the file, so the final mode used is "mode &
// ~umask". But we want to make sure the specified mode is used
// in the file no matter what the umask is.
err = os.Chmod(fullPath, mode)
```

So an operator cannot tighten this from outside the process.

Both locations carried `TODO` comments recording that the permissive modes were meant to be reduced:

```go
// TODO: figure out if we can reduce the permission. (Now it's 0777)
// TODO: figure out if we can reduce the permission. (Now it's 0666)
```

This PR reduces them.

#### Which issue(s) this PR fixes:

Fixes #2694

#### Proposed changes

- Private keys (`ca-key.pem`, `key.pem`, `tls.key`) → `0600`
- Certificates (`ca-cert.pem`, `cert.pem`, `tls.crt`) → `0644`
- Certificate directory → `0755`, matching the mode `atomic_writer.go` already applies to its own timestamped data directory
- Replaced the magic numbers with named constants (`keyFileMode`, `certFileMode`, `certDirMode`) and removed the two resolved `TODO`s

**On compatibility:** the same process writes and reads these files — `WriteCertsToDir` is called from `webhook_controller.go`, and `fsCertWriter.read()` reads them back — so owner-only access on the keys is sufficient. The certificates stay world-readable at `0644` since they are public material.

#### Testing

The package had no test files. Added `fs_test.go` covering the mode of each projected file, plus an assertion that no projected file and not the containing directory is group- or world-writable, so a future change cannot quietly reintroduce this.

```
$ go test ./pkg/yurtmanager/webhook/util/writer/...
ok      github.com/openyurtio/openyurt/pkg/yurtmanager/webhook/util/writer

$ GOOS=linux GOARCH=amd64 go build ./pkg/yurtmanager/webhook/...
$ go vet ./pkg/yurtmanager/webhook/util/writer/...
```

#### Special notes for your reviewer:

If any deployment relies on a sidecar or a different UID reading these keys from a shared volume, `0600` would break it. I could not find such a consumer in-tree, but you would know of any out-of-tree ones — happy to use `0640` with an appropriate group instead if you prefer.