### PR TITLE
Bugfix: grant yurthub RBAC for services

### DIFF
--- a/charts/yurt-manager/templates/yurthub-cfg.yaml
+++ b/charts/yurt-manager/templates/yurthub-cfg.yaml
@@ -54,6 +54,14 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - "services"
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

yurthub reads and watches Services, but the `yurt-hub` ClusterRole never granted `services`, so these fail under the Node authorizer:

- On every startup, the server-cert code does `Services("default").Get("kubernetes")` to add the ClusterIP to the certificate SAN (`pkg/yurthub/certificate/server/server.go`).
- The default `masterservice` and `nodeportisolation` filters `list`/`watch` Services through yurthub's shared informer factory.

This adds `services: get,list,watch` to the `yurt-hub` ClusterRole, alongside the existing `configmaps` and `endpointslices` grants on the same cluster-wide binding. A namespaced Role cannot authorize an all-namespace list/watch, so a ClusterRole is required.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Purely additive RBAC — it widens the existing grant and changes no behavior. The upstream `yurt-hub` ClusterRole currently grants events/nodepools/configmaps/secrets/leases/endpointslices/endpoints, but not services.

#### Does this PR introduce a user-facing change?

```release-note
Grant the yurt-hub ClusterRole get/list/watch on services, which yurthub needs for its server-certificate SAN and the default service filters.
```
