### PR TITLE
Bugfix: prevent Raven DNS panic on nil ConfigMap data

### DIFF
--- a/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go
+++ b/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go
@@ -153,6 +153,9 @@ func (r *ReconcileDNS) Reconcile(ctx context.Context, req reconcile.Request) (re
 		klog.Error(Format("could not list node, error %s", err.Error()))
 		return reconcile.Result{Requeue: true, RequeueAfter: 2 * time.Second}, err
 	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
 	cm.Data[util.ProxyNodesKey] = buildDNSRecords(&nodeList, enableProxy, proxyAddress)
 	err = r.updateDNS(cm)
 	if err != nil {

--- a/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller_test.go
+++ b/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller_test.go
@@ -205,3 +205,31 @@ func TestReconcileDNS_getService(t *testing.T) {
 		assert.Equal(t, ProxyIP, svc.Spec.ClusterIP, "expected correct clusterIP")
 	})
 }
+
+func TestReconcileDNS_InitializesNilConfigMapData(t *testing.T) {
+	r := mockReconciler()
+	key := client.ObjectKey{
+		Namespace: util.WorkingNamespace,
+		Name:      util.RavenProxyNodesConfig,
+	}
+
+	cm := &v1.ConfigMap{}
+	err := r.Get(context.Background(), key, cm)
+	assert.NoError(t, err)
+
+	cm.Data = nil
+	err = r.Update(context.Background(), cm)
+	assert.NoError(t, err)
+
+	_, err = r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: key,
+	})
+	assert.NoError(t, err)
+
+	updated := &v1.ConfigMap{}
+	err = r.Get(context.Background(), key, updated)
+	assert.NoError(t, err)
+	assert.NotNil(t, updated.Data)
+	_, exists := updated.Data[util.ProxyNodesKey]
+	assert.True(t, exists)
+}


### PR DESCRIPTION
/kind bug
/sig network

#### What this PR does / why we need it:

Initializes the Data map before the Raven DNS controller writes DNS records to the edge-tunnel-nodes ConfigMap.

This prevents a panic when the existing ConfigMap has no data field.

#### Which issue(s) this PR fixes:

Fixes #2709

#### Special notes for your reviewer:

Adds a regression test for a ConfigMap with Data set to nil.

Tested with:

```console
go test ./pkg/yurtmanager/controller/raven/dns
```

#### Does this PR introduce a user-facing change?

```release-note
Fixes a Raven DNS controller panic when the edge-tunnel-nodes ConfigMap has no data field.
```