### PR TITLE
fix(yurthub): synchronize cached nodePoolName in servicetopology and nodeportisolation filters

### DIFF
--- a/pkg/yurthub/filter/nodeportisolation/filter.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,6 +50,9 @@ func Register(filters *base.Filters) {
 }
 
 type nodePortIsolationFilter struct {
+	// nodePoolLock guards nodePoolName, because a single filter instance is shared
+	// by all of the goroutines that filter responses concurrently.
+	nodePoolLock sync.RWMutex
 	nodePoolName string
 	nodeName     string
 	client       kubernetes.Interface
@@ -63,6 +67,8 @@ func (nif *nodePortIsolationFilter) Name() string {
 }
 
 func (nif *nodePortIsolationFilter) SetNodePoolName(name string) error {
+	nif.nodePoolLock.Lock()
+	defer nif.nodePoolLock.Unlock()
 	nif.nodePoolName = name
 	return nil
 }
@@ -109,15 +115,23 @@ func (nif *nodePortIsolationFilter) isolateNodePortService(svc *v1.Service) *v1.
 }
 
 func (nif *nodePortIsolationFilter) resolveNodePoolName() string {
-	if len(nif.nodePoolName) != 0 {
-		return nif.nodePoolName
+	nif.nodePoolLock.RLock()
+	nodePoolName := nif.nodePoolName
+	nif.nodePoolLock.RUnlock()
+	if len(nodePoolName) != 0 {
+		return nodePoolName
 	}
 
+	// the node is fetched without holding the lock, so that a slow kube-apiserver
+	// can not block the other goroutines that are filtering responses.
 	node, err := nif.client.CoreV1().Nodes().Get(context.Background(), nif.nodeName, metav1.GetOptions{})
 	if err != nil {
 		klog.Warningf("skip isolateNodePortService filter, could not get node(%s), %v", nif.nodeName, err)
-		return nif.nodePoolName
+		return ""
 	}
+
+	nif.nodePoolLock.Lock()
+	defer nif.nodePoolLock.Unlock()
 	nif.nodePoolName = node.Labels[projectinfo.GetNodePoolLabel()]
 	return nif.nodePoolName
 }

--- a/pkg/yurthub/filter/nodeportisolation/filter_test.go
+++ b/pkg/yurthub/filter/nodeportisolation/filter_test.go
@@ -18,6 +18,7 @@ package nodeportisolation
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -380,5 +381,78 @@ func TestFilter(t *testing.T) {
 				t.Errorf("RuntimeObjectFilter got error, expected: \n%v\nbut got: \n%v\n", tc.expectObj, newObj)
 			}
 		})
+	}
+}
+
+// TestResolveNodePoolNameConcurrently ensures that the node pool name cached on the shared
+// filter instance can be resolved from several goroutines at once. The filter manager hands
+// the same nodePortIsolationFilter to every request, so Filter runs concurrently whenever
+// more than one component is listing or watching services. Run with -race to catch a
+// regression.
+func TestResolveNodePoolNameConcurrently(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node1",
+				Labels: map[string]string{projectinfo.GetNodePoolLabel(): "hangzhou"},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node2",
+				Labels: map[string]string{projectinfo.GetNodePoolLabel(): "shanghai"},
+			},
+		},
+	)
+	// node pool name is deliberately left unset, so that every Filter call has to resolve it
+	// from the node object. This is the default, because --nodepool-name is optional.
+	nif := &nodePortIsolationFilter{nodeName: "node1", client: client}
+
+	// kept: hangzhou is listed by the annotation. discarded: only shanghai is listed.
+	keptSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "kept",
+			Namespace:   "default",
+			Annotations: map[string]string{ServiceAnnotationNodePortListen: "hangzhou"},
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort},
+	}
+	discardedSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "discarded",
+			Namespace:   "default",
+			Annotations: map[string]string{ServiceAnnotationNodePortListen: "shanghai"},
+		},
+		Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort},
+	}
+
+	stopCh := make(<-chan struct{})
+	kept := make([]runtime.Object, 50)
+	discarded := make([]runtime.Object, 50)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			kept[i] = nif.Filter(keptSvc.DeepCopy(), stopCh)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			discarded[i] = nif.Filter(discardedSvc.DeepCopy(), stopCh)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range kept {
+		if util.IsNil(kept[i]) {
+			t.Errorf("goroutine %d: service listened by nodepool hangzhou should have been kept", i)
+		}
+		if !util.IsNil(discarded[i]) {
+			t.Errorf("goroutine %d: service listened only by nodepool shanghai should have been discarded, but got %v", i, discarded[i])
+		}
+	}
+
+	if poolName := nif.resolveNodePoolName(); poolName != "hangzhou" {
+		t.Errorf("expect cached node pool name hangzhou, but got %q", poolName)
 	}
 }

