### PR TITLE
Feature: add /openyurt-deploy Claude Code skill for node conversion

### DIFF
--- a/.claude/skills/openyurt-deploy/SKILL.md
+++ b/.claude/skills/openyurt-deploy/SKILL.md
@@ -1,0 +1,41 @@
+---
+description: Deploy OpenYurt onto an existing Kubernetes cluster and convert worker nodes into edge nodes.
+when_to_use: Use when the user wants to install OpenYurt on a running cluster, create a NodePool, convert existing worker nodes into edge nodes, or diagnose/undo a failed node conversion.
+disable-model-invocation: true
+allowed-tools: >
+  Bash(kubectl *)
+  Bash(helm *)
+  Read
+  Grep
+---
+
+# OpenYurt Deploy
+
+Guides the end-to-end setup of OpenYurt on a cluster that already has a working control plane: installing
+`yurt-manager`, creating a `NodePool`, and converting existing worker nodes into edge nodes via the
+label-driven `YurtNodeConversionController`. No SSH or node-side shell access is used — every step is a
+`kubectl` or `helm` command against the API server. The actual privileged work (installing YurtHub,
+redirecting kubelet traffic) happens inside a Job that the controller schedules on the target node, not
+from this session.
+
+`disable-model-invocation` is set because this skill cordons nodes, restarts non-pause containers, and
+changes NodePool membership — it should only run when a user explicitly asks for it, never picked up from
+ambient conversation.
+
+## Flow
+
+1. Read `references/openyurt-deploy-flow.md` and follow it step by step: preflight, `yurt-manager`
+   install/verification, `NodePool` creation, then labeling nodes to trigger conversion.
+2. If a node's `YurtNodeConversionFailed` condition reports `ConvertFailed`, or the conversion Job doesn't
+   reach `Converted` within a few minutes, switch to `references/openyurt-deploy-troubleshooting.md`.
+3. To undo a conversion (single node or full teardown), use `references/openyurt-deploy-uninstall.md`.
+
+## Guardrails
+
+- Never label a node with `apps.openyurt.io/nodepool` without first telling the user the node will be
+  cordoned and its non-pause containers restarted (see the flow doc's warning). Bare pods without an
+  owning controller are deleted permanently, not recreated.
+- Never write to the `openyurt.io/is-edge-worker` label directly — it is controller-managed and reflects
+  a completed conversion, not a request for one.
+- If `kubectl` isn't pointed at the cluster the user expects, stop and confirm the context
+  (`kubectl config current-context`) before making any change.

--- a/.claude/skills/openyurt-deploy/references/openyurt-deploy-flow.md
+++ b/.claude/skills/openyurt-deploy/references/openyurt-deploy-flow.md
@@ -1,0 +1,108 @@
+# Deployment Flow
+
+Target: an existing Kubernetes cluster with a healthy control plane. This flow installs `yurt-manager`,
+creates a `NodePool`, and converts existing worker nodes into edge nodes. It does not cover joining brand
+new nodes (`yurtadm join`) — that's a separate path for nodes that aren't in the cluster yet.
+
+## 1. Preflight
+
+```bash
+kubectl config current-context
+kubectl get nodes -o wide
+```
+
+Confirm the context matches the cluster the user intends to modify, and identify which nodes are
+candidates for conversion.
+
+The conversion Job later chroots into each target node's root filesystem and needs `crictl` (or `docker`)
+resolvable on the **host's** `PATH` — this is how `node-servant` detects the CRI socket
+(`pkg/node-servant/components/runtime.go`). `kubeadm` does not install `crictl` by default on
+containerd-based nodes, so check each candidate node before labeling it:
+
+```bash
+kubectl debug node/<node-name> -it --image=busybox -- chroot /host which crictl
+```
+
+If it's missing, the conversion Job will fail fast during the container-runtime detection step rather than
+leaving the node half-converted — but it's cheaper to catch this before cordoning the node at all.
+
+## 2. Install yurt-manager
+
+`yurt-manager` runs on a control-plane node and owns the `YurtNodeConversionController` that does the
+actual conversion work. Install or upgrade it via the chart in `charts/yurt-manager`, making sure the
+`yurtnodeconversion` controller is enabled:
+
+```bash
+helm upgrade --install yurt-manager ./charts/yurt-manager \
+  --namespace kube-system \
+  --set controllers="*,yurtnodeconversion"
+```
+
+`controllers` follows a `foo,-bar,*` allow/deny list — the default chart value is `-nodelifecycle,*`, which
+already enables everything except `nodelifecycle`, but be explicit about `yurtnodeconversion` since it's
+what this flow depends on. Optional flags if the cluster can't reach the default YurtHub binary mirror:
+
+```bash
+--set extraArgs="{--yurthub-version=v1.7.0,--yurthub-binary-url=http://<internal-mirror>/yurthub}"
+```
+
+Verify the controller is up:
+
+```bash
+kubectl get deploy -n kube-system yurt-manager
+kubectl logs -n kube-system deploy/yurt-manager | grep -i yurtnodeconversion
+```
+
+## 3. Create a NodePool
+
+Every node being converted must belong to a `NodePool` with `spec.type: Edge` — the controller checks this
+before it will touch the node.
+
+```yaml
+apiVersion: apps.openyurt.io/v1beta2
+kind: NodePool
+metadata:
+  name: <pool-name>
+spec:
+  type: Edge
+```
+
+```bash
+kubectl apply -f nodepool.yaml
+kubectl get nodepool <pool-name>
+```
+
+`spec.labels`, `spec.annotations`, and `spec.taints` on the NodePool are applied to every member node once
+converted — set them here if the workload placement needs them, rather than patching nodes individually
+afterward.
+
+## 4. Convert nodes
+
+> **Warning:** labeling a node cordons it (`spec.unschedulable=true`) for the duration of the conversion,
+> and on success the controller restarts every non-pause container on that node so their
+> `KUBERNETES_SERVICE_HOST` env picks up the new YurtHub proxy. Bare pods with no owning controller are
+> deleted and **not** recreated. Confirm with the user before labeling a node that's running production
+> traffic, especially single-replica StatefulSets without a PodDisruptionBudget.
+
+```bash
+kubectl label node <node-name> apps.openyurt.io/nodepool=<pool-name>
+```
+
+This is the only trigger — there's no separate `yurtadm convert` command for existing nodes. The
+controller reconciles on the label, cordons the node, sets a `YurtNodeConversionFailed` condition with
+`reason=Converting`, and creates a Job named `node-servant-conversion-<node-name>` in `kube-system`.
+
+Watch progress:
+
+```bash
+kubectl get node <node-name> -o jsonpath='{.status.conditions[?(@.type=="YurtNodeConversionFailed")]}'
+kubectl get job -n kube-system node-servant-conversion-<node-name>
+kubectl logs -n kube-system job/node-servant-conversion-<node-name>
+```
+
+On success the condition reason moves to `Converted`, the node gets `openyurt.io/is-edge-worker=true`, and
+it's uncordoned automatically. Do not set `openyurt.io/is-edge-worker` by hand — it's the controller's
+source of truth for conversion state, and writing it directly doesn't run any of the underlying setup.
+
+If the Job doesn't reach `Converted` within a few minutes, or the condition reason becomes `ConvertFailed`,
+go to `openyurt-deploy-troubleshooting.md`.

--- a/.claude/skills/openyurt-deploy/references/openyurt-deploy-troubleshooting.md
+++ b/.claude/skills/openyurt-deploy/references/openyurt-deploy-troubleshooting.md
@@ -1,0 +1,77 @@
+# Troubleshooting Node Conversion
+
+Start here whenever a conversion doesn't reach `Converted`, or you need to explain a failure to the user.
+Diagnosis is driven by the `YurtNodeConversionFailed` Node condition plus the conversion Job's status —
+check both before touching anything.
+
+```bash
+kubectl get node <node-name> -o jsonpath='{.status.conditions[?(@.type=="YurtNodeConversionFailed")]}{"\n"}'
+kubectl get job -n kube-system node-servant-conversion-<node-name> -o wide
+kubectl get pods -n kube-system -l openyurt.io/conversion-node=<node-name>
+kubectl logs -n kube-system job/node-servant-conversion-<node-name> --all-containers
+```
+
+## Decision tree
+
+**Condition reason is `Converting`, Job shows no pods yet**
+The Job hasn't been scheduled. Check for a taint or resource pressure keeping it pending:
+
+```bash
+kubectl describe job -n kube-system node-servant-conversion-<node-name>
+```
+
+If it's stuck in `Pending`, the node likely doesn't have room to schedule a privileged, `hostPID`/
+`hostNetwork` pod, or an admission webhook is rejecting it. Check `kubectl get events -n kube-system
+--field-selector involvedObject.name=node-servant-conversion-<node-name>`.
+
+**Condition reason is `Converting`, Job pod is `CrashLoopBackOff` or `Error`**
+Read the Job logs first — the two most common causes:
+
+1. `"crictl is required for container runtime"` (or similar from `NewContainerRuntimeForImage`) — the host
+   node doesn't have `crictl`/`docker` on its `PATH`. This is the preflight check in
+   `openyurt-deploy-flow.md` step 1; install `cri-tools` on the node and re-trigger by removing and
+   re-adding the NodePool label (see below).
+2. Binary download failure for the pinned YurtHub version — the node can't reach the default OSS mirror.
+   Re-run the `yurt-manager` install with `--yurthub-binary-url` pointed at a reachable mirror
+   (`openyurt-deploy-flow.md` step 2), then re-trigger conversion.
+
+**Condition reason is `ConvertFailed`**
+The Job exceeded its `backoffLimit` (default 3) without succeeding — the controller has already uncordoned
+the node, so there's no scheduling impact, but the node is not converted. Fix the underlying cause found
+in the Job logs, then re-trigger:
+
+```bash
+kubectl label node <node-name> apps.openyurt.io/nodepool-
+kubectl label node <node-name> apps.openyurt.io/nodepool=<pool-name>
+```
+
+Removing and re-adding is the supported retry path — the label value must not be edited in place, since
+the controller only reacts to add/remove transitions.
+
+**Condition never appears at all**
+The controller isn't watching this node, which almost always means one of:
+
+- `yurt-manager`'s `--controllers` flag doesn't include `yurtnodeconversion` — check
+  `kubectl logs -n kube-system deploy/yurt-manager | grep controllers`.
+- The `NodePool` referenced by the label doesn't exist, or its `spec.type` is `Cloud` instead of `Edge` —
+  the controller silently skips non-Edge pools. Verify with `kubectl get nodepool <pool-name> -o
+  jsonpath='{.spec.type}'`.
+
+**Job succeeded but workloads on the node are still misbehaving**
+Confirm containers actually restarted — the controller only restarts non-pause containers on success, so a
+container started before conversion may still hold the old `KUBERNETES_SERVICE_HOST`:
+
+```bash
+kubectl get pods -A --field-selector spec.nodeName=<node-name> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.startTime}{"\n"}{end}'
+```
+
+Any pod with a start time before the Job's completion time didn't get the restart and should be deleted
+manually to pick up the new proxy config.
+
+## When to stop and ask the user
+
+- If the node is running bare pods (no Deployment/StatefulSet/DaemonSet owner) — they were deleted
+  permanently by the restart step and can't be recovered by this skill.
+- If retrying conversion twice with the same failure — stop and surface the Job logs verbatim rather than
+  retrying a third time blind.

--- a/.claude/skills/openyurt-deploy/references/openyurt-deploy-uninstall.md
+++ b/.claude/skills/openyurt-deploy/references/openyurt-deploy-uninstall.md
@@ -1,0 +1,58 @@
+# Uninstall / Rollback
+
+## Revert a single node
+
+Removing the NodePool label is the supported rollback path — it triggers the same controller, running the
+Job with the `revert` subcommand instead of `convert`:
+
+```bash
+kubectl label node <node-name> apps.openyurt.io/nodepool-
+```
+
+This cordons the node, sets `YurtNodeConversionFailed` to `reason=Reverting`, and runs a Job that:
+
+1. Restores kubelet's traffic to point directly at the real API server (done first, to minimize
+   disruption).
+2. Stops and disables the `yurthub.service` systemd unit (idempotent — a missing or already-stopped
+   service is not an error).
+3. Removes the systemd unit file and drop-in directory, then reloads systemd.
+4. Removes the `yurthub` binary and its bootstrap config, plus its data/cache directory.
+5. Restarts non-pause containers on the node so they pick up the restored API server address.
+
+On success, the controller removes `openyurt.io/is-edge-worker`, uncordons the node, and sets the
+condition reason to `Reverted`. Confirm:
+
+```bash
+kubectl get node <node-name> -o jsonpath='{.status.conditions[?(@.type=="YurtNodeConversionFailed")]}{"\n"}'
+kubectl get node <node-name> -o jsonpath='{.metadata.labels.openyurt\.io/is-edge-worker}{"\n"}'
+```
+
+The second command should print nothing once revert succeeds. If revert fails
+(`reason=RevertFailed`), the node is uncordoned but still partially converted — check the Job logs the same
+way as in `openyurt-deploy-troubleshooting.md` before retrying with the same label-remove command (it's
+idempotent, safe to repeat).
+
+Same caveat as conversion applies in reverse: the container restart in step 5 will restart every non-pause
+container on the node, so confirm with the user before reverting a node carrying production traffic.
+
+## Tear down a NodePool
+
+Only delete a `NodePool` after every member node has been reverted (no node should still carry that pool's
+label) — deleting it out from under converted nodes doesn't revert them, it just orphans the reference.
+
+```bash
+kubectl get nodes -l apps.openyurt.io/nodepool=<pool-name>
+# should return no nodes before proceeding
+kubectl delete nodepool <pool-name>
+```
+
+## Remove yurt-manager
+
+Only after all NodePools in the cluster are gone or you're decommissioning OpenYurt entirely:
+
+```bash
+helm uninstall yurt-manager -n kube-system
+```
+
+This does not touch already-reverted nodes — they're back to being plain Kubernetes nodes at that point,
+independent of whether `yurt-manager` is still installed.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ gopath
 dockerbuild
 hack/cni
 config/demo
