### PR TITLE
docs: Add missing doc comments for exported API types

### DIFF
--- a/charts/yurt-manager/crds/apps.openyurt.io_nodepools.yaml
+++ b/charts/yurt-manager/crds/apps.openyurt.io_nodepools.yaml
@@ -452,6 +452,7 @@ spec:
                     Conditions represents the latest available observations of a NodePool's
                     current state that includes LeaderHubElection status.
                   items:
+                    description: NodePoolCondition defines the NodePoolCondition
                     properties:
                       lastTransitionTime:
                         description: Last time the condition transitioned from one status to another.

--- a/charts/yurt-manager/crds/apps.openyurt.io_yurtappsets.yaml
+++ b/charts/yurt-manager/crds/apps.openyurt.io_yurtappsets.yaml
@@ -352,6 +352,7 @@ spec:
                 workloadSummary:
                   description: Records the topology detailed information of each workload.
                   items:
+                    description: WorkloadSummary defines the WorkloadSummary
                     properties:
                       availableCondition:
                         type: string
@@ -590,6 +591,7 @@ spec:
                                   Patches is a list of advanced tweaks to be applied to a certain workload
                                   It can add/remove/replace the field values of specified paths in the template.
                                 items:
+                                  description: Patch defines the Patch
                                   properties:
                                     operation:
                                       description: Operation represents the operation

--- a/pkg/apis/apps/v1alpha1/groupversion_info.go
+++ b/pkg/apis/apps/v1alpha1/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "apps.openyurt.io", Version: "v1alpha1"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/apps/v1alpha1/nodepool_types.go
+++ b/pkg/apis/apps/v1alpha1/nodepool_types.go
@@ -21,10 +21,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// NodePoolType defines the NodePoolType
 type NodePoolType string
 
 const (
-	Edge  NodePoolType = "Edge"
+	// Edge defines the Edge
+	Edge NodePoolType = "Edge"
+	// Cloud defines the Cloud
 	Cloud NodePoolType = "Cloud"
 )
 

--- a/pkg/apis/apps/v1alpha1/yurtappset_types.go
+++ b/pkg/apis/apps/v1alpha1/yurtappset_types.go
@@ -28,11 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// TemplateType defines the TemplateType
 type TemplateType string
 
 const (
+	// StatefulSetTemplateType defines the StatefulSetTemplateType
 	StatefulSetTemplateType TemplateType = "StatefulSet"
-	DeploymentTemplateType  TemplateType = "Deployment"
+	// DeploymentTemplateType defines the DeploymentTemplateType
+	DeploymentTemplateType TemplateType = "Deployment"
 )
 
 // YurtAppSetConditionType indicates valid conditions type of a YurtAppSet.
@@ -184,6 +187,7 @@ type YurtAppSetStatus struct {
 	TemplateType TemplateType `json:"templateType"`
 }
 