--- a/pkg/yurthub/filter/servicetopology/filter.go
+++ b/pkg/yurthub/filter/servicetopology/filter.go
@@ -18,6 +18,7 @@ package servicetopology
 
 import (
 	"context"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -63,9 +64,12 @@ type serviceTopologyFilter struct {
 	enablePoolTopology bool
 	nodesGetter        filter.NodesInPoolGetter
 	nodesSynced        cache.InformerSynced
-	nodePoolName       string
-	nodeName           string
-	client             kubernetes.Interface
+	// nodePoolLock guards nodePoolName, because a single filter instance is shared
+	// by all of the goroutines that filter responses concurrently.
+	nodePoolLock sync.RWMutex
+	nodePoolName string
+	nodeName     string
+	client       kubernetes.Interface
 }
 
 func (stf *serviceTopologyFilter) Name() string {
@@ -105,6 +109,8 @@ func (stf *serviceTopologyFilter) SetNodeName(nodeName string) error {
 }
 
 func (stf *serviceTopologyFilter) SetNodePoolName(poolName string) error {
+	stf.nodePoolLock.Lock()
+	defer stf.nodePoolLock.Unlock()
 	stf.nodePoolName = poolName
 	return nil
 }
@@ -115,15 +121,23 @@ func (stf *serviceTopologyFilter) SetKubeClient(client kubernetes.Interface) err
 }
 
 func (stf *serviceTopologyFilter) resolveNodePoolName() string {
-	if len(stf.nodePoolName) != 0 {
-		return stf.nodePoolName
+	stf.nodePoolLock.RLock()
+	nodePoolName := stf.nodePoolName
+	stf.nodePoolLock.RUnlock()
+	if len(nodePoolName) != 0 {
+		return nodePoolName
 	}
 
+	// the node is fetched without holding the lock, so that a slow kube-apiserver
+	// can not block the other goroutines that are filtering responses.
 	node, err := stf.client.CoreV1().Nodes().Get(context.Background(), stf.nodeName, metav1.GetOptions{})
 	if err != nil {
 		klog.Warningf("could not get node(%s) in serviceTopologyFilter filter, %v", stf.nodeName, err)
-		return stf.nodePoolName
+		return ""
 	}
+
+	stf.nodePoolLock.Lock()
+	defer stf.nodePoolLock.Unlock()
 	stf.nodePoolName = node.Labels[projectinfo.GetNodePoolLabel()]
 	return stf.nodePoolName
 }

--- a/pkg/yurthub/filter/servicetopology/filter_test.go
+++ b/pkg/yurthub/filter/servicetopology/filter_test.go
@@ -18,6 +18,7 @@ package servicetopology
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -2742,5 +2743,122 @@ func TestReassembleEndpointSlice(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestResolveNodePoolNameConcurrently ensures that the node pool name cached on the shared
+// filter instance can be resolved from several goroutines at once. The filter manager hands
+// the same serviceTopologyFilter to every request, so Filter runs concurrently whenever more
+// than one component is listing or watching endpointslices. Run with -race to catch a
+// regression.
+func TestResolveNodePoolNameConcurrently(t *testing.T) {
+	scheme := runtime.NewScheme()
+	apis.AddToScheme(scheme)
+	nodeBucketGVRToListKind := map[schema.GroupVersionResource]string{
+		{Group: "apps.openyurt.io", Version: "v1alpha1", Resource: "nodebuckets"}: "NodeBucketList",
+	}
+	currentNodeName := "node1"
+
+	kubeClient := k8sfake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   currentNodeName,
+				Labels: map[string]string{projectinfo.GetNodePoolLabel(): "hangzhou"},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node2",
+				Labels: map[string]string{projectinfo.GetNodePoolLabel(): "shanghai"},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					AnnotationServiceTopologyKey: AnnotationServiceTopologyValueNodePool,
+				},
+			},
+		},
+	)
+	yurtClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, nodeBucketGVRToListKind,
+		&v1alpha1.NodeBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "hangzhou",
+				Labels: map[string]string{LabelNodePoolName: "hangzhou"},
+			},
+			Nodes: []v1alpha1.Node{{Name: currentNodeName}},
+		},
+		&v1alpha1.NodeBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "shanghai",
+				Labels: map[string]string{LabelNodePoolName: "shanghai"},
+			},
+			Nodes: []v1alpha1.Node{{Name: "node2"}},
+		},
+	)
+
+	factory := informers.NewSharedInformerFactory(kubeClient, 24*time.Hour)
+	stf := &serviceTopologyFilter{}
+	stf.SetSharedInformerFactory(factory)
+	stf.SetKubeClient(kubeClient)
+	stf.SetNodeName(currentNodeName)
+	// node pool name is deliberately left unset, so that every Filter call has to resolve it
+	// from the node object. This is the default, because --nodepool-name is optional.
+
+	stopper := make(chan struct{})
+	defer close(stopper)
+	factory.Start(stopper)
+	factory.WaitForCacheSync(stopper)
+
+	yurtFactory := dynamicinformer.NewDynamicSharedInformerFactory(yurtClient, 24*time.Hour)
+	initializer.NewNodesInitializer(false, true, yurtFactory).Initialize(stf)
+
+	stopper2 := make(chan struct{})
+	defer close(stopper2)
+	yurtFactory.Start(stopper2)
+	yurtFactory.WaitForCacheSync(stopper2)
+
+	responseObject := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1-np7sf",
+			Namespace: "default",
+			Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
+		},
+		Endpoints: []discovery.Endpoint{
+			{Addresses: []string{"10.244.1.2"}, NodeName: &currentNodeName},
+			{Addresses: []string{"10.244.1.3"}, NodeName: &[]string{"node2"}[0]},
+		},
+	}
+
+	stopCh := make(<-chan struct{})
+	results := make([]*discovery.EndpointSlice, 50)
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			newObj := stf.Filter(responseObject.DeepCopy(), stopCh)
+			results[i], _ = newObj.(*discovery.EndpointSlice)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, got := range results {
+		if got == nil {
+			t.Fatalf("goroutine %d got a nil or unexpectedly typed object", i)
+		}
+		// only the endpoint on node1 belongs to the hangzhou node pool
+		if len(got.Endpoints) != 1 {
+			t.Fatalf("goroutine %d expect 1 endpoint left, but got %d", i, len(got.Endpoints))
+		}
+		if *got.Endpoints[0].NodeName != currentNodeName {
+			t.Errorf("goroutine %d expect endpoint on node %q, but got %q", i, currentNodeName, *got.Endpoints[0].NodeName)
+		}
+	}
+
+	if poolName := stf.resolveNodePoolName(); poolName != "hangzhou" {
+		t.Errorf("expect cached node pool name hangzhou, but got %q", poolName)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network

#### What this PR does / why we need it:

`servicetopology` and `nodeportisolation` both cache the node pool name of the local node on
the filter struct, and both read and write that field without any synchronization.

**Root cause.** The filter manager builds a single instance of each object filter at startup
and stores it in `nameToObjectFilter` (`pkg/yurthub/filter/manager/manager.go:41`).
`FindResponseFilter()` and `FindObjectFilter()` look the instance out of that map and wrap
it — they never copy it — so the *same* filter object is used by every request. Every
component that lists or watches through yurthub (kube-proxy, coredns,
nginx-ingress-controller) therefore drives `Filter()` on that shared instance from its own
goroutine, and each watch event is filtered on the goroutine that is draining that watch.

Both filters resolve the node pool lazily when `--nodepool-name` was not passed:

```go
func (nif *nodePortIsolationFilter) resolveNodePoolName() string {
	if len(nif.nodePoolName) != 0 {      // unsynchronized read
		return nif.nodePoolName
	}
	node, err := nif.client.CoreV1().Nodes().Get(...)
	...
	nif.nodePoolName = node.Labels[projectinfo.GetNodePoolLabel()]   // unsynchronized write
	return nif.nodePoolName
}
```

This is not an unusual configuration, it is the default one. `--nodepool-name` is optional:
`charts/yurthub/values.yaml` ships `nodePoolName: ""`, and both the static pod and the
systemd unit templates in `pkg/yurtadm/constants/constants.go` only emit the flag inside
`{{if .nodePoolName}}`. With the flag unset, the lazy path above runs for every filtered
object.

**Why it matters.** `nodePoolName` is a `string`, i.e. a two-word pointer/length header, so a
concurrent reader can observe a *torn* value — the pointer of one string with the length of
another — not merely a stale one. Both filters then misbehave silently:

- `servicetopology`: `nodePoolTopologyHandler()` passes the value to `stf.nodesGetter(...)`.
  A torn name makes the node pool lookup fail, and the filter logs a warning and returns the
  **unfiltered** EndpointSlice. kube-proxy then programs endpoints from outside the node
  pool and service traffic leaves the pool — the exact thing the filter exists to prevent.
- `nodeportisolation`: a torn name makes `isNodePoolEnabled()` return false, so a NodePort
  service that *should* be listened on this node pool is dropped from kube-proxy's view and
  the NodePort silently stops working on that node.

**The fix.** Guard `nodePoolName` with a `sync.RWMutex` in both filters, in
`SetNodePoolName()` and in `resolveNodePoolName()`. The `Nodes().Get()` call is deliberately
kept *outside* the lock: holding a write lock across a kube-apiserver round trip would let
one slow or hanging API call block every other goroutine that is filtering a response, which
matters most during a cloud-edge disconnect. The error path now returns `""` explicitly
instead of re-reading the field; that is the same value it returned before, since the field
is only read there in the case where it was already empty.

This deliberately does not change *when* the node is fetched. Collapsing the repeated
`Nodes().Get()` calls that happen while a node has no node pool label is a separate
behavioural question (it needs a decision about caching a negative result), so it is left
out of a bug fix.

#### Which issue(s) this PR fixes:

Fixes #2714

#### Special notes for your reviewer:

Verified with go1.25.0 (matching `go.mod`):

- The race is real and was confirmed before writing the fix. Each new test was run against
  the **unmodified** filters and both report `WARNING: DATA RACE` in `resolveNodePoolName()`
  and fail; with the fix applied both pass.
- `go build ./...` — clean for the whole repo.
- `go vet ./pkg/yurthub/filter/...` — clean. Worth noting because adding a mutex to these
  structs would make `vet`'s copylocks check fail if either filter were ever copied by
  value; it is not.
- `gofmt -l` on the changed files — clean.
- `go test -race -count=1 ./pkg/yurthub/filter/...` — all packages pass.
- `go test -count=1 ./pkg/yurthub/...` — all packages pass, no regressions.

The two new tests are `TestResolveNodePoolNameConcurrently` in each package. Both drive the
real `Filter()` entry point concurrently against a shared filter instance with the node pool
name left unset, and assert the filtering result on top of tripping the race detector.
Please run them with `-race`: the `test` target in the `Makefile` does not pass `-race`,
which is why this was never caught in CI.

AI assistance (Claude) was used to investigate and implement this change; I reviewed and
verified the result.

#### Does this PR introduce a user-facing change?

```release-note
Fix a data race on the cached node pool name in the yurthub servicetopology and nodeportisolation filters, which could cause endpoints outside the node pool to be returned to kube-proxy or a NodePort service to be dropped on nodes where --nodepool-name is not set.
```
