### PR TITLE
fix(yurthub): resolve data races, tombstone panics, and filter store leaks in MultiplexerManager

### DIFF
--- a/pkg/yurthub/multiplexer/multiplexer.go
+++ b/pkg/yurthub/multiplexer/multiplexer.go
@@ -110,33 +110,58 @@ func NewRequestMultiplexerManager(
 }
 
 func (m *MultiplexerManager) addConfigmap(obj interface{}) {
-	cm, _ := obj.(*corev1.ConfigMap)
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		if tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown); isTombstone {
+			cm, ok = tombstone.Obj.(*corev1.ConfigMap)
+		}
+	}
+	if !ok || cm == nil {
+		return
+	}
 
 	m.updateLeaderHubConfiguration(cm)
+	m.RLock()
+	source := m.sourceForPoolScopeMetadata
+	metadata := m.poolScopeMetadata.Clone()
+	m.RUnlock()
+
 	klog.Infof(
 		"after added configmap, source for pool scope metadata: %s, pool scope metadata: %v",
-		m.sourceForPoolScopeMetadata,
-		m.poolScopeMetadata,
+		source,
+		metadata,
 	)
 }
 
 func (m *MultiplexerManager) updateConfigmap(oldObj, newObj interface{}) {
-	oldCM, _ := oldObj.(*corev1.ConfigMap)
-	newCM, _ := newObj.(*corev1.ConfigMap)
+	oldCM, okOld := oldObj.(*corev1.ConfigMap)
+	newCM, okNew := newObj.(*corev1.ConfigMap)
+	if !okOld || !okNew || oldCM == nil || newCM == nil {
+		return
+	}
 
 	if maps.Equal(oldCM.Data, newCM.Data) {
 		return
 	}
 
 	m.updateLeaderHubConfiguration(newCM)
+	m.RLock()
+	source := m.sourceForPoolScopeMetadata
+	metadata := m.poolScopeMetadata.Clone()
+	m.RUnlock()
+
 	klog.Infof(
 		"after updated configmap, source for pool scope metadata: %s, pool scope metadata: %v",
-		m.sourceForPoolScopeMetadata,
-		m.poolScopeMetadata,
+		source,
+		metadata,
 	)
 }
 
 func (m *MultiplexerManager) updateLeaderHubConfiguration(cm *corev1.ConfigMap) {
+	if cm == nil {
+		return
+	}
+
 	newPoolScopeMetadata := sets.New[string]()
 	if len(cm.Data[PoolScopeMetadataKey]) != 0 {
 		for _, part := range strings.Split(cm.Data[PoolScopeMetadataKey], ",") {
@@ -172,6 +197,9 @@ func (m *MultiplexerManager) updateLeaderHubConfiguration(cm *corev1.ConfigMap) 
 		newSource = PoolSourceForPoolScopeMetadata
 	}
 
+	m.Lock()
+	defer m.Unlock()
+
 	// LeaderHubEndpoints are changed, related health checker and load balancer are need to be updated.
 	if !m.leaderAddresses.Equal(newLeaderAddresses) {
 		servers := m.resolveLeaderHubServers(newLeaderAddresses)
@@ -188,8 +216,6 @@ func (m *MultiplexerManager) updateLeaderHubConfiguration(cm *corev1.ConfigMap) 
 	// if pool scope metadata are removed, related GVR cache should be destroyed.
 	deletedPoolScopeMetadata := m.poolScopeMetadata.Difference(newPoolScopeMetadata)
 
-	m.Lock()
-	defer m.Unlock()
 	m.sourceForPoolScopeMetadata = newSource
 	m.poolScopeMetadata = newPoolScopeMetadata
 	for _, gvrStr := range deletedPoolScopeMetadata.UnsortedList() {
@@ -198,6 +224,7 @@ func (m *MultiplexerManager) updateLeaderHubConfiguration(cm *corev1.ConfigMap) 
 		}
 		delete(m.lazyLoadedGVRCacheDestroyFunc, gvrStr)
 		delete(m.lazyLoadedGVRCache, gvrStr)
+		m.filterStoreManager.DeleteFilterStore(gvrStr)
 	}
 }
 

--- a/pkg/yurthub/multiplexer/multiplexer_test.go
+++ b/pkg/yurthub/multiplexer/multiplexer_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplexer
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/proxy/remote"
+)
+
+type dummyHealthChecker struct{}
+
+func (d *dummyHealthChecker) RenewKubeletLeaseTime()                   {}
+func (d *dummyHealthChecker) IsHealthy() bool                          { return true }
+func (d *dummyHealthChecker) BackendIsHealthy(server *url.URL) bool     { return true }
+func (d *dummyHealthChecker) PickOneHealthyBackend() *url.URL          { return nil }
+func (d *dummyHealthChecker) UpdateBackends(servers []*url.URL)        {}
+
+type dummyLoadBalancer struct{}
+
+func (d *dummyLoadBalancer) UpdateBackends(remoteServers []*url.URL) {}
+func (d *dummyLoadBalancer) PickOne(req *http.Request) *remote.RemoteProxy {
+	return nil
+}
+func (d *dummyLoadBalancer) CurrentStrategy() remote.LoadBalancingStrategy {
+	return nil
+}
+
+func TestMultiplexerManager_TombstoneAndNilHandling(t *testing.T) {
+	m := &MultiplexerManager{
+		lazyLoadedGVRCache:            make(map[string]Interface),
+		lazyLoadedGVRCacheDestroyFunc: make(map[string]func()),
+		poolScopeMetadata:             sets.New[string](),
+		leaderAddresses:               sets.New[string](),
+		healthCheckerForLeaders:       &dummyHealthChecker{},
+		loadBalancerForLeaders:        &dummyLoadBalancer{},
+	}
+
+	// 1. Should handle nil object gracefully
+	assert.NotPanics(t, func() {
+		m.addConfigmap(nil)
+		m.updateConfigmap(nil, nil)
+	})
+
+	// 2. Should handle non-ConfigMap invalid types gracefully
+	assert.NotPanics(t, func() {
+		m.addConfigmap("invalid-string-obj")
+		m.updateConfigmap("invalid-old", "invalid-new")
+	})
+
+	// 3. Should handle DeletedFinalStateUnknown tombstone gracefully
+	tombstone := cache.DeletedFinalStateUnknown{
+		Key: "default/leader-hub-pool1",
+		Obj: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "leader-hub-pool1",
+				Namespace: "default",
+			},
+			Data: map[string]string{
+				PoolScopeMetadataKey: "apps/v1/deployments",
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		m.addConfigmap(tombstone)
+	})
+	assert.Equal(t, 1, m.poolScopeMetadata.Len())
+	assert.True(t, m.poolScopeMetadata.Has("apps/v1/deployments"))
+}
+
+func TestMultiplexerManager_FilterStoreCleanupOnGVRDeletion(t *testing.T) {
+	fsm := &filterStoreManager{
+		filterStores: make(map[string]*filterStore),
+	}
+	fsm.filterStores["apps/v1/deployments"] = &filterStore{}
+
+	m := &MultiplexerManager{
+		filterStoreManager:            fsm,
+		lazyLoadedGVRCache:            make(map[string]Interface),
+		lazyLoadedGVRCacheDestroyFunc: make(map[string]func()),
+		poolScopeMetadata:             sets.New("apps/v1/deployments"),
+		leaderAddresses:               sets.New[string](),
+		healthCheckerForLeaders:       &dummyHealthChecker{},
+		loadBalancerForLeaders:        &dummyLoadBalancer{},
+	}
+
+	// Update ConfigMap without deployments
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			PoolScopeMetadataKey: "",
+		},
+	}
+
+	m.updateLeaderHubConfiguration(cm)
+
+	// Verify filterStore for apps/v1/deployments was purged
+	assert.False(t, m.poolScopeMetadata.Has("apps/v1/deployments"))
+	fsm.RLock()
+	_, exists := fsm.filterStores["apps/v1/deployments"]
+	fsm.RUnlock()
+	assert.False(t, exists, "filterStore for removed GVR should be purged from filterStoreManager")
+}
+
+func TestMultiplexerManager_ConcurrentConfigMapUpdateAndResolution(t *testing.T) {
+	m := &MultiplexerManager{
+		lazyLoadedGVRCache:            make(map[string]Interface),
+		lazyLoadedGVRCacheDestroyFunc: make(map[string]func()),
+		poolScopeMetadata:             sets.New("apps/v1/deployments", "core/v1/services"),
+		leaderAddresses:               sets.New[string](),
+		healthCheckerForLeaders:       &dummyHealthChecker{},
+		loadBalancerForLeaders:        &dummyLoadBalancer{},
+	}
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Goroutine 1: Rapidly updates ConfigMap
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				cm := &corev1.ConfigMap{
+					Data: map[string]string{
+						PoolScopeMetadataKey: "apps/v1/deployments,core/v1/pods",
+						LeaderEndpointsKey:   "node1/10.0.0.1",
+						EnableLeaderElection: "true",
+					},
+				}
+				m.updateLeaderHubConfiguration(cm)
+			}
+		}
+	}()
+
+	// Goroutine 2: Rapidly reads source and resolves requests
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				_ = m.SourceForPoolScopeMetadata()
+
+				req, _ := http.NewRequest("GET", "/api/v1/pods", nil)
+				reqInfo := &apirequest.RequestInfo{
+					Verb:       "list",
+					APIGroup:   "",
+					APIVersion: "v1",
+					Resource:   "pods",
+				}
+				req = req.WithContext(apirequest.WithRequestInfo(req.Context(), reqInfo))
+				_, _ = m.ResolveRequestForPoolScopeMetadata(req)
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network

#### What this PR does / why we need it:

This PR resolves multiple data races, potential nil pointer panics on informer tombstone updates, and memory leaks in the `MultiplexerManager` when the `leader-hub` configmap is updated:
1. **Thread-Safe Log Output**: Clones and accesses the configmap state metrics under a read lock (`RLock`/`RUnlock`) in the `addConfigmap` and `updateConfigmap` event handlers.
2. **Lock Scoping**: Moved the lock acquisition (`m.Lock()`) in `updateLeaderHubConfiguration` to the beginning of the configuration update logic, ensuring all map read/comparison and write operations are synchronized.
3. **Tombstone & Nil Verification**: Checks for `cache.DeletedFinalStateUnknown` tombstones and verifies the assertion result before dereferencing in both configmap event handlers.
4. **Stale cache/filterStore Purging**: Dynamically removes stale entries from `filterStoreManager` when a resource is deleted from pool scope metadata.
5. **Unit Tests**: Adds unit tests covering concurrent reads/writes under race check conditions, tombstone updates, and filter store purges.

#### Which issue(s) this PR fixes:

Fixes #2730

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
