### PR TITLE
fix(yurtmanager): prevent nil map assignment panic in hubleader controller

### DIFF
--- a/pkg/yurtmanager/controller/hubleader/hubleader_controller.go
+++ b/pkg/yurtmanager/controller/hubleader/hubleader_controller.go
@@ -176,8 +176,10 @@ func (r *ReconcileHubLeader) reconcileHubLeader(ctx context.Context, nodepool *a
 	// Set match labels
 	matchLabels := make(map[string]string)
 	if nodepool.Spec.LeaderElectionStrategy == string(appsv1beta2.ElectionStrategyMark) {
-		// Add mark strategy match labels
-		matchLabels = nodepool.Spec.LeaderNodeLabelSelector
+		// Add mark strategy match labels safely without overwriting matchLabels with a potential nil map
+		for k, v := range nodepool.Spec.LeaderNodeLabelSelector {
+			matchLabels[k] = v
+		}
 	}
 	matchLabels[projectinfo.GetNodePoolLabel()] = nodepool.GetName()
 

--- a/pkg/yurtmanager/controller/hubleader/hubleader_controller.go
+++ b/pkg/yurtmanager/controller/hubleader/hubleader_controller.go
@@ -177,9 +177,7 @@ func (r *ReconcileHubLeader) reconcileHubLeader(ctx context.Context, nodepool *a
 	matchLabels := make(map[string]string)
 	if nodepool.Spec.LeaderElectionStrategy == string(appsv1beta2.ElectionStrategyMark) {
 		// Add mark strategy match labels safely without overwriting matchLabels with a potential nil map
-		for k, v := range nodepool.Spec.LeaderNodeLabelSelector {
-			matchLabels[k] = v
-		}
+		maps.Copy(matchLabels, nodepool.Spec.LeaderNodeLabelSelector)
 	}
 	matchLabels[projectinfo.GetNodePoolLabel()] = nodepool.GetName()
 

--- a/pkg/yurtmanager/controller/hubleader/hubleader_controller_test.go
+++ b/pkg/yurtmanager/controller/hubleader/hubleader_controller_test.go
@@ -328,6 +328,48 @@ func TestReconcile(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		"mark election strategy with nil LeaderNodeLabelSelector": {
+			pool: &appsv1beta2.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hangzhou",
+				},
+				Spec: appsv1beta2.NodePoolSpec{
+					Type: appsv1beta2.Edge,
+					Labels: map[string]string{
+						"region": "hangzhou",
+					},
+					LeaderElectionStrategy:  string(appsv1beta2.ElectionStrategyMark),
+					LeaderNodeLabelSelector: nil,
+					LeaderReplicas:          1,
+					EnableLeaderElection:    true,
+				},
+			},
+			expectedNodePool: &appsv1beta2.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hangzhou",
+				},
+				Spec: appsv1beta2.NodePoolSpec{
+					Type: appsv1beta2.Edge,
+					Labels: map[string]string{
+						"region": "hangzhou",
+					},
+					LeaderElectionStrategy:  string(appsv1beta2.ElectionStrategyMark),
+					LeaderNodeLabelSelector: nil,
+					EnableLeaderElection:    true,
+					LeaderReplicas:          1,
+				},
+				Status: appsv1beta2.NodePoolStatus{
+					LeaderEndpoints: []appsv1beta2.Leader{
+						{
+							NodeName: "ready with internal IP",
+							Address:  "10.0.0.1",
+						},
+					},
+					LeaderNum: 1,
+				},
+			},
+			expectErr: false,
+		},
 		"no potential leaders in hangzhou with mark strategy": {
 			pool: &appsv1beta2.NodePool{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### What this PR does / why we need it
Fixes a potential `nil` map assignment panic in `hubleader_controller`.

When `nodepool.Spec.LeaderElectionStrategy` is set to `mark` but `nodepool.Spec.LeaderNodeLabelSelector` is `nil` (or omitted), `matchLabels = nodepool.Spec.LeaderNodeLabelSelector` overwrote the non-nil `matchLabels` map with `nil`. Attempting to write `matchLabels[projectinfo.GetNodePoolLabel()] = nodepool.GetName()` subsequently triggered a runtime panic (`panic: assignment to entry in nil map`).

This PR safely iterates and copies key-value pairs from `nodepool.Spec.LeaderNodeLabelSelector` into `matchLabels` without replacing the non-nil map reference.

### Which issue(s) this PR fixes
N/A

### Special notes for your reviewer
- Added unit test case `mark election strategy with nil LeaderNodeLabelSelector` to `pkg/yurtmanager/controller/hubleader/hubleader_controller_test.go`.
- All package unit tests and race detection tests pass cleanly.