### PR TITLE
fix(yurtmanager): initialize configmap Data before writing framework in platformadmin controller

### DIFF
--- a/pkg/yurtmanager/controller/platformadmin/platform_admin_controller.go
+++ b/pkg/yurtmanager/controller/platformadmin/platform_admin_controller.go
@@ -717,6 +717,9 @@ func (r *ReconcilePlatformAdmin) writeFramework(ctx context.Context, platformAdm
 
 	// Creates configmap on behalf of the framework, which is called only once upon creation
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
 		cm.Data["framework"] = string(data)
 		return controllerutil.SetOwnerReference(platformAdmin, cm, r.Scheme())
 	})

--- a/pkg/yurtmanager/controller/platformadmin/platform_admin_controller_test.go
+++ b/pkg/yurtmanager/controller/platformadmin/platform_admin_controller_test.go
@@ -180,3 +180,48 @@ func TestReconcilePlatformAdmin(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteFrameworkWithNilConfigMapData(t *testing.T) {
+	platformAdmin := &iotv1beta1.PlatformAdmin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-platformadmin",
+			Namespace: "default",
+		},
+		Spec: iotv1beta1.PlatformAdminSpec{
+			Version:   "minnesota",
+			NodePools: []string{"pool1"},
+		},
+	}
+
+	// The framework configmap already exists but its Data field is nil, e.g. because
+	// it was created or edited outside of the normal reconcile path.
+	existingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-platformadmin-framework",
+			Namespace: "default",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(platformAdmin, existingConfigMap).Build()
+
+	r := &ReconcilePlatformAdmin{
+		Client:         fakeClient,
+		scheme:         fakeScheme,
+		recorder:       &fakeEventRecorder{},
+		yamlSerializer: kjson.NewSerializerWithOptions(kjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, kjson.SerializerOptions{Yaml: true, Pretty: true}),
+	}
+
+	platformAdminFramework := &PlatformAdminFramework{
+		name: "test-platformadmin-framework",
+	}
+
+	assert.NotPanics(t, func() {
+		err := r.writeFramework(context.TODO(), platformAdmin, platformAdminFramework)
+		assert.NoError(t, err)
+	})
+
+	updatedConfigMap := &corev1.ConfigMap{}
+	err := fakeClient.Get(context.TODO(), client.ObjectKey{Name: "test-platformadmin-framework", Namespace: "default"}, updatedConfigMap)
+	assert.NoError(t, err)
+	assert.Contains(t, updatedConfigMap.Data, "framework")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`writeFramework` in the PlatformAdmin controller fetches the framework ConfigMap via `r.Get()` and, inside the `CreateOrUpdate` mutate function, writes directly into `cm.Data["framework"]`. The nil-map guard only exists on the "not found" path (via `initFramework`, which builds a fresh ConfigMap with `Data` populated). If the ConfigMap already exists but has a nil `Data` map (for example it was created/edited outside of this controller, or restored from a backup that stripped `data`), `r.Get` succeeds, control falls through to `CreateOrUpdate`, and the write panics with `assignment to entry in nil map`, crashing the yurt-manager reconcile loop.

This PR initializes `cm.Data` with `map[string]string{}` before writing to it, guarded on it being nil, matching the pattern already used elsewhere in the codebase for this same class of bug.

A regression test (`TestWriteFrameworkWithNilConfigMapData`) is added that seeds a framework ConfigMap with no `Data` and asserts `writeFramework` completes without panicking and persists the expected `framework` key.

#### Which issue(s) this PR fixes:
Fixes #2707

#### Special notes for your reviewer:
This is the same bug class as the recently merged fixes for the YurtStaticSet controller (#2698), the Node mutating webhook (#2681), and the PlatformAdmin conversion webhook (#2692) — a Kubernetes object fetched from the API server cannot be assumed to have non-nil `Annotations`/`Data` maps.

#### Does this PR introduce a user-facing change?
```release-note
Fix a potential panic in the PlatformAdmin controller when the managed framework configmap has a nil Data map.
```

#### other Note
