### PR TITLE
fix: use StrategicMergePatchType for pod condition updates to avoid TOCTOU race

### DIFF
--- a/pkg/yurthub/otaupdate/ota.go
+++ b/pkg/yurthub/otaupdate/ota.go
@@ -41,7 +41,6 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/daemonsetupgradestrategy"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/daemonsetupgradestrategy/daemonpodupdater"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/daemonsetupgradestrategy/imagepreheat"
-	podutil "github.com/openyurtio/openyurt/pkg/yurtmanager/controller/util/pod"
 )
 
 const (
@@ -261,14 +260,13 @@ func PullPodImage(clientset kubernetes.Interface, nodeName string) http.Handler 
 			Status:  corev1.ConditionFalse,
 			Message: daemonsetupgradestrategy.VersionPrefix + imagepreheat.GetPodNextHashVersion(pod),
 		}
-		podutil.UpdatePodCondition(&pod.Status, &cond)
 
 		patchBody := struct {
 			Status struct {
 				Conditions []corev1.PodCondition `json:"conditions"`
 			} `json:"status"`
 		}{}
-		patchBody.Status.Conditions = pod.Status.Conditions
+		patchBody.Status.Conditions = []corev1.PodCondition{cond}
 
 		patchBytes, err := json.Marshal(patchBody)
 		if err != nil {
@@ -280,7 +278,7 @@ func PullPodImage(clientset kubernetes.Interface, nodeName string) http.Handler 
 		_, err = clientset.CoreV1().Pods(namespace).Patch(
 			context.TODO(),
 			podName,
-			types.MergePatchType,
+			types.StrategicMergePatchType,
 			patchBytes,
 			metav1.PatchOptions{
 				FieldManager: "yurthub-ota",

--- a/pkg/yurthub/otaupdate/ota_test.go
+++ b/pkg/yurthub/otaupdate/ota_test.go
@@ -18,6 +18,8 @@ package otaupdate
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -29,8 +31,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/openyurtio/openyurt/cmd/yurthub/app/options"
 	"github.com/openyurtio/openyurt/pkg/yurthub/cachemanager"
@@ -42,6 +47,7 @@ import (
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage/disk"
 	"github.com/openyurtio/openyurt/pkg/yurthub/transport"
 	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/daemonsetupgradestrategy"
+	"github.com/openyurtio/openyurt/pkg/yurtmanager/controller/daemonsetupgradestrategy/imagepreheat"
 )
 
 func TestGetPods(t *testing.T) {
@@ -749,5 +755,62 @@ func TestImagePullPod(t *testing.T) {
 				assert.Contains(t, rr.Body.String(), tt.expectedBody)
 			}
 		})
+	}
+}
+
+func TestPullPodImageStrategicMergePatch(t *testing.T) {
+	pod := createDaemonPod("nginx", "default", "node1")
+	clientset := fake.NewSimpleClientset(pod)
+
+	expectedCond := corev1.PodCondition{
+		Type:    daemonsetupgradestrategy.PodImageReady,
+		Status:  corev1.ConditionFalse,
+		Message: daemonsetupgradestrategy.VersionPrefix + imagepreheat.GetPodNextHashVersion(pod),
+	}
+
+	var gotPatchType types.PatchType
+	var gotPatch []byte
+	clientset.PrependReactor("patch", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if !ok {
+			return true, nil, fmt.Errorf("expected patch action, got %T", action)
+		}
+		gotPatchType = patchAction.GetPatchType()
+		gotPatch = patchAction.GetPatch()
+		return false, nil, nil
+	})
+
+	req, err := http.NewRequest("POST", "/openyurt.io/v1/namespaces/default/pods/nginx/imagepull", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vars := map[string]string{
+		"ns":      "default",
+		"podname": "nginx",
+	}
+	req = mux.SetURLVars(req, vars)
+	rr := httptest.NewRecorder()
+
+	PullPodImage(clientset, "node1").ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, types.StrategicMergePatchType, gotPatchType)
+
+	var patchBody struct {
+		Status struct {
+			Conditions []corev1.PodCondition `json:"conditions"`
+		} `json:"status"`
+	}
+	err = json.Unmarshal(gotPatch, &patchBody)
+	assert.NoError(t, err)
+	assert.Equal(t, []corev1.PodCondition{expectedCond}, patchBody.Status.Conditions)
+
+	updated, err := clientset.CoreV1().Pods("default").Get(context.TODO(), "nginx", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, updated.Status.Conditions, 2)
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == daemonsetupgradestrategy.PodImageReady {
+			assert.Equal(t, expectedCond, cond)
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

**Background**

The `PullPodImage` handler in `pkg/yurthub/otaupdate/ota.go` injects a 
`PodImageReady` condition onto a Pod during OTA image pull. It fetched the 
current Pod, locally mutated the full `Status.Conditions` array via 
`podutil.UpdatePodCondition`, and patched the Pod with the entire array 
using `types.MergePatchType`.

**The Bug**

`MergePatchType` (RFC 7386 JSON Merge Patch) does not support array 
merging — it replaces arrays wholesale. If the Kubelet or another 
controller updated a Pod condition (e.g. `Ready=True`) in the window 
between this handler's `getPod()` call and its `Patch()` call, that 
update was silently overwritten by the stale array this handler had 
fetched earlier. This could leave a Pod stuck reporting as not-ready on 
the control plane even after the Kubelet had confirmed it was running.

**Verification of the fix approach**

Checked `k8s.io/api v0.34.0`'s `PodStatus.Conditions` field definition 
directly — it carries `patchStrategy:"merge" patchMergeKey:"type"`, 
confirming the API server natively supports a strategic merge patch that 
merges condition entries by their `Type` field. Also confirmed the fake 
clientset used in this package's tests fully supports 
`StrategicMergePatchType`.

**The Fix**

- Removed the local `podutil.UpdatePodCondition` full-array mutation 
  (and the now-unused `podutil` import).
- Changed the patch payload to contain only the single new condition 
  instead of the full conditions array.
- Changed the patch type from `types.MergePatchType` to 
  `types.StrategicMergePatchType`, letting the API server perform the 
  merge natively by condition `Type`, eliminating the TOCTOU window 
  entirely.

Added `TestPullPodImageStrategicMergePatch`, verifying the patch sent is 
`StrategicMergePatchType` and contains exactly one condition.

#### Which issue(s) this PR fixes:
Fixes #2754

#### Special notes for your reviewer:
- `go test -v ./pkg/yurthub/otaupdate/...` — all tests pass (verified on Linux/WSL), including the new test
- `go build`/`go vet` on the affected package — clean
- No exported function signatures changed; scoped entirely to the patch construction inside `PullPodImage`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### other Note