### PR TITLE
Bugfix: reject WatchList on the offline path so clients fall back

### DIFF
--- a/pkg/yurthub/proxy/local/local.go
+++ b/pkg/yurthub/proxy/local/local.go
@@ -175,6 +175,19 @@ func (lp *LocalProxy) localWatch(w http.ResponseWriter, req *http.Request) error
 		return apierrors.NewBadRequest(err.Error())
 	}
 
+	// A WatchList client (sendInitialEvents=true) waits for a synthetic
+	// "k8s.io/initial-events-end" bookmark before it considers its store synced, and this
+	// watch never emits any event at all. Answering 200 would therefore hang the client
+	// forever: the missing bookmark is only ever logged as a warning by client-go's
+	// reflector, never surfaced as an error, so it neither fails nor falls back.
+	// Reject the request instead. client-go treats any error that is not a 429 or a
+	// connection refusal as a signal to fall back to LIST+WATCH, which this proxy can serve
+	// from the local cache.
+	if opts.SendInitialEvents != nil && *opts.SendInitialEvents {
+		klog.V(2).Infof("rejecting watchlist request %s while disconnected, so the client falls back to list+watch", hubutil.ReqString(req))
+		return apierrors.NewBadRequest("yurthub does not support sendInitialEvents(WatchList) while disconnected from the cloud, use list+watch instead")
+	}
+
 	ctx := req.Context()
 	contentType, _ := hubutil.ReqContentTypeFrom(ctx)
 	w.Header().Set(yurtutil.HTTPHeaderContentType, contentType)

--- a/pkg/yurthub/proxy/local/local_test.go
+++ b/pkg/yurthub/proxy/local/local_test.go
@@ -100,6 +100,26 @@ func TestServeHTTPForWatch(t *testing.T) {
 			code:      http.StatusOK,
 			ceil:      61 * time.Second,
 		},
+		// A WatchList client must be rejected rather than parked on a 200 that never
+		// carries the initial-events-end bookmark, so client-go falls back to list+watch.
+		// The tight ceiling is the point: it must fail fast, not hang for the timeout.
+		"watchlist request is rejected immediately": {
+			userAgent: "kubelet",
+			accept:    "application/json",
+			verb:      "GET",
+			path:      "/api/v1/nodes?watch=true&sendInitialEvents=true&resourceVersionMatch=NotOlderThan&allowWatchBookmarks=true&timeoutSeconds=60",
+			code:      http.StatusBadRequest,
+			ceil:      5 * time.Second,
+		},
+		"watch request with sendInitialEvents=false is unaffected": {
+			userAgent: "kubelet",
+			accept:    "application/json",
+			verb:      "GET",
+			path:      "/api/v1/nodes?watch=true&sendInitialEvents=false&timeoutSeconds=5",
+			code:      http.StatusOK,
+			floor:     4 * time.Second,
+			ceil:      6 * time.Second,
+		},
 	}
 
 	resolver := newTestRequestInfoResolver()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

While the cloud is unreachable, `LocalProxy.localWatch` answered a WatchList request (`sendInitialEvents=true`) with a 200, but this offline watch has no events and never emits the synthetic `k8s.io/initial-events-end` bookmark that client-go waits for. client-go's reflector only logs the missing bookmark as a warning — it is never surfaced as an error — so the informer waits forever and never syncs (a permanent hang), rather than falling back.

This returns a 400 before writing the 200 header. client-go treats any error that is not a 429 or a connection refusal as a signal to fall back to LIST+WATCH, which the local proxy can serve from the on-disk cache. The non-WatchList path (`sendInitialEvents` absent or false) is untouched.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Adds two cases to `local_test.go`: a WatchList request must fail fast (asserted under a tight deadline) so the client can fall back, and a `sendInitialEvents=false` request is unaffected.

#### Does this PR introduce a user-facing change?

```release-note
Reject WatchList (sendInitialEvents) requests on yurthub's offline path so client-go falls back to LIST+WATCH instead of hanging.
```
