### PR TITLE
fix(controller): prevent infinite Requeue loop during conversion Job deletion

### DIFF
--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -218,6 +218,11 @@ func (r *ReconcileYurtNodeConversion) handleStaleJob(
 	ctx context.Context, node *corev1.Node, job *batchv1.Job,
 	desiredAction, currentJobAction string,
 ) (reconcile.Result, error) {
+	if job.DeletionTimestamp != nil {
+		klog.V(4).Info(Format("node(%s) stale job %s is already deleting, waiting for it to be removed", node.Name, job.Name))
+		return reconcile.Result{}, nil
+	}
+
 	if isJobFinished(job) {
 		klog.V(4).Info(Format("node(%s) deleting stale job %s, desiredAction=%s currentJobAction=%s",
 			node.Name, job.Name, desiredAction, currentJobAction))

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
@@ -280,6 +280,34 @@ func TestReconcileDeleteStaleFinishedJob(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestReconcileIgnoreDeletingStaleJob(t *testing.T) {
+	node := newNode("node-a", map[string]string{
+		projectinfo.GetEdgeWorkerLabelKey(): "true",
+	}, false, nil)
+	job := newConversionJobForTest(t, actionConvert, "node-a")
+	job.Status.Conditions = []batchv1.JobCondition{{
+		Type:   batchv1.JobComplete,
+		Status: corev1.ConditionTrue,
+	}}
+	job.Status.Succeeded = 1
+	now := metav1.Now()
+	job.DeletionTimestamp = &now
+	job.Finalizers = []string{"dummy-finalizer"}
+
+	r, cli := newReconcilerForTest(t, node, job)
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-a"}})
+	require.NoError(t, err)
+	assert.False(t, result.Requeue)
+
+	ignoredJob := &batchv1.Job{}
+	err = cli.Get(context.Background(), types.NamespacedName{
+		Namespace: r.conversionJobNamespace(),
+		Name:      conversionJobName("node-a"),
+	}, ignoredJob)
+	assert.NoError(t, err)
+}
+
 func TestReconcileKeepRunningJobInProgress(t *testing.T) {
 	node := newNode("node-a", map[string]string{
 		projectinfo.GetNodePoolLabel(): "pool-a",


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Fixes an infinite CPU-pegging reconciliation loop in the `YurtNodeConversionController`.
When a conversion round is reversed (e.g., from `convert` to `revert`), the controller deletes the old `node-servant` Job in `handleStaleJob` and immediately returns `reconcile.Result{Requeue: true}`. Because of the delay in Kubernetes background cascading garbage collection, the Job object isn't immediately purged and receives a `DeletionTimestamp`. Returning `Requeue: true` instantly wakes up the controller, which pulls the same Job from the cache, attempts to delete it again, and requeues again, creating an aggressive infinite busy-loop.

This PR adds a `DeletionTimestamp` check to the top of `handleStaleJob`. If the Job is already being deleted, it returns a `nil` result without a requeue. The controller will safely sleep until it is automatically re-awakened by the `DeleteEvent` when the API server finally purges the Job from the cache.

#### Which issue(s) this PR fixes:
Fixes #2644

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
Fixed an infinite CPU-pegging reconciliation loop in the yurt-manager YurtNodeConversionController during stale job cleanup.
```