### PR TITLE
fix(yurt-manager): resolve endpointslice patch collision by using Uni…

### DIFF
--- a/pkg/yurtmanager/controller/servicetopology/adapter/adapter.go
+++ b/pkg/yurtmanager/controller/servicetopology/adapter/adapter.go
@@ -51,6 +51,8 @@ func appendKeys(keys []string, obj interface{}) []string {
 }
 
 func getUpdateTriggerPatch() []byte {
-	patch := fmt.Sprintf(`{"metadata":{"annotations": {"openyurt.io/update-trigger": "%d"}}}`, time.Now().Unix())
-	return []byte(patch)
+    // Changed Unix() to UnixNano() to prevent patch collisions if multiple 
+    // service annotations are updated within the same second.
+    patch := fmt.Sprintf(`{"metadata":{"annotations": {"openyurt.io/update-trigger": "%d"}}}`, time.Now().UnixNano())
+    return []byte(patch)
 }


### PR DESCRIPTION
…xNano timestamp

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design
> /sig ai
> /sig iot
> /sig network
> /sig storage

#### What this PR does / why we need it:

This PR resolves a race condition in the `servicetopology` controller that caused topology annotation changes to appear inert at the edge. 

Previously, `UpdateTriggerAnnotations` utilized `time.Now().Unix()` to generate the `openyurt.io/update-trigger` patch. Because this only resolves to the second, rapid updates to multiple Services within the same 1-second window resulted in identical patch payloads. The Kubernetes API server dropped these identical patches due to idempotency, meaning no watch events were propagated to `yurthub`. 

By upgrading the timestamp generation to `time.Now().UnixNano()`, every patch is guaranteed to mutate the object state, ensuring reliable event propagation to the edge nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2612 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
