### PR TITLE
fix(yurthub): use sync.Once to protect filterwatch from concurrent panics

### DIFF
--- a/pkg/yurthub/multiplexer/filterwatch.go
+++ b/pkg/yurthub/multiplexer/filterwatch.go
@@ -17,6 +17,8 @@ limitations under the License.
 package multiplexer
 
 import (
+	"sync"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -26,19 +28,18 @@ import (
 )
 
 type filterWatch struct {
-	source watch.Interface
-	filter filter.ObjectFilter
-	result chan watch.Event
-	done   chan struct{}
+	source   watch.Interface
+	filter   filter.ObjectFilter
+	result   chan watch.Event
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 func (f *filterWatch) Stop() {
-	select {
-	case <-f.done:
-	default:
+	f.stopOnce.Do(func() {
 		close(f.done)
 		f.source.Stop()
-	}
+	})
 }
 
 func newFilterWatch(source watch.Interface, filter filter.ObjectFilter) watch.Interface {


### PR DESCRIPTION
### What this PR does / why we need it
This PR resolves a zero-day concurrency panic in the `yurthub` multiplexer that can completely crash the edge proxy daemon. 

In `pkg/yurthub/multiplexer/filterwatch.go`, the `Stop()` method previously used a naive `select` block to attempt to safely close the `f.done` channel. However, under high concurrency, multiple goroutines could enter the `default` block simultaneously before the channel was actually closed, resulting in a fatal `panic: close of closed channel`.

This PR modernizes the teardown logic by wrapping it in a `sync.Once` block. This guarantees that the underlying watch is stopped and the `done` channel is closed exactly once, making the operation perfectly idempotent and thread-safe regardless of concurrency load.

### Which issue(s) this PR fixes
Fixes #2700

### Special notes for your reviewer
I verified this using standard go data race tools and stress-tested the `Stop()` method. The `sync.Once` drop-in replacement carries virtually zero overhead while strictly enforcing idempotency.