### PR TITLE
Bugfix: parse the kubelet EnvironmentFile path safely in GetNodeName

### DIFF
--- a/pkg/yurtadm/util/edgenode/edgenode.go
+++ b/pkg/yurtadm/util/edgenode/edgenode.go
@@ -96,6 +96,20 @@ func CopyFile(sourceFile string, destinationFile string, perm os.FileMode) error
 	return nil
 }
 
+// parseEnvironmentFilePath extracts the file path from a systemd EnvironmentFile
+// directive such as "EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env". It drops
+// the directive key and the optional leading "-" (which only tells systemd to ignore
+// a missing file), and keeps any "-" inside the path itself. An empty string is
+// returned when the directive carries no path.
+func parseEnvironmentFilePath(directive string) string {
+	path := directive
+	if i := strings.IndexByte(path, '='); i >= 0 {
+		path = path[i+1:]
+	}
+	path = strings.TrimPrefix(strings.TrimSpace(path), "-")
+	return strings.TrimSpace(path)
+}
+
 // GetNodeName gets the node name based on environment variable, parameters --hostname-override
 // in the configuration file or hostname
 func GetNodeName(kubeadmConfPath string) (string, error) {
@@ -108,7 +122,7 @@ func GetNodeName(kubeadmConfPath string) (string, error) {
 	//2. find --hostname-override in 10-kubeadm.conf
 	nodeName, err := GetSingleContentFromFile(kubeadmConfPath, constants.KubeletHostname)
 	if nodeName != "" {
-		nodeName = strings.Split(nodeName, NodeNameSplit)[1]
+		nodeName = strings.SplitN(nodeName, NodeNameSplit, 2)[1]
 		return nodeName, nil
 	} else {
 		klog.V(4).Info("get nodename err: ", err)
@@ -120,10 +134,13 @@ func GetNodeName(kubeadmConfPath string) (string, error) {
 		return "", err
 	}
 	for _, ef := range environmentFiles {
-		ef = strings.Split(ef, "-")[1]
+		ef = parseEnvironmentFilePath(ef)
+		if ef == "" {
+			continue
+		}
 		nodeName, err = GetSingleContentFromFile(ef, constants.KubeletHostname)
 		if nodeName != "" {
-			nodeName = strings.Split(nodeName, NodeNameSplit)[1]
+			nodeName = strings.SplitN(nodeName, NodeNameSplit, 2)[1]
 			return nodeName, nil
 		} else {
 			klog.V(4).Info("get nodename err: ", err)

--- a/pkg/yurtadm/util/edgenode/edgenode_test.go
+++ b/pkg/yurtadm/util/edgenode/edgenode_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package edgenode
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -91,6 +93,106 @@ func Test_GetHostName(t *testing.T) {
 				if test.expectedHostName != hostName {
 					t.Errorf("expected output %q, got %q", test.expectedHostName, hostName)
 				}
+			}
+		})
+	}
+}
+
+func Test_parseEnvironmentFilePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+		expected  string
+	}{
+		{
+			"kubeadm default, optional '-' prefix and '-' inside the path",
+			"EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env",
+			"/var/lib/kubelet/kubeadm-flags.env",
+		},
+		{
+			"no '-' anywhere",
+			"EnvironmentFile=/opt/kubelet/config.env",
+			"/opt/kubelet/config.env",
+		},
+		{
+			"path without a leading '-' but with hyphens inside",
+			"EnvironmentFile=/etc/default/kube-lite-node.env",
+			"/etc/default/kube-lite-node.env",
+		},
+		{
+			"trailing whitespace",
+			"EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env   ",
+			"/var/lib/kubelet/kubeadm-flags.env",
+		},
+		{
+			"directive without a path",
+			"EnvironmentFile=",
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseEnvironmentFilePath(test.directive); got != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func Test_GetNodeNameFromEnvironmentFile(t *testing.T) {
+	tests := []struct {
+		name string
+		// envFileName is the file the EnvironmentFile directive points at.
+		envFileName string
+		// dashPrefix reproduces systemd's optional "ignore if missing" marker.
+		dashPrefix bool
+	}{
+		{
+			// The kubeadm default. The old code split on every '-' and took
+			// index [1], which truncated the path at the hyphen in the file name.
+			"path with a '-' inside and the systemd '-' prefix",
+			"kubeadm-flags.env",
+			true,
+		},
+		{
+			// No '-' anywhere, so the old code indexed a one-element slice and
+			// panicked with "index out of range [1]".
+			"path without any '-'",
+			"config.env",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(NodeName, "")
+
+			dir := t.TempDir()
+			envFile := filepath.Join(dir, test.envFileName)
+			if err := os.WriteFile(envFile, []byte(`KUBELET_KUBEADM_ARGS="--hostname-override=edge-node-1"`+"\n"), 0644); err != nil {
+				t.Fatalf("could not write env file: %v", err)
+			}
+
+			// The kubeadm layout: no --hostname-override in the drop-in itself,
+			// only an EnvironmentFile directive pointing at the flags file.
+			directive := "EnvironmentFile="
+			if test.dashPrefix {
+				directive += "-"
+			}
+			kubeadmConf := filepath.Join(dir, "10-kubeadm.conf")
+			if err := os.WriteFile(kubeadmConf, []byte("[Service]\n"+directive+envFile+"\n"), 0644); err != nil {
+				t.Fatalf("could not write kubeadm conf: %v", err)
+			}
+
+			nodeName, err := GetNodeName(kubeadmConf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if nodeName != "edge-node-1" {
+				t.Errorf("expected node name %q, got %q", "edge-node-1", nodeName)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`GetNodeName` in `pkg/yurtadm/util/edgenode/edgenode.go` reads the kubelet systemd drop-in to discover the node name. To recover the path out of an `EnvironmentFile=` directive it did:

```go
for _, ef := range environmentFiles {
	ef = strings.Split(ef, "-")[1]
	...
}
```

`constants.KubeletEnvironmentFile` is `EnvironmentFile=.*`, so `ef` is the entire directive, e.g. `EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env`. Splitting on **every** `-` and unconditionally indexing `[1]` breaks in two ways:

1. **Wrong path.** For the kubeadm default above, the result is `/var/lib/kubelet/kubeadm` — truncated at the hyphen inside `kubeadm-flags.env`. Reading that non-existent file fails, so this branch never finds `--hostname-override`, and `GetNodeName` silently falls through to `/etc/hostname`, which can be a different name than the operator configured.
2. **Panic.** The leading `-` is optional in systemd — it only means "ignore if the file is missing" — and the path need not contain a hyphen either, e.g. `EnvironmentFile=/etc/default/kubelet`. Then `strings.Split` returns a one-element slice and `[1]` panics with `index out of range [1]`. This is reachable from `node-servant convert`, which calls `GetNodeName` via `options.Complete()` (`pkg/node-servant/convert/options.go`), so the command crashes instead of reporting an error.

This PR replaces the heuristic with a small explicit parser that drops the directive key and a single optional leading `-`, and keeps any hyphens inside the path:

```go
func parseEnvironmentFilePath(directive string) string {
	path := directive
	if i := strings.IndexByte(path, '='); i >= 0 {
		path = path[i+1:]
	}
	path = strings.TrimPrefix(strings.TrimSpace(path), "-")
	return strings.TrimSpace(path)
}
```

A directive that carries no path is now skipped rather than read as `""`.

While in the same function, the two `strings.Split(nodeName, NodeNameSplit)[1]` calls that pull the value out of `--hostname-override=<name>` became `strings.SplitN(..., 2)[1]`. `KubeletHostname` matches `[^"\s]*`, which permits `=`, so an override value containing `=` was previously truncated at the first one.

#### Which issue(s) this PR fixes:

Fixes #2661

#### Special notes for your reviewer:

Verified both directions locally:

* `Test_parseEnvironmentFilePath` is a table test over the kubeadm default, a path with no `-` at all, a path with hyphens but no `-` prefix, trailing whitespace, and an empty directive.
* `Test_GetNodeNameFromEnvironmentFile` drives the real `GetNodeName` against a temporary drop-in + flags file for both layouts. Against the current code the first case fails (falls through past the truncated path) and the second panics; both pass with this change.

#### Does this PR introduce a user-facing change?

```release-note
Fix `node-servant convert` / yurtadm resolving the wrong node name — or panicking — when the kubelet drop-in's EnvironmentFile path contains a "-" or omits systemd's optional "-" prefix.
```
