### PR TITLE
fix: add node identity to yurt-hub-multiplexer-binding during node-se…

### DIFF
--- a/charts/yurt-manager/templates/yurt-manager.yaml
+++ b/charts/yurt-manager/templates/yurt-manager.yaml
@@ -38,6 +38,35 @@ subjects:
   name: yurt-manager
   namespace: {{ .Release.Namespace }}
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-servant
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-servant
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings"]
+    resourceNames: ["yurt-hub-multiplexer-binding"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-servant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-servant
+subjects:
+  - kind: ServiceAccount
+    name: node-servant
+    namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/pkg/node-servant/constant.go
+++ b/pkg/node-servant/constant.go
@@ -49,6 +49,7 @@ spec:
       hostPID: true
       hostNetwork: true
       restartPolicy: Never
+      serviceAccountName: node-servant
       nodeName: {{.nodeName}}
       tolerations:
       - operator: Exists

--- a/pkg/node-servant/convert/convert.go
+++ b/pkg/node-servant/convert/convert.go
@@ -17,8 +17,16 @@ limitations under the License.
 package convert
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	nodeservant "github.com/openyurtio/openyurt/pkg/node-servant"
 	"github.com/openyurtio/openyurt/pkg/node-servant/components"
@@ -26,7 +34,10 @@ import (
 	yurthubutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
 
-const bootstrapModeKubeletCertificate = "kubeletcertificate"
+const (
+	bootstrapModeKubeletCertificate   = "kubeletcertificate"
+	multiplexerClusterRoleBindingName = "yurt-hub-multiplexer-binding"
+)
 
 var (
 	getAPIServerAddressFunc = components.GetAPIServerAddress
@@ -38,6 +49,24 @@ var (
 	}
 	restartContainersFunc = func(nodeName string) error {
 		return components.RestartNonPauseContainers(nodeName, conversionJobPodPrefix(nodeName))
+	}
+	getKubeClientFunc = func(kubeadmConfPaths []string) (kubernetes.Interface, error) {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			for _, path := range kubeadmConfPaths {
+				if len(path) == 0 {
+					continue
+				}
+				if c, err := clientcmd.BuildConfigFromFlags("", path); err == nil {
+					cfg = c
+					break
+				}
+			}
+		}
+		if cfg == nil {
+			return nil, fmt.Errorf("failed to get kube client config")
+		}
+		return kubernetes.NewForConfig(cfg)
 	}
 )
 
@@ -69,6 +98,9 @@ func NewConverterWithOptions(o *Options) *nodeConverter {
 // Do is used for the convert job.
 // shall be implemented as idempotent, can execute multiple times with no side effect.
 func (n *nodeConverter) Do() error {
+	if err := n.ensureNodeInMultiplexerRBAC(); err != nil {
+		return err
+	}
 	if err := n.installYurtHub(); err != nil {
 		return err
 	}
@@ -77,6 +109,41 @@ func (n *nodeConverter) Do() error {
 	}
 	if err := n.restartContainers(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (n *nodeConverter) ensureNodeInMultiplexerRBAC() error {
+	client, err := getKubeClientFunc(n.kubeadmConfPaths)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client for RBAC update: %w", err)
+	}
+
+	crb, err := client.RbacV1().ClusterRoleBindings().Get(context.TODO(), multiplexerClusterRoleBindingName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("ClusterRoleBinding %s not found: %w", multiplexerClusterRoleBindingName, err)
+		}
+		return fmt.Errorf("failed to get ClusterRoleBinding %s: %w", multiplexerClusterRoleBindingName, err)
+	}
+
+	targetSubject := rbacv1.Subject{
+		Kind:     "User",
+		Name:     "system:node:" + n.nodeName,
+		APIGroup: "rbac.authorization.k8s.io",
+	}
+
+	for _, sub := range crb.Subjects {
+		if sub.Kind == targetSubject.Kind && sub.Name == targetSubject.Name && sub.APIGroup == targetSubject.APIGroup {
+			return nil
+		}
+	}
+
+	crb.Subjects = append(crb.Subjects, targetSubject)
+	_, err = client.RbacV1().ClusterRoleBindings().Update(context.TODO(), crb, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update ClusterRoleBinding %s: %w", multiplexerClusterRoleBindingName, err)
 	}
 
 	return nil

--- a/pkg/node-servant/convert/convert_test.go
+++ b/pkg/node-servant/convert/convert_test.go
@@ -17,24 +17,57 @@ limitations under the License.
 package convert
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
 	yurthubutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
+
+func newFakeClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: multiplexerClusterRoleBindingName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "Group",
+				Name:     "openyurt:multiplexer",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "yurt-hub-multiplexer",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+}
 
 func TestNodeConverterDo(t *testing.T) {
 	oldGetAPIServerAddressFunc := getAPIServerAddressFunc
 	oldInstallYurthubFunc := installYurthubFunc
 	oldRedirectKubeletFunc := redirectKubeletFunc
 	oldRestartContainersFunc := restartContainersFunc
+	oldGetKubeClientFunc := getKubeClientFunc
 	defer func() {
 		getAPIServerAddressFunc = oldGetAPIServerAddressFunc
 		installYurthubFunc = oldInstallYurthubFunc
 		redirectKubeletFunc = oldRedirectKubeletFunc
 		restartContainersFunc = oldRestartContainersFunc
+		getKubeClientFunc = oldGetKubeClientFunc
 	}()
+
+	fakeClient := fake.NewSimpleClientset(newFakeClusterRoleBinding())
+	getKubeClientFunc = func(kubeadmConfPaths []string) (kubernetes.Interface, error) {
+		return fakeClient, nil
+	}
 
 	converter := &nodeConverter{
 		Config: Config{
@@ -94,6 +127,86 @@ func TestNodeConverterDo(t *testing.T) {
 	if !reflect.DeepEqual(gotCfg, wantCfg) {
 		t.Fatalf("unexpected yurthub host config, got=%#v, want=%#v", gotCfg, wantCfg)
 	}
+
+	// Verify RBAC update
+	crb, err := fakeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), multiplexerClusterRoleBindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get CRB: %v", err)
+	}
+	found := false
+	for _, sub := range crb.Subjects {
+		if sub.Kind == "User" && sub.Name == "system:node:node-a" && sub.APIGroup == "rbac.authorization.k8s.io" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected subject User system:node:node-a in CRB subjects: %v", crb.Subjects)
+	}
+}
+
+func TestEnsureNodeInMultiplexerRBACIdempotency(t *testing.T) {
+	oldGetKubeClientFunc := getKubeClientFunc
+	defer func() {
+		getKubeClientFunc = oldGetKubeClientFunc
+	}()
+
+	fakeClient := fake.NewSimpleClientset(newFakeClusterRoleBinding())
+	getKubeClientFunc = func(kubeadmConfPaths []string) (kubernetes.Interface, error) {
+		return fakeClient, nil
+	}
+
+	converter := &nodeConverter{
+		Config: Config{
+			nodeName: "node-a",
+		},
+	}
+
+	// Run twice to verify idempotency
+	if err := converter.ensureNodeInMultiplexerRBAC(); err != nil {
+		t.Fatalf("first ensureNodeInMultiplexerRBAC() failed: %v", err)
+	}
+	if err := converter.ensureNodeInMultiplexerRBAC(); err != nil {
+		t.Fatalf("second ensureNodeInMultiplexerRBAC() failed: %v", err)
+	}
+
+	crb, err := fakeClient.RbacV1().ClusterRoleBindings().Get(context.TODO(), multiplexerClusterRoleBindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get CRB: %v", err)
+	}
+
+	userCount := 0
+	for _, sub := range crb.Subjects {
+		if sub.Kind == "User" && sub.Name == "system:node:node-a" {
+			userCount++
+		}
+	}
+	if userCount != 1 {
+		t.Fatalf("expected exactly 1 User system:node:node-a subject, got %d", userCount)
+	}
+}
+
+func TestEnsureNodeInMultiplexerRBACMissingCRB(t *testing.T) {
+	oldGetKubeClientFunc := getKubeClientFunc
+	defer func() {
+		getKubeClientFunc = oldGetKubeClientFunc
+	}()
+
+	fakeClient := fake.NewSimpleClientset()
+	getKubeClientFunc = func(kubeadmConfPaths []string) (kubernetes.Interface, error) {
+		return fakeClient, nil
+	}
+
+	converter := &nodeConverter{
+		Config: Config{
+			nodeName: "node-a",
+		},
+	}
+
+	err := converter.ensureNodeInMultiplexerRBAC()
+	if err == nil {
+		t.Fatal("expected error when ClusterRoleBinding is missing, got nil")
+	}
 }
 
 func TestNodeConverterStopsWhenInstallFails(t *testing.T) {
@@ -101,12 +214,19 @@ func TestNodeConverterStopsWhenInstallFails(t *testing.T) {
 	oldInstallYurthubFunc := installYurthubFunc
 	oldRedirectKubeletFunc := redirectKubeletFunc
 	oldRestartContainersFunc := restartContainersFunc
+	oldGetKubeClientFunc := getKubeClientFunc
 	defer func() {
 		getAPIServerAddressFunc = oldGetAPIServerAddressFunc
 		installYurthubFunc = oldInstallYurthubFunc
 		redirectKubeletFunc = oldRedirectKubeletFunc
 		restartContainersFunc = oldRestartContainersFunc
+		getKubeClientFunc = oldGetKubeClientFunc
 	}()
+
+	fakeClient := fake.NewSimpleClientset(newFakeClusterRoleBinding())
+	getKubeClientFunc = func(kubeadmConfPaths []string) (kubernetes.Interface, error) {
+		return fakeClient, nil
+	}
 
 	converter := &nodeConverter{
 		Config: Config{


### PR DESCRIPTION
## Problem

During node-servant conversion, YurtHub authenticates using the kubelet's
existing client certificate (`CN=system:node:<node-name>`, `O=system:nodes`).
The static `yurt-hub-multiplexer-binding` ClusterRoleBinding grants access
only to the custom group `openyurt:multiplexer`, which is not present on
kubelet certificates and is never assigned by any dynamic mechanism.

This causes YurtHub to receive 403s on ConfigMaps/NodePools requests, and
the hub never becomes Ready after node-servant conversion.

Fixes #2716

## Fix

Added `ensureNodeInMultiplexerRBAC()` as the **first step** in
`nodeConverter.Do()` (before `installYurtHub()`). It idempotently patches
`yurt-hub-multiplexer-binding` to append a per-node User subject:
```yaml
- kind: User
  name: system:node:<node-name>
  apiGroup: rbac.authorization.k8s.io
