### PR TITLE
fix(yurtadm): honor --yurthub-binary-url on edge and cloud joins

### DIFF
--- a/pkg/yurtadm/cmd/join/join.go
+++ b/pkg/yurtadm/cmd/join/join.go
@@ -160,7 +160,7 @@ func addJoinConfigFlags(flagSet *flag.FlagSet, joinOptions *joinOptions) {
 	)
 	flagSet.StringVar(
 		&joinOptions.yurthubBinaryURL, yurtconstants.YurtHubBinaryURL, joinOptions.yurthubBinaryURL,
-		"Sets the binary URL of yurthub (tar.gz), we will download and untar it automatically, then deploy local mode yurthub in systemd",
+		"Sets the binary URL of yurthub (tar.gz), we will download and untar it automatically. Required for local mode, optional for edge and cloud nodes where it overrides the default download URL",
 	)
 	flagSet.StringVar(
 		&joinOptions.hostControlPlaneAddr, yurtconstants.HostControlPlaneAddr, joinOptions.hostControlPlaneAddr,

--- a/pkg/yurtadm/cmd/join/phases/prepare.go
+++ b/pkg/yurtadm/cmd/join/phases/prepare.go
@@ -72,7 +72,7 @@ func RunPrepare(data joindata.YurtJoinData) error {
 
 	if data.NodeRegistration().WorkingMode != constants.LocalNode {
 		// All non-local nodes: install yurthub binary
-		if err := yurthub.CheckAndInstallYurthub(projectinfo.Get().GitVersion); err != nil {
+		if err := yurthub.CheckAndInstallYurthub(projectinfo.Get().GitVersion, data.YurtHubBinaryURL()); err != nil {
 			return err
 		}
 

--- a/pkg/yurtadm/util/yurthub/yurthub.go
+++ b/pkg/yurtadm/util/yurthub/yurthub.go
@@ -57,20 +57,32 @@ var (
 	yurthubVersionWithCommitRegexp = regexp.MustCompile(`^(v[0-9]+\.[0-9]+\.[0-9]+)-[0-9a-f]{7,40}$`)
 )
 
-func CheckAndInstallYurthub(yurthubVersion string) error {
+// customYurthubPackageName is the local file name for a package downloaded from
+// --yurthub-binary-url. Using a fixed name rather than the URL's base name keeps a URL
+// ending in "/yurthub" from being picked up by findYurthubBinary as the binary itself.
+const customYurthubPackageName = "yurthub.tar.gz"
+
+// CheckAndInstallYurthub installs the yurthub binary. When yurthubBinaryURL is set, that
+// package is used, otherwise it is derived from the yurtadm release version.
+func CheckAndInstallYurthub(yurthubVersion, yurthubBinaryURL string) error {
 	if _, err := lookPath(yurthubExecStartPath); err == nil {
 		klog.Infof("Yurthub binary already exists, skip install.")
 		return nil
 	}
 
-	yurthubVersion, err := resolveYurthubReleaseVersion(yurthubVersion)
-	if err != nil {
-		return err
-	}
-	klog.Infof("Check and install yurthub %s", yurthubVersion)
+	packageName := customYurthubPackageName
+	packageURL := yurthubBinaryURL
+	if packageURL == "" {
+		yurthubVersion, err := resolveYurthubReleaseVersion(yurthubVersion)
+		if err != nil {
+			return err
+		}
+		klog.Infof("Check and install yurthub %s", yurthubVersion)
 
-	packageName := fmt.Sprintf("yurthub-%s-linux-%s.tar.gz", yurthubVersion, runtime.GOARCH)
-	packageURL := fmt.Sprintf(constants.YurthubExecURLFormat, yurthubVersion, yurthubVersion, runtime.GOARCH)
+		packageName = fmt.Sprintf("yurthub-%s-linux-%s.tar.gz", yurthubVersion, runtime.GOARCH)
+		packageURL = fmt.Sprintf(constants.YurthubExecURLFormat, yurthubVersion, yurthubVersion, runtime.GOARCH)
+	}
+
 	tmpDir, err := os.MkdirTemp(constants.TmpDownloadDir, "yurthub-")
 	if err != nil {
 		return err

--- a/pkg/yurtadm/util/yurthub/yurthub_test.go
+++ b/pkg/yurtadm/util/yurthub/yurthub_test.go
@@ -445,7 +445,7 @@ func TestCheckAndInstallYurthub(t *testing.T) {
 			return oldLookPath(file)
 		}
 
-		err = CheckAndInstallYurthub("v1.7.0")
+		err = CheckAndInstallYurthub("v1.7.0", "")
 		if err != nil {
 			t.Errorf("CheckAndInstallYurthub() error = %v, wantErr %v", err, nil)
 		}
@@ -496,7 +496,7 @@ func TestCheckAndInstallYurthub(t *testing.T) {
 			return nil
 		}
 
-		err := CheckAndInstallYurthub("v1.7.0-6fc029d")
+		err := CheckAndInstallYurthub("v1.7.0-6fc029d", "")
 		assert.NoError(t, err)
 	})
 
@@ -513,9 +513,46 @@ func TestCheckAndInstallYurthub(t *testing.T) {
 			return nil
 		}
 
-		err := CheckAndInstallYurthub("6fc029d")
+		err := CheckAndInstallYurthub("6fc029d", "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "can not parse yurthub release version")
+	})
+
+	t.Run("Yurthub binary URL is used and skips version resolution", func(t *testing.T) {
+		lookPath = func(file string) (string, error) {
+			if file == yurthubExecStartPath {
+				return "", &os.PathError{Op: "stat", Path: file, Err: os.ErrNotExist}
+			}
+			return oldLookPath(file)
+		}
+
+		wantURL := "https://example.com/releases/download/yurthub-linux-amd64.tar.gz"
+		downloadFile = func(url, savePath string, retry int) error {
+			if url != wantURL {
+				t.Fatalf("unexpected download url: %s, want %s", url, wantURL)
+			}
+			if filepath.Base(savePath) != customYurthubPackageName {
+				t.Fatalf("unexpected save path: %s", savePath)
+			}
+			return nil
+		}
+		untar = func(src, dst string) error {
+			binaryDir := filepath.Join(dst, fmt.Sprintf("linux-%s", runtime.GOARCH))
+			if err := os.MkdirAll(binaryDir, 0755); err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Join(binaryDir, constants.Yurthub), []byte("dummy"), 0755)
+		}
+		copyFile = func(src, dest string, mode os.FileMode) error {
+			if dest != yurthubExecStartPath {
+				t.Fatalf("unexpected copy destination: %s", dest)
+			}
+			return nil
+		}
+
+		// The version is unresolvable on purpose: an explicit URL must make it irrelevant.
+		err := CheckAndInstallYurthub("dev-6fc029d", wantURL)
+		assert.NoError(t, err)
 	})
 }
 
@@ -796,7 +833,7 @@ func Test_CheckAndInstallYurthub_LookPathErrorCausesDownloadAttempt(t *testing.T
 		return errors.New("simulated download failure")
 	}
 
-	err := CheckAndInstallYurthub("v0.0.0-test")
+	err := CheckAndInstallYurthub("v0.0.0-test", "")
 	if err == nil {
 		t.Fatalf("CheckAndInstallYurthub() expected to return an error when binary missing and download/copy fails, but got nil")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`--yurthub-binary-url` is registered for every node type, but only local mode reads it. On edge and cloud joins, `RunPrepare` calls `CheckAndInstallYurthub(projectinfo.Get().GitVersion)`, which derives the download URL from yurtadm's own build version alone. So the flag is silently ignored, and an edge/cloud node can only ever install the yurthub release that matches the yurtadm binary — there is no way to point it at a mirror or a specific release.

This threads the flag value (already exposed as `data.YurtHubBinaryURL()`, which local mode already uses) into `CheckAndInstallYurthub`. When it is set, that package URL is used and the version-resolution step is skipped; when it is empty, the function resolves the release version and builds the default URL exactly as before.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- **No behavior change when the flag is empty.** The empty-URL branch runs the same statements in the same order as today; the three pre-existing `TestCheckAndInstallYurthub` subtests still pass unchanged (only their call sites gained a `""` argument).
- A downloaded custom package is saved under a fixed name (`yurthub.tar.gz`) rather than the URL's base name, so a URL ending in `/yurthub` cannot be mistaken for the extracted binary by `findYurthubBinary`.
- New subtest asserts that an explicit URL is downloaded verbatim and makes version resolution irrelevant (the version passed in is deliberately unresolvable).
- On the security surface: the flag accepts a plain `http://` URL whose tarball becomes the root systemd yurthub. That is not new — local mode has accepted this same flag with the same property already; this PR only makes edge/cloud honor it too.

#### Does this PR introduce a user-facing change?

```release-note
yurtadm now honors --yurthub-binary-url on edge and cloud joins, not only in local mode.
```
