### PR TITLE
Bugfix: make filterWatch.Stop idempotent under concurrent calls

### DIFF
--- a/pkg/yurthub/multiplexer/filterwatch.go
+++ b/pkg/yurthub/multiplexer/filterwatch.go
@@ -17,6 +17,8 @@ limitations under the License.
 package multiplexer
 
 import (
+	"sync"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -26,19 +28,21 @@ import (
 )
 
 type filterWatch struct {
-	source watch.Interface
-	filter filter.ObjectFilter
-	result chan watch.Event
-	done   chan struct{}
+	source   watch.Interface
+	filter   filter.ObjectFilter
+	result   chan watch.Event
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
+// Stop is idempotent and safe for concurrent use. It is called both by the
+// watch consumer and by receive() when the source channel is drained, so the
+// close of done must happen exactly once.
 func (f *filterWatch) Stop() {
-	select {
-	case <-f.done:
-	default:
+	f.stopOnce.Do(func() {
 		close(f.done)
 		f.source.Stop()
-	}
+	})
 }
 
 func newFilterWatch(source watch.Interface, filter filter.ObjectFilter) watch.Interface {

--- a/pkg/yurthub/multiplexer/filterwatch_test.go
+++ b/pkg/yurthub/multiplexer/filterwatch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package multiplexer
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,4 +106,37 @@ func TestFilterWatch_Stop(t *testing.T) {
 	fw.Stop()
 
 	assert.Equal(t, true, source.IsStopped())
+}
+
+// TestFilterWatch_ConcurrentStop makes sure Stop is idempotent when several
+// goroutines race on it. Before the fix, the check-then-close in Stop let more
+// than one goroutine reach close(f.done) and crashed yurthub with
+// "panic: close of closed channel".
+func TestFilterWatch_ConcurrentStop(t *testing.T) {
+	filter := &ctesting.IgnoreEndpointslicesWithNodeName{IgnoreNodeName: "node1"}
+	const (
+		rounds   = 1000
+		stoppers = 16
+	)
+
+	for i := 0; i < rounds; i++ {
+		source := watch.NewFake()
+		fw := newFilterWatch(source, filter)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(stoppers)
+		for j := 0; j < stoppers; j++ {
+			go func() {
+				defer wg.Done()
+				<-start
+				fw.Stop()
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+
+		assert.Equal(t, true, source.IsStopped())
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`filterWatch.Stop()` in `pkg/yurthub/multiplexer/filterwatch.go` guarded the close of `f.done` with a check-then-close:

```go
func (f *filterWatch) Stop() {
	select {
	case <-f.done:
	default:
		close(f.done)
		f.source.Stop()
	}
}
```

The check and the close are not atomic. Two goroutines can both observe `f.done` as still open and both take the `default` branch; the second `close(f.done)` then panics with `close of closed channel`. That panic is not recoverable by the caller and takes down the whole `yurthub` process, so an edge node loses request caching and autonomy.

This is reachable in normal operation rather than only under synthetic load — `Stop` has two independent callers on the same watch:

* `receive()` runs `defer f.Stop()`, which fires as soon as the source watch channel is drained (API server disconnect, watch expiry, source tear-down);
* the watch consumer calls `Stop()` itself when the client goes away.

A disconnect that races with a client tear-down puts both on `Stop()` at the same time.

The fix guards the body with a `sync.Once`, so `close(f.done)` and `f.source.Stop()` happen exactly once no matter how many callers arrive. `Once.Do` also blocks later callers until the first one finishes, so `Stop()` still returns only after the source is actually stopped — the behaviour the previous code intended.

Also adds `TestFilterWatch_ConcurrentStop`, which races 16 goroutines on `Stop()` across 1000 freshly created watches. Against the old code it panics on every run I tried; with the fix the package passes with `-count=3`.

#### Which issue(s) this PR fixes:

Fixes #2700

#### Special notes for your reviewer:

The `stopOnce` field is placed on the struct rather than replacing `done`, because `done` is still needed as a signal — it is passed to `filter.Filter(newObj, f.done)` and selected on in `receive()`.

#### Does this PR introduce a user-facing change?

```release-note
Fix a panic ("close of closed channel") that could crash yurthub when a multiplexer filter watch was stopped concurrently by the watch consumer and by its own receive loop.
```