-.claude
+.claude/*
+!.claude/skills/
 
 vendor
 .vscode


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Adds a Claude Code skill (`/openyurt-deploy`) that walks through deploying OpenYurt on an existing
Kubernetes cluster: installing `yurt-manager` with the `yurtnodeconversion` controller enabled, creating
an Edge `NodePool`, and converting existing worker nodes via the label-driven
`YurtNodeConversionController` (`apps.openyurt.io/nodepool` label), per the mechanism introduced in
`docs/proposals/20260303-label-driven-yurthub.md`.

Structure follows the proposal discussed on the issue: a short `SKILL.md` entrypoint with YAML
frontmatter, and separate reference docs for the happy-path flow, troubleshooting, and uninstall/revert,
so a Helm value or label key change only touches one reference file instead of a monolithic command file.

- `allowed-tools` is scoped to `kubectl`/`helm`/`Read`/`Grep` only. The conversion mechanism in this repo
  is fully cluster-native — the controller creates a Job that runs the privileged work on the target node
  — so the skill itself never shells into a node directly (no `ssh`/`systemctl` in the tool scope).
- `disable-model-invocation: true` is set because this skill cordons nodes and restarts non-pause
  containers on success; it should only run on explicit user request, not picked up from ambient
  conversation.
- Troubleshooting reference is keyed off the actual `YurtNodeConversionFailed` node condition reasons
  (`Converting`/`Converted`/`ConvertFailed`/etc.) and the Job's `backoffLimit`, rather than generic advice.
- `.gitignore` needed a small fix (`.claude/*` + `!.claude/skills/`) since `.claude` was fully ignored
  repo-wide, which would have silently dropped the skill files from any commit.

**Scope**: this PR covers `/openyurt-deploy` only. `/openyurt-raven` is intentionally left as a follow-up,
matching the phased scope from the original proposal comment on the issue.

#### Which issue(s) this PR fixes:
Part of #2559

#### Special notes for your reviewer:
Doc/tooling-only change — no Go code, CRDs, or Helm charts modified. Verified locally with `make verify`,
`make lint`, and `make test` (all pass), plus `typos --config ./typos.toml` against the new files.

#### Does this PR introduce a user-facing change?
```release-note
Add a `/openyurt-deploy` Claude Code skill that guides deploying OpenYurt on an existing cluster and
converting worker nodes to edge nodes via the label-driven node conversion controller.
```