+// WorkloadSummary defines the WorkloadSummary
 type WorkloadSummary struct {
 	AvailableCondition corev1.ConditionStatus `json:"availableCondition"`
 	Replicas           int32                  `json:"replicas"`

--- a/pkg/apis/apps/v1alpha1/yurtstaticset_types.go
+++ b/pkg/apis/apps/v1alpha1/yurtstaticset_types.go
@@ -36,8 +36,10 @@ type YurtStaticSetUpgradeStrategy struct {
 type YurtStaticSetUpgradeStrategyType string
 
 const (
+	// AdvancedRollingUpdateUpgradeStrategyType defines the AdvancedRollingUpdateUpgradeStrategyType
 	AdvancedRollingUpdateUpgradeStrategyType YurtStaticSetUpgradeStrategyType = "AdvancedRollingUpdate"
-	OTAUpgradeStrategyType                   YurtStaticSetUpgradeStrategyType = "OTA"
+	// OTAUpgradeStrategyType defines the OTAUpgradeStrategyType
+	OTAUpgradeStrategyType YurtStaticSetUpgradeStrategyType = "OTA"
 )
 
 // YurtStaticSetSpec defines the desired state of YurtStaticSet

--- a/pkg/apis/apps/v1beta1/conditions.go
+++ b/pkg/apis/apps/v1beta1/conditions.go
@@ -19,5 +19,6 @@ package v1beta1
 import v1 "k8s.io/api/core/v1"
 
 const (
+	// NodeAutonomy defines the NodeAutonomy
 	NodeAutonomy v1.NodeConditionType = "Autonomy"
 )

--- a/pkg/apis/apps/v1beta1/groupversion_info.go
+++ b/pkg/apis/apps/v1beta1/groupversion_info.go
@@ -28,6 +28,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "apps.openyurt.io", Version: "v1beta1"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/apps/v1beta1/nodepool_types.go
+++ b/pkg/apis/apps/v1beta1/nodepool_types.go
@@ -21,10 +21,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// NodePoolType defines the NodePoolType
 type NodePoolType string
 
 const (
-	Edge  NodePoolType = "Edge"
+	// Edge defines the Edge
+	Edge NodePoolType = "Edge"
+	// Cloud defines the Cloud
 	Cloud NodePoolType = "Cloud"
 )
 

--- a/pkg/apis/apps/v1beta1/yurtappset_types.go
+++ b/pkg/apis/apps/v1beta1/yurtappset_types.go
@@ -124,14 +124,19 @@ type ContainerImage struct {
 	TargetImage string `json:"targetImage"`
 }
 
+// Operation defines the Operation
 type Operation string
 
 const (
-	ADD     Operation = "add"     // json patch
-	REMOVE  Operation = "remove"  // json patch
+	// ADD defines the ADD
+	ADD Operation = "add" // json patch
+	// REMOVE defines the REMOVE
+	REMOVE Operation = "remove" // json patch
+	// REPLACE defines the REPLACE
 	REPLACE Operation = "replace" // json patch
 )
 
+// Patch defines the Patch
 type Patch struct {
 	// Path represents the path in the json patch
 	Path string `json:"path"`

--- a/pkg/apis/apps/v1beta2/groupversion_info.go
+++ b/pkg/apis/apps/v1beta2/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "apps.openyurt.io", Version: "v1beta2"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/apps/v1beta2/nodepool_types.go
+++ b/pkg/apis/apps/v1beta2/nodepool_types.go
@@ -21,16 +21,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// NodePoolType defines the NodePoolType
 type NodePoolType string
 
 // LeaderElectionStrategy represents the policy how to elect a leader Yurthub in a nodepool.
 type LeaderElectionStrategy string
 
 const (
-	Edge  NodePoolType = "Edge"
+	// Edge defines the Edge
+	Edge NodePoolType = "Edge"
+	// Cloud defines the Cloud
 	Cloud NodePoolType = "Cloud"
 
-	ElectionStrategyMark   LeaderElectionStrategy = "mark"
+	// ElectionStrategyMark defines the ElectionStrategyMark
+	ElectionStrategyMark LeaderElectionStrategy = "mark"
+	// ElectionStrategyRandom defines the ElectionStrategyRandom
 	ElectionStrategyRandom LeaderElectionStrategy = "random"
 
 	// LeaderStatus means the status of leader yurthub election.
@@ -140,6 +145,7 @@ type Leader struct {
 // NodePoolConditionType represents a NodePool condition value.
 type NodePoolConditionType string
 
+// NodePoolCondition defines the NodePoolCondition
 type NodePoolCondition struct {
 	// Type of NodePool condition.
 	Type NodePoolConditionType `json:"type,omitempty"`

--- a/pkg/apis/calico/v3/blockaffinity.go
+++ b/pkg/apis/calico/v3/blockaffinity.go
@@ -22,7 +22,9 @@ import (
 )
 
 const (
-	KindBlockAffinity     = "BlockAffinity"
+	// KindBlockAffinity defines the KindBlockAffinity
+	KindBlockAffinity = "BlockAffinity"
+	// KindBlockAffinityList defines the KindBlockAffinityList
 	KindBlockAffinityList = "BlockAffinityList"
 )
 

--- a/pkg/apis/calico/v3/register.go
+++ b/pkg/apis/calico/v3/register.go
@@ -22,12 +22,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// SchemeGroupVersion defines the SchemeGroupVersion
 var SchemeGroupVersion = schema.GroupVersion{Group: "crd.projectcalico.org", Version: "v1"}
 
 var (
+	// SchemeBuilder defines the SchemeBuilder
 	SchemeBuilder      runtime.SchemeBuilder
 	localSchemeBuilder = &SchemeBuilder
-	AddToScheme        = localSchemeBuilder.AddToScheme
+	// AddToScheme defines the AddToScheme
+	AddToScheme = localSchemeBuilder.AddToScheme
 )
 
 func init() {

--- a/pkg/apis/iot/v1alpha1/condition_const.go
+++ b/pkg/apis/iot/v1alpha1/condition_const.go
@@ -20,45 +20,58 @@ const (
 	// ConfigmapAvailableCondition documents the status of the PlatformAdmin configmap.
 	ConfigmapAvailableCondition PlatformAdminConditionType = "ConfigmapAvailable"
 
+	// ConfigmapProvisioningReason defines the ConfigmapProvisioningReason
 	ConfigmapProvisioningReason = "ConfigmapProvisioning"
 
+	// ConfigmapProvisioningFailedReason defines the ConfigmapProvisioningFailedReason
 	ConfigmapProvisioningFailedReason = "ConfigmapProvisioningFailed"
 	// ServiceAvailableCondition documents the status of the PlatformAdmin service.
 	ServiceAvailableCondition PlatformAdminConditionType = "ServiceAvailable"
 
+	// ServiceProvisioningReason defines the ServiceProvisioningReason
 	ServiceProvisioningReason = "ServiceProvisioning"
 
+	// ServiceProvisioningFailedReason defines the ServiceProvisioningFailedReason
 	ServiceProvisioningFailedReason = "ServiceProvisioningFailed"
 	// DeploymentAvailableCondition documents the status of the PlatformAdmin deployment.
 	DeploymentAvailableCondition PlatformAdminConditionType = "DeploymentAvailable"
 
+	// DeploymentProvisioningReason defines the DeploymentProvisioningReason
 	DeploymentProvisioningReason = "DeploymentProvisioning"
 
+	// DeploymentProvisioningFailedReason defines the DeploymentProvisioningFailedReason
 	DeploymentProvisioningFailedReason = "DeploymentProvisioningFailed"
 
 	// DeviceSyncedCondition indicates that the device exists in both OpenYurt and edge platform
 	DeviceSyncedCondition DeviceConditionType = "DeviceSynced"
 
+	// DeviceManagingReason defines the DeviceManagingReason
 	DeviceManagingReason = "This device is not managed by openyurt"
 
+	// DeviceCreateSyncedReason defines the DeviceCreateSyncedReason
 	DeviceCreateSyncedReason = "Failed to create device on edge platform"
 
 	// DeviceManagingCondition indicates that the device is being managed by cloud and its properties are being reconciled
 	DeviceManagingCondition DeviceConditionType = "DeviceManaging"
 
+	// DeviceVisitedCoreMetadataSyncedReason defines the DeviceVisitedCoreMetadataSyncedReason
 	DeviceVisitedCoreMetadataSyncedReason = "Failed to visit the EdgeX core-metadata-service"
 
+	// DeviceUpdateStateReason defines the DeviceUpdateStateReason
 	DeviceUpdateStateReason = "Failed to update AdminState or OperatingState of device on edge platform"
 
 	// DeviceServiceSyncedCondition indicates that the deviceService exists in both OpenYurt and edge platform
 	DeviceServiceSyncedCondition DeviceServiceConditionType = "DeviceServiceSynced"
 
+	// DeviceServiceManagingReason defines the DeviceServiceManagingReason
 	DeviceServiceManagingReason = "This deviceService is not managed by openyurt"
 
 	// DeviceServiceManagingCondition indicates that the deviceService is being managed by cloud and its field are being reconciled
 	DeviceServiceManagingCondition DeviceServiceConditionType = "DeviceServiceManaging"
 
+	// DeviceServiceCreateSyncedReason defines the DeviceServiceCreateSyncedReason
 	DeviceServiceCreateSyncedReason = "Failed to add DeviceService to EdgeX"
 
+	// DeviceServiceUpdateStatusSyncedReason defines the DeviceServiceUpdateStatusSyncedReason
 	DeviceServiceUpdateStatusSyncedReason = "Failed to update DeviceService status"
 )

--- a/pkg/apis/iot/v1alpha1/device_types.go
+++ b/pkg/apis/iot/v1alpha1/device_types.go
@@ -22,27 +22,36 @@ import (
 )
 
 const (
+	// DeviceFinalizer defines the DeviceFinalizer
 	DeviceFinalizer = "iot.openyurt.io/device"
 )
 
 // DeviceConditionType indicates valid conditions type of a Device.
 type DeviceConditionType string
 
+// AdminState defines the AdminState
 type AdminState string
 
 const (
-	Locked   AdminState = "LOCKED"
+	// Locked defines the Locked
+	Locked AdminState = "LOCKED"
+	// UnLocked defines the UnLocked
 	UnLocked AdminState = "UNLOCKED"
 )
 
+// OperatingState defines the OperatingState
 type OperatingState string
 
 const (
+	// Unknown defines the Unknown
 	Unknown OperatingState = "UNKNOWN"
-	Up      OperatingState = "UP"
-	Down    OperatingState = "DOWN"
+	// Up defines the Up
+	Up OperatingState = "UP"
+	// Down defines the Down
+	Down OperatingState = "DOWN"
 )
 
+// ProtocolProperties defines the ProtocolProperties
 type ProtocolProperties map[string]string
 
 // DeviceSpec defines the desired state of Device
@@ -78,12 +87,14 @@ type DeviceSpec struct {
 	DeviceProperties map[string]DesiredPropertyState `json:"deviceProperties,omitempty"`
 }
 
+// DesiredPropertyState defines the DesiredPropertyState
 type DesiredPropertyState struct {
 	Name         string `json:"name"`
 	PutURL       string `json:"putURL,omitempty"`
 	DesiredValue string `json:"desiredValue"`
 }
 
+// ActualPropertyState defines the ActualPropertyState
 type ActualPropertyState struct {
 	Name        string `json:"name"`
 	GetURL      string `json:"getURL,omitempty"`

--- a/pkg/apis/iot/v1alpha1/deviceprofile_types.go
+++ b/pkg/apis/iot/v1alpha1/deviceprofile_types.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
+	// DeviceProfileFinalizer defines the DeviceProfileFinalizer
 	DeviceProfileFinalizer = "iot.openyurt.io/deviceprofile"
 )
 
+// DeviceResource defines the DeviceResource
 type DeviceResource struct {
 	Description string             `json:"description"`
 	Name        string             `json:"name"`
@@ -33,6 +35,7 @@ type DeviceResource struct {
 	Attributes  map[string]string  `json:"attributes,omitempty"`
 }
 
+// ResourceProperties defines the ResourceProperties
 type ResourceProperties struct {
 	ReadWrite    string `json:"readWrite,omitempty"`    // Read/Write Permissions set for this property
 	Minimum      string `json:"minimum,omitempty"`      // Minimum value that can be get/set from this property
@@ -49,6 +52,7 @@ type ResourceProperties struct {
 	ValueType    string `json:"valueType,omitempty"`
 }
 
+// DeviceCommand defines the DeviceCommand
 type DeviceCommand struct {
 	Name               string              `json:"name"`
 	IsHidden           bool                `json:"isHidden"`
@@ -56,6 +60,7 @@ type DeviceCommand struct {
 	ResourceOperations []ResourceOperation `json:"resourceOperations"`
 }
 
+// ResourceOperation defines the ResourceOperation
 type ResourceOperation struct {
 	DeviceResource string            `json:"deviceResource,omitempty"`
 	Mappings       map[string]string `json:"mappings,omitempty"`

--- a/pkg/apis/iot/v1alpha1/deviceservice_types.go
+++ b/pkg/apis/iot/v1alpha1/deviceservice_types.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	// DeviceServiceFinalizer defines the DeviceServiceFinalizer
 	DeviceServiceFinalizer = "iot.openyurt.io/deviceservice"
 )
 

--- a/pkg/apis/iot/v1alpha1/groupversion_info.go
+++ b/pkg/apis/iot/v1alpha1/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "iot.openyurt.io", Version: "v1alpha1"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/iot/v1alpha1/platformadmin_types.go
+++ b/pkg/apis/iot/v1alpha1/platformadmin_types.go
@@ -26,11 +26,14 @@ const (
 	// name of finalizer
 	EdgexFinalizer = "edgex.edgexfoundry.org"
 
+	// LabelEdgeXGenerate defines the LabelEdgeXGenerate
 	LabelEdgeXGenerate = "www.edgexfoundry.org/generate"
 )
 
 // PlatformAdminConditionType indicates valid conditions type of a iot platform.
 type PlatformAdminConditionType string
+
+// PlatformAdminConditionSeverity defines the PlatformAdminConditionSeverity
 type PlatformAdminConditionSeverity string
 
 // DeploymentTemplateSpec defines the pool template of Deployment.

--- a/pkg/apis/iot/v1alpha2/condition_const.go
+++ b/pkg/apis/iot/v1alpha2/condition_const.go
@@ -20,13 +20,17 @@ const (
 	// ConfigmapAvailableCondition documents the status of the PlatformAdmin configmap.
 	ConfigmapAvailableCondition PlatformAdminConditionType = "ConfigmapAvailable"
 
+	// ConfigmapProvisioningReason defines the ConfigmapProvisioningReason
 	ConfigmapProvisioningReason = "ConfigmapProvisioning"
 
+	// ConfigmapProvisioningFailedReason defines the ConfigmapProvisioningFailedReason
 	ConfigmapProvisioningFailedReason = "ConfigmapProvisioningFailed"
 	// ComponentAvailableCondition documents the status of the PlatformAdmin component.
 	ComponentAvailableCondition PlatformAdminConditionType = "ComponentAvailable"
 
+	// ComponentProvisioningReason defines the ComponentProvisioningReason
 	ComponentProvisioningReason = "ComponentProvisioning"
 
+	// ComponentProvisioningFailedReason defines the ComponentProvisioningFailedReason
 	ComponentProvisioningFailedReason = "ComponentProvisioningFailed"
 )

--- a/pkg/apis/iot/v1alpha2/groupversion_info.go
+++ b/pkg/apis/iot/v1alpha2/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "iot.openyurt.io", Version: "v1alpha2"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/iot/v1alpha2/platformadmin_types.go
+++ b/pkg/apis/iot/v1alpha2/platformadmin_types.go
@@ -25,6 +25,7 @@ const (
 	// name of finalizer
 	PlatformAdminFinalizer = "iot.openyurt.io"
 
+	// LabelPlatformAdminGenerate defines the LabelPlatformAdminGenerate
 	LabelPlatformAdminGenerate = "iot.openyurt.io/generate"
 )
 
@@ -35,6 +36,8 @@ const (
 
 // PlatformAdminConditionType indicates valid conditions type of a PlatformAdmin.
 type PlatformAdminConditionType string
+
+// PlatformAdminConditionSeverity defines the PlatformAdminConditionSeverity
 type PlatformAdminConditionSeverity string
 
 // Component defines the components of EdgeX

--- a/pkg/apis/iot/v1beta1/condition_const.go
+++ b/pkg/apis/iot/v1beta1/condition_const.go
@@ -20,13 +20,17 @@ const (
 	// ConfigmapAvailableCondition documents the status of the PlatformAdmin configmap.
 	ConfigmapAvailableCondition PlatformAdminConditionType = "ConfigmapAvailable"
 
+	// ConfigmapProvisioningReason defines the ConfigmapProvisioningReason
 	ConfigmapProvisioningReason = "ConfigmapProvisioning"
 
+	// ConfigmapProvisioningFailedReason defines the ConfigmapProvisioningFailedReason
 	ConfigmapProvisioningFailedReason = "ConfigmapProvisioningFailed"
 	// ComponentAvailableCondition documents the status of the PlatformAdmin component.
 	ComponentAvailableCondition PlatformAdminConditionType = "ComponentAvailable"
 
+	// ComponentProvisioningReason defines the ComponentProvisioningReason
 	ComponentProvisioningReason = "ComponentProvisioning"
 
+	// ComponentProvisioningFailedReason defines the ComponentProvisioningFailedReason
 	ComponentProvisioningFailedReason = "ComponentProvisioningFailed"
 )

--- a/pkg/apis/iot/v1beta1/groupversion_info.go
+++ b/pkg/apis/iot/v1beta1/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "iot.openyurt.io", Version: "v1beta1"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/iot/v1beta1/platformadmin_types.go
+++ b/pkg/apis/iot/v1beta1/platformadmin_types.go
@@ -25,6 +25,7 @@ const (
 	// name of finalizer
 	PlatformAdminFinalizer = "iot.openyurt.io"
 
+	// LabelPlatformAdminGenerate defines the LabelPlatformAdminGenerate
 	LabelPlatformAdminGenerate = "iot.openyurt.io/generate"
 )
 
@@ -35,6 +36,8 @@ const (
 
 // PlatformAdminConditionType indicates valid conditions type of a PlatformAdmin.
 type PlatformAdminConditionType string
+
+// PlatformAdminConditionSeverity defines the PlatformAdminConditionSeverity
 type PlatformAdminConditionSeverity string
 
 // Component defines the components of EdgeX

--- a/pkg/apis/network/v1alpha1/groupversion_info.go
+++ b/pkg/apis/network/v1alpha1/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "network.openyurt.io", Version: "v1alpha1"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/network/well_known_labels_annotations.go
+++ b/pkg/apis/network/well_known_labels_annotations.go
@@ -17,7 +17,10 @@ limitations under the License.
 package network
 
 const (
-	LabelServiceName           = "openyurt.io/service-name"
-	LabelNodePoolName          = "openyurt.io/pool-name"
+	// LabelServiceName defines the LabelServiceName
+	LabelServiceName = "openyurt.io/service-name"
+	// LabelNodePoolName defines the LabelNodePoolName
+	LabelNodePoolName = "openyurt.io/pool-name"
+	// AnnotationNodePoolSelector defines the AnnotationNodePoolSelector
 	AnnotationNodePoolSelector = "service.openyurt.io/nodepool-labelselector"
 )

--- a/pkg/apis/raven/v1alpha1/gateway_types.go
+++ b/pkg/apis/raven/v1alpha1/gateway_types.go
@@ -32,14 +32,17 @@ const (
 	EventActiveEndpointLost = "ActiveEndpointLost"
 )
 
+// ServiceNamespacedName defines the ServiceNamespacedName
 var ServiceNamespacedName = types.NamespacedName{
 	Namespace: "kube-system",
 	Name:      "raven-agent-service",
 }
 
+// ExposeType defines the ExposeType
 type ExposeType string
 
 const (
+	// ExposeTypeLoadBalancer defines the ExposeTypeLoadBalancer
 	ExposeTypeLoadBalancer = "LoadBalancer"
 )
 

--- a/pkg/apis/raven/v1alpha1/groupversion_info.go
+++ b/pkg/apis/raven/v1alpha1/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "raven.openyurt.io", Version: "v1alpha1"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/raven/v1beta1/gateway_types.go
+++ b/pkg/apis/raven/v1beta1/gateway_types.go
@@ -30,17 +30,25 @@ const (
 )
 
 const (
-	ExposeTypePublicIP     = "PublicIP"
+	// ExposeTypePublicIP defines the ExposeTypePublicIP
+	ExposeTypePublicIP = "PublicIP"
+	// ExposeTypeLoadBalancer defines the ExposeTypeLoadBalancer
 	ExposeTypeLoadBalancer = "LoadBalancer"
 )
 
 const (
-	Proxy  = "proxy"
+	// Proxy defines the Proxy
+	Proxy = "proxy"
+	// Tunnel defines the Tunnel
 	Tunnel = "tunnel"
 
-	DefaultProxyServerSecurePort   = 10263
+	// DefaultProxyServerSecurePort defines the DefaultProxyServerSecurePort
+	DefaultProxyServerSecurePort = 10263
+	// DefaultProxyServerInsecurePort defines the DefaultProxyServerInsecurePort
 	DefaultProxyServerInsecurePort = 10264
-	DefaultProxyServerExposedPort  = 10262
+	// DefaultProxyServerExposedPort defines the DefaultProxyServerExposedPort
+	DefaultProxyServerExposedPort = 10262
+	// DefaultTunnelServerExposedPort defines the DefaultTunnelServerExposedPort
 	DefaultTunnelServerExposedPort = 4500
 )
 

--- a/pkg/apis/raven/v1beta1/groupversion_info.go
+++ b/pkg/apis/raven/v1beta1/groupversion_info.go
@@ -29,6 +29,7 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "raven.openyurt.io", Version: "v1beta1"}
 
+	// SchemeGroupVersion defines the SchemeGroupVersion
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme

--- a/pkg/apis/raven/well_known_labels_annotations.go
+++ b/pkg/apis/raven/well_known_labels_annotations.go
@@ -18,6 +18,7 @@ package raven
 
 const (
 	// LabelCurrentGateway indicates which gateway the node is currently belonging to
-	LabelCurrentGateway     = "raven.openyurt.io/gateway"
+	LabelCurrentGateway = "raven.openyurt.io/gateway"
+	// LabelCurrentGatewayType defines the LabelCurrentGatewayType
 	LabelCurrentGatewayType = "raven.openyurt.io/gateway-type"
 )


### PR DESCRIPTION
### What this PR does / why we need it:
Adds missing docstrings for exported API types across `pkg/apis/`. This resolves standard Go linter warnings and improves code readability for new contributors exploring core OpenYurt CRDs.

### Which issue(s) this PR fixes:
Fixes #2635

### How to test:
- **Manual Verification:** Ran `golangci-lint` locally to confirm all missing docstring warnings in `pkg/apis/` are resolved.