### PR TITLE
Bugfix: an incomplete list response must not delete cached objects

### DIFF
--- a/pkg/yurthub/cachemanager/cache_manager.go
+++ b/pkg/yurthub/cachemanager/cache_manager.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/watch"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -130,7 +131,7 @@ func (cm *cacheManager) CacheResponse(req *http.Request, prc io.ReadCloser, stop
 	}
 
 	if isList(ctx) {
-		return cm.saveListObject(ctx, info, buf.Bytes())
+		return cm.saveListObject(ctx, info, buf.Bytes(), listRequestIsIncomplete(req))
 	}
 
 	return cm.saveOneObject(ctx, info, buf.Bytes())
@@ -466,7 +467,48 @@ func (cm *cacheManager) saveWatchObject(ctx context.Context, info *apirequest.Re
 	}
 }
 
-func (cm *cacheManager) saveListObject(ctx context.Context, info *apirequest.RequestInfo, b []byte) error {
+// listRequestIsIncomplete reports whether a list request asks for something less than the
+// complete current contents of the collection, so its response must not be used to delete
+// cached objects it does not mention. Three shapes qualify:
+//
+//   - a continuation page (?continue=). This has to be read from the request, because the
+//     LAST page of a paginated list carries an empty continue token in its response — that
+//     is how a client detects the end of the sequence — so the response alone cannot tell a
+//     last page from a complete list.
+//   - a list narrowed to one object by ?fieldSelector=metadata.name=. RequestInfo.Name is
+//     not a reliable signal for this: it is only populated when the value is a valid path
+//     segment, so "..", ".", "" and any value containing "/" or "%" leave it empty. The
+//     selector is decoded directly instead, which is also what the read path
+//     (queryListObject) does, so the two agree.
+//   - a point-in-time read pinned to one exact resourceVersion, which describes the
+//     collection as it was then and says nothing about objects created since.
+func listRequestIsIncomplete(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	if req.URL.Query().Get("continue") != "" {
+		return true
+	}
+	if isListRequestWithNameFieldSelector(req) {
+		return true
+	}
+	// An informer's relist sends resourceVersion=0 (or nothing) with no match parameter,
+	// meaning "any version, newest available" — a current view, which must keep pruning.
+	return req.URL.Query().Get("resourceVersionMatch") == string(metav1.ResourceVersionMatchExact)
+}
+
+// listResponseHasMorePages reports whether a list response carries a continue token,
+// which means it is one page of a paginated list and the remaining objects are on
+// subsequent pages.
+func listResponseHasMorePages(list runtime.Object) bool {
+	accessor, err := meta.ListAccessor(list)
+	if err != nil || accessor == nil {
+		return false
+	}
+	return accessor.GetContinue() != ""
+}
+
+func (cm *cacheManager) saveListObject(ctx context.Context, info *apirequest.RequestInfo, b []byte, reqIsIncomplete bool) error {
 	comp, _ := util.TruncatedClientComponentFrom(ctx)
 	respContentType, _ := util.RespContentTypeFrom(ctx)
 	gvr := schema.GroupVersionResource{
@@ -534,34 +576,113 @@ func (cm *cacheManager) saveListObject(ctx context.Context, info *apirequest.Req
 			Version:   info.APIVersion,
 		})
 		return cm.storeObjectWithKey(key, items[0])
-	} else {
-		// list all objects or with fieldselector/labelselector
-		objs := make(map[storage.Key]runtime.Object)
-		for i := range items {
-			accessor.SetKind(items[i], kind)
-			accessor.SetAPIVersion(items[i], groupVersion)
-			name, _ := accessor.Name(items[i])
-			ns, _ := accessor.Namespace(items[i])
-			if ns == "" {
-				ns = info.Namespace
-			}
-			key, _ := cm.storage.KeyFunc(storage.KeyBuildInfo{
-				Component: comp,
-				Namespace: ns,
-				Name:      name,
-				Resources: info.Resource,
-				Group:     info.APIGroup,
-				Version:   info.APIVersion,
-			})
-			objs[key] = items[i]
-		}
-		// if no objects in cloud cluster(objs is empty), it will clean the old files in the path of rootkey
-		return cm.storage.ReplaceComponentList(comp, schema.GroupVersionResource{
-			Group:    info.APIGroup,
-			Version:  info.APIVersion,
-			Resource: info.Resource,
-		}, info.Namespace, objs)
 	}
+
+	// ReplaceComponentList deletes every object cached under the rootkey that is absent
+	// from the response, so it is only correct for a response that provably carries the
+	// COMPLETE set of objects matching the request. Two kinds of response do not:
+	//
+	//  1. a list narrowed to a single object by ?fieldSelector=metadata.name=<name>. The
+	//     rootkey deliberately excludes the name, so such a response is evidence about
+	//     that one object and never about the collection. An empty one (the object does
+	//     not exist) would otherwise delete the whole collection.
+	//
+	//     info.Name is NOT sufficient to recognise this, which is why the request is
+	//     inspected too: RequestInfo carries the name only when it is a valid path
+	//     segment, so "..", ".", "" and any value containing "/" or "%" leave it empty
+	//     while still being name-selector lists. Both terms are kept deliberately —
+	//     info.Name is a strict subset, but it costs one comparison and still holds if
+	//     the selector decode here ever diverges from the one RequestInfo did, and what
+	//     is being guarded is the deletion of a node's whole cached collection.
+	//  2. one page of a paginated list, which by construction omits the objects on the
+	//     other pages. Both ends of the sequence have to be recognised: the first page by
+	//     the continue token in its response, the last page — otherwise identical to a
+	//     complete list — only by the continue parameter on its request.
+	//
+	// For those, cache the objects the response does carry and delete nothing. Keeping a
+	// stale-but-complete cached view is always better than a fresh-but-truncated one,
+	// because the truncation only becomes visible when the node reboots while
+	// disconnected and serves the cache to kubelet.
+	if partial := info.Name != "" || reqIsIncomplete || listResponseHasMorePages(list); partial {
+		klog.V(4).Infof("%s returned an incomplete set of objects, caching its %d object(s) without deleting the rest",
+			util.ReqInfoString(info), len(items))
+		return cm.storeObjectsWithoutDeleting(comp, info, items, kind, groupVersion)
+	}
+
+	// list all objects or with fieldselector/labelselector
+	objs := make(map[storage.Key]runtime.Object)
+	for i := range items {
+		accessor.SetKind(items[i], kind)
+		accessor.SetAPIVersion(items[i], groupVersion)
+		name, _ := accessor.Name(items[i])
+		ns, _ := accessor.Namespace(items[i])
+		if ns == "" {
+			ns = info.Namespace
+		}
+		key, _ := cm.storage.KeyFunc(storage.KeyBuildInfo{
+			Component: comp,
+			Namespace: ns,
+			Name:      name,
+			Resources: info.Resource,
+			Group:     info.APIGroup,
+			Version:   info.APIVersion,
+		})
+		objs[key] = items[i]
+	}
+	// if no objects in cloud cluster(objs is empty), it will clean the old files in the path of rootkey
+	return cm.storage.ReplaceComponentList(comp, schema.GroupVersionResource{
+		Group:    info.APIGroup,
+		Version:  info.APIVersion,
+		Resource: info.Resource,
+	}, info.Namespace, objs)
+}
+
+// storeObjectsWithoutDeleting caches each object of an incomplete list response
+// individually, leaving every other object already cached for the component in place.
+//
+// Unlike ReplaceComponentList this does not create the collection's directory when the
+// response carries no objects, so a component whose cached collection does not exist yet
+// still has none afterwards. That is deliberate: the realistic case is an empty response
+// to a ?fieldSelector=metadata.name= list, and queryListObject already answers such a
+// request with an empty list rather than an error when nothing is cached. Writing any
+// object creates the directories on the way (CreateFile creates its parents), so a
+// paginated sequence that returns objects needs nothing extra here either.
+func (cm *cacheManager) storeObjectsWithoutDeleting(comp string, info *apirequest.RequestInfo, items []runtime.Object, kind, groupVersion string) error {
+	accessor := meta.NewAccessor()
+	errs := make([]error, 0, len(items))
+	for i := range items {
+		// An unassigned pod is deliberately not cached (storeObjectWithKey rejects it),
+		// which is normal for a list response and must not be reported as a failure.
+		if isNotAssignedPod(items[i]) {
+			continue
+		}
+		accessor.SetKind(items[i], kind)
+		accessor.SetAPIVersion(items[i], groupVersion)
+		name, _ := accessor.Name(items[i])
+		ns, _ := accessor.Namespace(items[i])
+		if ns == "" {
+			ns = info.Namespace
+		}
+		key, err := cm.storage.KeyFunc(storage.KeyBuildInfo{
+			Component: comp,
+			Namespace: ns,
+			Name:      name,
+			Resources: info.Resource,
+			Group:     info.APIGroup,
+			Version:   info.APIVersion,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("could not get key for %s/%s, %v", ns, name, err))
+			continue
+		}
+		// A cached object that is already fresher than the incoming one is not an error:
+		// ReplaceComponentList, which this replaces, overwrote regardless of
+		// resourceVersion, so a rejected stale write must not fail the whole response.
+		if err := cm.storeObjectWithKey(key, items[i]); err != nil && !errors.Is(err, storage.ErrUpdateConflict) {
+			errs = append(errs, err)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
 }
 
 func (cm *cacheManager) saveOneObject(ctx context.Context, info *apirequest.RequestInfo, b []byte) error {
@@ -687,7 +808,9 @@ func (cm *cacheManager) storeObjectWithKey(key storage.Key, obj runtime.Object) 
 		klog.V(2).Infof("skip to cache watch event because key(%s) is under processing", key.Key())
 		return nil
 	default:
-		return fmt.Errorf("could not store obj with rv %s of key: %s, %v", newRv, key.Key(), err)
+		// wrapped with %w so a caller can classify the failure; a stale-resourceVersion
+		// conflict is benign for a caller that is merging an incomplete list response.
+		return fmt.Errorf("could not store obj with rv %s of key: %s, %w", newRv, key.Key(), err)
 	}
 	return nil
 }

--- a/pkg/yurthub/cachemanager/cache_truncation_test.go
+++ b/pkg/yurthub/cachemanager/cache_truncation_test.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2026 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cachemanager
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/filters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/configuration"
+	hubmeta "github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/meta"
+	"github.com/openyurtio/openyurt/pkg/yurthub/kubernetes/serializer"
+	proxyutil "github.com/openyurtio/openyurt/pkg/yurthub/proxy/util"
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
+	"github.com/openyurtio/openyurt/pkg/yurthub/util"
+)
+
+// A cached list is written with ReplaceComponentList, which deletes every previously
+// cached object that is absent from the response. That is only a safe thing to do when
+// the response provably carries the COMPLETE set of matching objects.
+//
+// Two kinds of response do not, and both used to reach ReplaceComponentList:
+//
+//  1. a response to a list restricted to a single object by
+//     ?fieldSelector=metadata.name=<name> — evidence about one object, never about the
+//     collection;
+//  2. one page of a paginated list (?limit=, or a continuation), which by construction
+//     omits the objects on the other pages.
+//
+// Both are reachable by any client that can reach a yurthub proxy port, because
+// cacheability is decided from the caller-supplied User-Agent (CanCacheFor) and the
+// recorded per-key selector identity covers only label and field selectors — not limit
+// and not continue. The damage is invisible until the node reboots while disconnected,
+// at which point kubelet is served a near-empty pod list.
+//
+// These tests seed a component's cache with a complete list and then assert that neither
+// kind of response is allowed to delete what it does not contain.
+func newTruncationTestCacheManager(t *testing.T, dir string) (CacheManager, *serializer.SerializerManager) {
+	t.Helper()
+	dStorage, err := disk.NewDiskStorage(dir)
+	if err != nil {
+		t.Fatalf("could not create disk storage, %v", err)
+	}
+	restRESTMapperMgr, err := hubmeta.NewRESTMapperManager(dir)
+	if err != nil {
+		t.Fatalf("could not create RESTMapper manager, %v", err)
+	}
+	serializerM := serializer.NewSerializerManager()
+	fakeSharedInformerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
+	configManager := configuration.NewConfigurationManager("node1", fakeSharedInformerFactory)
+	return NewCacheManager(NewStorageWrapper(dStorage), serializerM, restRESTMapperMgr, configManager), serializerM
+}
+
+// cacheListResponse drives one list response through the same middleware chain the proxy
+// builds, so User-Agent, RequestInfo and content type are populated exactly as in production.
+func cacheListResponse(t *testing.T, cm CacheManager, serializerM *serializer.SerializerManager, path string, obj runtime.Object) error {
+	t.Helper()
+	req, _ := http.NewRequest("GET", path, nil)
+	req.Header.Set("User-Agent", "kubelet")
+	req.Header.Set("Accept", "application/json")
+	req.RemoteAddr = "127.0.0.1"
+
+	var cacheErr error
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		info, _ := request.RequestInfoFrom(ctx)
+		reqContentType, _ := util.ReqContentTypeFrom(ctx)
+		ctx = util.WithRespContentType(ctx, reqContentType)
+		req = req.WithContext(ctx)
+
+		gvr := schema.GroupVersionResource{Group: info.APIGroup, Version: info.APIVersion, Resource: info.Resource}
+		s := serializerM.CreateSerializer(reqContentType, gvr.Group, gvr.Version, gvr.Resource)
+		encoder, err := s.Encoder(reqContentType, nil)
+		if err != nil {
+			t.Fatalf("could not create encoder, %v", err)
+		}
+		buf := bytes.NewBuffer([]byte{})
+		if err := encoder.Encode(obj, buf); err != nil {
+			t.Fatalf("could not encode input object, %v", err)
+		}
+		cacheErr = cm.CacheResponse(req, io.NopCloser(buf), nil)
+	})
+
+	handler = proxyutil.WithRequestContentType(handler)
+	handler = proxyutil.WithListRequestSelector(handler)
+	handler = proxyutil.WithRequestClientComponent(handler)
+	handler = proxyutil.WithPartialObjectMetadataRequest(handler)
+	handler = filters.WithRequestInfo(handler, newTestRequestInfoResolver())
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	return cacheErr
+}
+
+func pod(name, rv string) v1.Pod {
+	return v1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", ResourceVersion: rv},
+		Spec:       v1.PodSpec{NodeName: "mynode"},
+	}
+}
+
+func completePodList(rv string, pods ...v1.Pod) *v1.PodList {
+	return &v1.PodList{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PodList"},
+		ListMeta: metav1.ListMeta{ResourceVersion: rv},
+		Items:    pods,
+	}
+}
+
+// cachedPodNames returns the pod names currently cached for the kubelet component.
+func cachedPodNames(t *testing.T, cm CacheManager) []string {
+	t.Helper()
+	req, _ := http.NewRequest("GET", "/api/v1/pods?fieldSelector=spec.nodeName=mynode", nil)
+	req.Header.Set("User-Agent", "kubelet")
+	req.RemoteAddr = "127.0.0.1"
+
+	var names []string
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		obj, err := cm.QueryCache(req)
+		if err != nil {
+			t.Logf("QueryCache returned error: %v", err)
+			return
+		}
+		list, ok := obj.(*v1.PodList)
+		if !ok {
+			t.Fatalf("expected a *v1.PodList, got %T", obj)
+		}
+		for i := range list.Items {
+			names = append(names, list.Items[i].Name)
+		}
+	})
+	handler = proxyutil.WithRequestContentType(handler)
+	handler = proxyutil.WithListRequestSelector(handler)
+	handler = proxyutil.WithRequestClientComponent(handler)
+	handler = filters.WithRequestInfo(handler, newTestRequestInfoResolver())
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	return names
+}
+
+// A list narrowed to a single object with ?fieldSelector=metadata.name= must never be
+// treated as evidence about the whole collection. An empty response to such a request
+// (the named object does not exist) used to delete every pod cached for the component.
+func TestNameSelectorListDoesNotWipeCollection(t *testing.T) {
+	dir := t.TempDir()
+	cm, serializerM := newTruncationTestCacheManager(t, dir)
+
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=spec.nodeName=mynode",
+		completePodList("10", pod("pod-a", "1"), pod("pod-b", "2"), pod("pod-c", "3"))); err != nil {
+		t.Fatalf("seeding the cache failed: %v", err)
+	}
+	if got := cachedPodNames(t, cm); len(got) != 3 {
+		t.Fatalf("precondition failed: expected 3 cached pods, got %d (%v)", len(got), got)
+	}
+
+	// The named pod does not exist, so the apiserver answers with an empty list.
+	// It is evidence that "pod-zzz" is absent, and nothing more.
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=metadata.name=pod-zzz",
+		completePodList("11")); err != nil {
+		t.Fatalf("caching the name-selector response failed: %v", err)
+	}
+
+	got := cachedPodNames(t, cm)
+	if len(got) != 3 {
+		t.Errorf("an empty response to a metadata.name list deleted the cached collection: expected 3 pods still cached, got %d (%v)", len(got), got)
+	}
+}
+
+// RequestInfo.Name is NOT a reliable way to recognise a metadata.name list.
+// requestinfo.go assigns it only when the value is a valid path segment, and
+// path.IsValidPathSegmentName rejects "." and ".." outright and anything containing "/" or
+// "%". For those values the request is still a name-selector list — the apiserver answers
+// it with an empty list — but info.Name is empty, so a guard keyed on info.Name lets the
+// response through to ReplaceComponentList and the whole collection is deleted.
+//
+// The read path already gets this right (queryListObject uses
+// isListRequestWithNameFieldSelector), so the write path has to agree with it.
+func TestOddNameSelectorValuesDoNotWipeCollection(t *testing.T) {
+	for _, name := range []string{"..", ".", "", "a%2Fb", "a%25b", "a/b"} {
+		t.Run("metadata.name="+name, func(t *testing.T) {
+			dir := t.TempDir()
+			cm, serializerM := newTruncationTestCacheManager(t, dir)
+
+			if err := cacheListResponse(t, cm, serializerM,
+				"/api/v1/pods?fieldSelector=spec.nodeName=mynode",
+				completePodList("10", pod("pod-a", "1"), pod("pod-b", "2"), pod("pod-c", "3"))); err != nil {
+				t.Fatalf("seeding the cache failed: %v", err)
+			}
+			if got := cachedPodNames(t, cm); len(got) != 3 {
+				t.Fatalf("precondition failed: expected 3 cached pods, got %d (%v)", len(got), got)
+			}
+
+			// The apiserver answers with an empty list: no object has this name.
+			if err := cacheListResponse(t, cm, serializerM,
+				"/api/v1/pods?fieldSelector="+url.QueryEscape("metadata.name="+name),
+				completePodList("11")); err != nil {
+				t.Fatalf("caching the name-selector response failed: %v", err)
+			}
+
+			if got := cachedPodNames(t, cm); len(got) != 3 {
+				t.Errorf("an empty response to metadata.name=%q deleted the cached collection: expected 3 pods still cached, got %d (%v)", name, len(got), got)
+			}
+		})
+	}
+}
+
+// One page of a paginated list omits the objects on every other page, so it must never
+// be allowed to delete them. Both ends of the sequence matter: the first page is
+// identified by a continue token in the RESPONSE, and the last page — which carries an
+// empty continue token and is otherwise indistinguishable from a complete list — only by
+// the continue parameter on the REQUEST.
+func TestPaginatedListDoesNotWipeCollection(t *testing.T) {
+	seed := func(t *testing.T, cm CacheManager, serializerM *serializer.SerializerManager) {
+		if err := cacheListResponse(t, cm, serializerM,
+			"/api/v1/pods?fieldSelector=spec.nodeName=mynode",
+			completePodList("10", pod("pod-a", "1"), pod("pod-b", "2"), pod("pod-c", "3"))); err != nil {
+			t.Fatalf("seeding the cache failed: %v", err)
+		}
+		if got := cachedPodNames(t, cm); len(got) != 3 {
+			t.Fatalf("precondition failed: expected 3 cached pods, got %d (%v)", len(got), got)
+		}
+	}
+
+	t.Run("first page, continue token in the response", func(t *testing.T) {
+		dir := t.TempDir()
+		cm, serializerM := newTruncationTestCacheManager(t, dir)
+		seed(t, cm, serializerM)
+
+		firstPage := completePodList("11", pod("pod-a", "4"))
+		firstPage.ListMeta.Continue = "some-continue-token"
+		if err := cacheListResponse(t, cm, serializerM,
+			"/api/v1/pods?fieldSelector=spec.nodeName=mynode&limit=1", firstPage); err != nil {
+			t.Fatalf("caching the first page failed: %v", err)
+		}
+
+		if got := cachedPodNames(t, cm); len(got) != 3 {
+			t.Errorf("the first page of a paginated list deleted the pods on the other pages: expected 3 pods still cached, got %d (%v)", len(got), got)
+		}
+	})
+
+	t.Run("last page, continue token only on the request", func(t *testing.T) {
+		dir := t.TempDir()
+		cm, serializerM := newTruncationTestCacheManager(t, dir)
+		seed(t, cm, serializerM)
+
+		// The final page of a paginated sequence: its response continue token is empty,
+		// exactly like a complete list. Only the request tells them apart.
+		lastPage := completePodList("11", pod("pod-c", "5"))
+		if err := cacheListResponse(t, cm, serializerM,
+			"/api/v1/pods?fieldSelector=spec.nodeName=mynode&limit=1&continue=some-continue-token", lastPage); err != nil {
+			t.Fatalf("caching the last page failed: %v", err)
+		}
+
+		if got := cachedPodNames(t, cm); len(got) != 3 {
+			t.Errorf("the last page of a paginated list deleted the pods on the earlier pages: expected 3 pods still cached, got %d (%v)", len(got), got)
+		}
+	})
+}
+
+// Not creating the collection directory for an empty incomplete response is a deliberate
+// simplification, and it rests on queryListObject answering a metadata.name list with an
+// empty list rather than an error when nothing is cached. Assert that, so the
+// simplification cannot silently become an offline "not found".
+func TestNameSelectorListOnColdCacheReturnsEmptyList(t *testing.T) {
+	dir := t.TempDir()
+	cm, serializerM := newTruncationTestCacheManager(t, dir)
+
+	// Nothing has ever been cached for this component.
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=metadata.name=pod-zzz",
+		completePodList("11")); err != nil {
+		t.Fatalf("caching an empty name-selector response on a cold cache failed: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", "/api/v1/pods?fieldSelector=metadata.name=pod-zzz", nil)
+	req.Header.Set("User-Agent", "kubelet")
+	req.RemoteAddr = "127.0.0.1"
+	var queryErr error
+	var got runtime.Object
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		got, queryErr = cm.QueryCache(req)
+	})
+	handler = proxyutil.WithRequestContentType(handler)
+	handler = proxyutil.WithListRequestSelector(handler)
+	handler = proxyutil.WithRequestClientComponent(handler)
+	handler = filters.WithRequestInfo(handler, newTestRequestInfoResolver())
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if queryErr != nil {
+		t.Fatalf("an offline metadata.name list on a cold cache must return an empty list, got error: %v", queryErr)
+	}
+	list, ok := got.(*v1.PodList)
+	if !ok {
+		t.Fatalf("expected a *v1.PodList, got %T", got)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected an empty list, got %d items", len(list.Items))
+	}
+}
+
+// A list pinned to one exact resourceVersion describes the collection as it was then, so
+// it must not delete objects created since.
+func TestPointInTimeListDoesNotWipeCollection(t *testing.T) {
+	dir := t.TempDir()
+	cm, serializerM := newTruncationTestCacheManager(t, dir)
+
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=spec.nodeName=mynode",
+		completePodList("100", pod("pod-a", "100"), pod("pod-b", "101"), pod("pod-c", "102"))); err != nil {
+		t.Fatalf("seeding the cache failed: %v", err)
+	}
+
+	// A read pinned to an older version: pod-b and pod-c did not exist yet at rv 50.
+	older := completePodList("50", pod("pod-a", "40"))
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=spec.nodeName=mynode&resourceVersion=50&resourceVersionMatch=Exact",
+		older); err != nil {
+		t.Fatalf("caching the point-in-time response failed: %v", err)
+	}
+
+	if got := cachedPodNames(t, cm); len(got) != 3 {
+		t.Errorf("a point-in-time list rolled the cache back: expected 3 pods still cached, got %d (%v)", len(got), got)
+	}
+}
+
+// The fix has two halves — do not delete, and still cache what the response carries. The
+// second half was initially unasserted, so a no-op would have passed. Assert that an
+// object appearing only on a paginated page really is written.
+func TestIncompleteListStillCachesItsOwnObjects(t *testing.T) {
+	dir := t.TempDir()
+	cm, serializerM := newTruncationTestCacheManager(t, dir)
+
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=spec.nodeName=mynode",
+		completePodList("10", pod("pod-a", "1"))); err != nil {
+		t.Fatalf("seeding the cache failed: %v", err)
+	}
+
+	// pod-d is new and arrives only on a page of a paginated list.
+	page := completePodList("11", pod("pod-d", "12"))
+	page.ListMeta.Continue = "more"
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=spec.nodeName=mynode&limit=1", page); err != nil {
+		t.Fatalf("caching the page failed: %v", err)
+	}
+
+	got := cachedPodNames(t, cm)
+	found := false
+	for _, n := range got {
+		if n == "pod-d" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("an object carried by a paginated page must still be cached: got %v, expected it to contain pod-d", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected pod-a to survive alongside pod-d, got %v", got)
+	}
+}
+
+// A genuinely complete list must keep pruning, because that is how an object deleted in
+// the cloud leaves the node's cache. This is the behaviour the two fixes above must not
+// disturb, and it is asserted here so a future change cannot quietly trade it away.
+func TestCompleteListStillPrunes(t *testing.T) {
+	dir := t.TempDir()
+	cm, serializerM := newTruncationTestCacheManager(t, dir)
+
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=spec.nodeName=mynode",
+		completePodList("10", pod("pod-a", "1"), pod("pod-b", "2"), pod("pod-c", "3"))); err != nil {
+		t.Fatalf("seeding the cache failed: %v", err)
+	}
+
+	// pod-b and pod-c were deleted in the cloud; a complete relist must evict them.
+	if err := cacheListResponse(t, cm, serializerM,
+		"/api/v1/pods?fieldSelector=spec.nodeName=mynode",
+		completePodList("12", pod("pod-a", "6"))); err != nil {
+		t.Fatalf("caching the complete relist failed: %v", err)
+	}
+
+	got := cachedPodNames(t, cm)
+	if len(got) != 1 || got[0] != "pod-a" {
+		t.Errorf("a complete list must still prune objects deleted in the cloud: expected only pod-a cached, got %v", got)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`saveListObject` routed every multi-object list response into `ReplaceComponentList`, which deletes every cached object of that type that is absent from the response — i.e. it treats the response as the complete, authoritative list. Two common list shapes carry only a subset, so this silently truncated the cache:

- An empty `?fieldSelector=metadata.name=<x>` list (the named object does not exist) **deleted the whole cached collection** for that type.
- Any page of a paginated list carries only that page, so each page deleted the objects on the other pages. The last page is indistinguishable from a complete list by its response alone (the continue token is empty either way), so only the request reveals it.

This routes those shapes to a no-delete merge path that writes the carried objects and prunes nothing. A genuinely complete list (an informer relist with no name selector, no pagination and no `resourceVersionMatch=Exact`) still prunes, as before.

Trade-off worth stating: a component that always paginates now keeps objects that were deleted in the cloud while yurthub was disconnected (GC still collects pods and events). Serving a stale-but-complete cached view is preferable to handing a truncated collection to a consumer.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

New `cache_truncation_test.go` covers the empty name-selector wipe, odd name-selector values, first/last page pagination, a cold cache, point-in-time lists, and `TestCompleteListStillPrunes` (a genuinely complete list must still prune). Each fails on the current code and passes with the fix.

#### Does this PR introduce a user-facing change?

```release-note
Stop yurthub from deleting cached objects when it receives an incomplete list response (an empty metadata.name field-selector list, or a page of a paginated list).
```
