### PR TITLE
fix(node-servant): add system:nodes group to yurt-hub-multiplexer ClusterRoleBinding

### DIFF
--- a/pkg/node-servant/convert/convert.go
+++ b/pkg/node-servant/convert/convert.go
@@ -17,8 +17,15 @@ limitations under the License.
 package convert
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 
 	nodeservant "github.com/openyurtio/openyurt/pkg/node-servant"
 	"github.com/openyurtio/openyurt/pkg/node-servant/components"
@@ -27,6 +34,8 @@ import (
 )
 
 const bootstrapModeKubeletCertificate = "kubeletcertificate"
+
+const multiplexerClusterRoleBindingName = "yurt-hub-multiplexer-binding"
 
 var (
 	getAPIServerAddressFunc = components.GetAPIServerAddress
@@ -38,6 +47,13 @@ var (
 	}
 	restartContainersFunc = func(nodeName string) error {
 		return components.RestartNonPauseContainers(nodeName, conversionJobPodPrefix(nodeName))
+	}
+	getKubeClientFunc = func() (kubernetes.Interface, error) {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get in-cluster config: %w", err)
+		}
+		return kubernetes.NewForConfig(cfg)
 	}
 )
 
@@ -69,6 +85,9 @@ func NewConverterWithOptions(o *Options) *nodeConverter {
 // Do is used for the convert job.
 // shall be implemented as idempotent, can execute multiple times with no side effect.
 func (n *nodeConverter) Do() error {
+	if err := n.ensureMultiplexerRBAC(); err != nil {
+		return fmt.Errorf("failed to configure RBAC: %w", err)
+	}
 	if err := n.installYurtHub(); err != nil {
 		return err
 	}
@@ -92,6 +111,43 @@ func (n *nodeConverter) installYurtHub() error {
 	}
 
 	return installYurthubFunc(n.yurthubHostConfig(apiServerAddress))
+}
+
+func (n *nodeConverter) ensureMultiplexerRBAC() error {
+	client, err := getKubeClientFunc()
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes client for RBAC setup: %w", err)
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		crb, err := client.RbacV1().ClusterRoleBindings().Get(
+			context.TODO(),
+			multiplexerClusterRoleBindingName,
+			metav1.GetOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to get ClusterRoleBinding %q: %w", multiplexerClusterRoleBindingName, err)
+		}
+
+		for _, sub := range crb.Subjects {
+			if sub.Kind == rbacv1.GroupKind && sub.Name == "system:nodes" {
+				return nil
+			}
+		}
+
+		crb.Subjects = append(crb.Subjects, rbacv1.Subject{
+			Kind:     rbacv1.GroupKind,
+			Name:     "system:nodes",
+			APIGroup: rbacv1.GroupName,
+		})
+
+		_, err = client.RbacV1().ClusterRoleBindings().Update(
+			context.TODO(),
+			crb,
+			metav1.UpdateOptions{},
+		)
+		return err
+	})
 }
 
 func (n *nodeConverter) convertKubelet() error {

--- a/pkg/node-servant/convert/convert_test.go
+++ b/pkg/node-servant/convert/convert_test.go
@@ -21,10 +21,26 @@ import (
 	"reflect"
 	"testing"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
 	yurthubutil "github.com/openyurtio/openyurt/pkg/yurtadm/util/yurthub"
 )
 
 func TestNodeConverterDo(t *testing.T) {
+	fakeCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: multiplexerClusterRoleBindingName,
+		},
+		Subjects: []rbacv1.Subject{},
+	}
+
+	getKubeClientFunc = func() (kubernetes.Interface, error) {
+		return fake.NewSimpleClientset(fakeCRB), nil
+	}
+
 	oldGetAPIServerAddressFunc := getAPIServerAddressFunc
 	oldInstallYurthubFunc := installYurthubFunc
 	oldRedirectKubeletFunc := redirectKubeletFunc
@@ -94,6 +110,7 @@ func TestNodeConverterDo(t *testing.T) {
 	if !reflect.DeepEqual(gotCfg, wantCfg) {
 		t.Fatalf("unexpected yurthub host config, got=%#v, want=%#v", gotCfg, wantCfg)
 	}
+
 }
 
 func TestNodeConverterStopsWhenInstallFails(t *testing.T) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
 /kind bug


#### What this PR does / why we need it:
Fixes node-servant conversion failing with "context deadline exceeded" during label-driven edge node conversion. Root cause: YurtHub authenticates as `system:node:<name>`, but the `yurt-hub-multiplexer` ClusterRole is bound only to the `openyurt:multiplexer` group. Since node identities are never added to this group, YurtHub is being denied access to ConfigMaps and NodePool resources it needs at startup, causing it to never reach a ready state, node-servant then times out waiting for YurtHub's readiness signal.

This PR adds the `system:nodes` group (which all node identities automatically belong to) to the `yurt-hub-multiplexer-binding` ClusterRoleBinding as part of the conversion process. This is done once, idempotently, covering all current and future nodes — rather than adding individual per-node entries, which would grow unboundedly at scale.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2716 

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
This adds a `system:nodes` Group subject rather than per-node User entries, to avoid the ClusterRoleBinding's subject list growing unboundedly as nodes are converted. Uses `retry.RetryOnConflict` to handle concurrent conversions safely.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Fixed node-servant conversion failing with "context deadline exceeded" due to missing RBAC permissions for YurtHub during edge node conversion.
```

#### other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager
If the PR title name begins with [WIP], OpenYurt-bot automatically adds a do-not-merge/work-in-progress label for your pr 
-->
