### PR TITLE
Bugfix: avoid nil map panic when raven DNS ConfigMap has no data section

### DIFF
--- a/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go
+++ b/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go
@@ -153,6 +153,11 @@ func (r *ReconcileDNS) Reconcile(ctx context.Context, req reconcile.Request) (re
 		klog.Error(Format("could not list node, error %s", err.Error()))
 		return reconcile.Result{Requeue: true, RequeueAfter: 2 * time.Second}, err
 	}
+	// The ConfigMap is read from the cluster, so its data section may be absent even
+	// though buildRavenDNSConfigMap always creates it with one.
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
 	cm.Data[util.ProxyNodesKey] = buildDNSRecords(&nodeList, enableProxy, proxyAddress)
 	err = r.updateDNS(cm)
 	if err != nil {

--- a/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller_test.go
+++ b/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller_test.go
@@ -205,3 +205,33 @@ func TestReconcileDNS_getService(t *testing.T) {
 		assert.Equal(t, ProxyIP, svc.Spec.ClusterIP, "expected correct clusterIP")
 	})
 }
+
+func TestReconcileDNS_ReconcileConfigMapWithoutData(t *testing.T) {
+	// The DNS ConfigMap is read from the cluster, so it may exist without a data
+	// section. buildRavenDNSConfigMap is only called when the ConfigMap is absent,
+	// so that path does not guarantee Data is populated.
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.RavenProxyNodesConfig,
+			Namespace: util.WorkingNamespace,
+		},
+	}
+	c := fake.NewClientBuilder().WithRuntimeObjects([]runtime.Object{cm, &v1.NodeList{}}...).Build()
+	r := &ReconcileDNS{Client: c, recorder: record.NewFakeRecorder(100)}
+
+	t.Run("reconcile does not panic when the configmap has no data", func(t *testing.T) {
+		res, err := r.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: util.WorkingNamespace, Name: util.RavenProxyNodesConfig},
+		})
+		assert.Equal(t, reconcile.Result{}, res)
+		assert.NoError(t, err)
+
+		updated := &v1.ConfigMap{}
+		err = r.Get(context.TODO(), client.ObjectKey{
+			Namespace: util.WorkingNamespace,
+			Name:      util.RavenProxyNodesConfig,
+		}, updated)
+		assert.NoError(t, err)
+		assert.Contains(t, updated.Data, util.ProxyNodesKey, "expected the dns record key to be populated")
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network

#### What this PR does / why we need it:

`ReconcileDNS.Reconcile` writes the generated DNS records straight into `cm.Data`:

```go
// pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go:156
cm.Data[util.ProxyNodesKey] = buildDNSRecords(&nodeList, enableProxy, proxyAddress)
```

`cm` comes from `getProxyDNS`, which reads the ConfigMap from the cluster and only falls back to creating one when it is `NotFound`:

```go
err = r.Get(ctx, objKey, &cm)
if err != nil {
    if apierrors.IsNotFound(err) {
        err = r.buildRavenDNSConfigMap()
        ...
```

`buildRavenDNSConfigMap` does populate `Data`, but that path only runs when the object is missing. A ConfigMap that **exists without a data section** is perfectly valid, so `Data` can legitimately be `nil` on the read path, and the assignment panics — crashing the yurt-manager DNS controller.

This is reachable in normal operation whenever `raven-proxy-nodes` is created or edited without data, for example:

- `kubectl create configmap raven-proxy-nodes -n kube-system` with no keys
- removing the last key from it
- a GitOps/Helm manifest that renders the ConfigMap without a `data:` section

#### Reproduction

Reconciling against a ConfigMap with no data section panics on current `master`:

```
--- FAIL: TestReconcileDNS_ReconcileConfigMapWithoutData
panic: assignment to entry in nil map [recovered, repanicked]

github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/dns.(*ReconcileDNS).Reconcile
    pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go:156
```

#### Which issue(s) this PR fixes:

No existing issue — found while reading the raven DNS controller.

#### Proposed changes

Initialise the map before writing to it:

```go
// The ConfigMap is read from the cluster, so its data section may be absent even
// though buildRavenDNSConfigMap always creates it with one.
if cm.Data == nil {
    cm.Data = make(map[string]string)
}
cm.Data[util.ProxyNodesKey] = buildDNSRecords(&nodeList, enableProxy, proxyAddress)
```

Reconcile then repopulates the record and persists it through the existing `updateDNS` call, so a ConfigMap that lost its data is repaired rather than crashing the controller.

#### Testing

The existing tests seed the ConfigMap with a populated `Data` map (`mockKubeClient`), which is why this path was never exercised. Added `TestReconcileDNS_ReconcileConfigMapWithoutData`, which reconciles against a ConfigMap with no data section and asserts that reconcile succeeds and that the DNS record key ends up populated. I confirmed it panics at the line above without the fix and passes with it.

```
$ go test ./pkg/yurtmanager/controller/raven/...
ok      github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/dns
ok      github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/gatewaypickup
ok      github.com/openyurtio/openyurt/pkg/yurtmanager/controller/raven/gatewaypublicservice

$ GOOS=linux GOARCH=amd64 go build ./pkg/yurtmanager/...
$ go vet ./pkg/yurtmanager/controller/raven/dns/...
```