### PR TITLE
fix: prevent yurthub from overwriting valid kube-system token with empty bearer token in tenant mode

### DIFF
--- a/pkg/yurthub/proxy/util/util.go
+++ b/pkg/yurthub/proxy/util/util.go
@@ -368,8 +368,13 @@ func WithSaTokenSubstitute(handler http.Handler, tenantMgr tenant.Interface) htt
 					if tenantNs, _, err := serviceaccount.SplitUsername(oldClaim.Subject); err == nil {
 
 						if tenantMgr.GetTenantNs() != tenantNs && tenantNs == "kube-system" && tenantMgr.WaitForCacheSync() { // token is not from tenant's namespace
-							req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tenantMgr.GetTenantToken()))
-							klog.V(2).Infof("replace token, old: %s, new: %s", oldToken, tenantMgr.GetTenantToken())
+							newToken := tenantMgr.GetTenantToken()
+							if newToken != "" {
+								req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", newToken))
+								klog.V(2).Infof("replace token for request %s", util.ReqString(req))
+							} else {
+								klog.Warningf("tenant token is not ready for request %s, keep original token", util.ReqString(req))
+							}
 						}
 
 					} else {

--- a/pkg/yurthub/proxy/util/util_test.go
+++ b/pkg/yurthub/proxy/util/util_test.go
@@ -711,6 +711,79 @@ func TestWithSaTokenSubstituteTenantTokenEmpty(t *testing.T) {
 	}
 }
 
+type stubTenantMgr struct {
+	tenantNs string
+	token    string
+	isSynced bool
+}
+
+func (s *stubTenantMgr) GetTenantNs() string {
+	return s.tenantNs
+}
+
+func (s *stubTenantMgr) GetTenantToken() string {
+	return s.token
+}
+
+func (s *stubTenantMgr) WaitForCacheSync() bool {
+	return s.isSynced
+}
+
+func (s *stubTenantMgr) SetSecret(sec *v1.Secret) {
+}
+
+func TestWithSaTokenSubstituteWithStubTenant(t *testing.T) {
+	kubeSystemToken := "eyJhbGciOiJSUzI1NiIsImtpZCI6InVfTVZpZWIySUFUTzQ4NjlkM0VwTlBRb0xJOWVKUGg1ZXVzbEdaY0ZxckEifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJkZWZhdWx0LXRva2VuLXF3c2ZtIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6ImRlZmF1bHQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI4M2EwMzc4ZS1mY2UxLTRmZDEtOGI1NC00MTE2MjUzYzNkYWMiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZS1zeXN0ZW06ZGVmYXVsdCJ9.sFpHHg4o88Z0CBJseMBvBeP00bS5isLBmQJpAOiYs3BTkEAD63YLTnDURt0r3I9QjtcP0DZAb5wSOccGChMAFVtxMIoIoZC6Mk4FSB720kawRxFVujNFR1T7uVV_dbpEU-wsxSb9-Y4ILVknuJR9t35x6lUbRkUE9tN1wDy4DH296C3gEGNJf8sbJMERZzOckc82_BamlCzaieo1nX396KafxdQGVIgxstx88hm_rgpjDy3LA1GNsx6x2pqXdzZ8mufQt7sTljRorXUk-rNU6y9wX2RvIMO8tNiPClNkdIpgpmeQo-g7XZivpEeq3VzoeExphRbusgCtO9T9tgU64w"
+	tenantToken := "tenant-token"
+
+	testcases := map[string]struct {
+		tenantToken string
+		isSynced    bool
+		expectToken string
+	}{
+		"non-empty tenant token, header replaced": {
+			tenantToken: tenantToken,
+			isSynced:    true,
+			expectToken: fmt.Sprintf("Bearer %s", tenantToken),
+		},
+		"empty tenant token, original header preserved": {
+			tenantToken: "",
+			isSynced:    true,
+			expectToken: fmt.Sprintf("Bearer %s", kubeSystemToken),
+		},
+		"cache not synced, original header preserved": {
+			tenantToken: tenantToken,
+			isSynced:    false,
+			expectToken: fmt.Sprintf("Bearer %s", kubeSystemToken),
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/api/v1/namespaces/kube-system/pods?resourceVersion=1494416105", nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", kubeSystemToken))
+
+			tenantMgr := &stubTenantMgr{
+				tenantNs: "myspace",
+				token:    tc.tenantToken,
+				isSynced: tc.isSynced,
+			}
+
+			var gotToken string
+			var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				gotToken = req.Header.Get("Authorization")
+			})
+
+			handler = WithSaTokenSubstitute(handler, tenantMgr)
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			if gotToken != tc.expectToken {
+				t.Errorf("expect authorization header %q, but got %q", tc.expectToken, gotToken)
+			}
+		})
+	}
+}
+
 func TestIsListRequestWithNameFieldSelector(t *testing.T) {
 	testcases := map[string]struct {
 		Verb   string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`WithSaTokenSubstitute` (`pkg/yurthub/proxy/util/util.go`) replaces the 
request's `Authorization` header with the tenant's token whenever the 
request is authenticated as a kube-system service account and the tenant 
secret informer has synced. It unconditionally called `GetTenantToken()` 
and, if that returned an empty string, the header became 
`Authorization: Bearer ` (empty) — destroying the original, still-valid 
token.

`GetTenantToken()` returns `""` whenever `TenantSecret == nil`, and 
`TenantSecret` is only set once the informer observes a default 
service-account token secret in the tenant namespace. On Kubernetes 
>=1.24, legacy SA token secrets are no longer auto-created for the 
default SA, so in a tenant deployment this secret may not exist at hub 
startup (or at all until explicitly provisioned). `WaitForCacheSync()` 
only guarantees the informer's initial list was processed — it does not 
guarantee the token secret exists.

Consequence: as soon as the tenant informer synced but before the tenant 
token secret appeared, every kube-system request through the hub had its 
valid token overwritten with an empty one, and the tenant kube-apiserver 
returned 401 for all of them — with no fallback and no error surfaced, 
fully cutting off the edge node in tenant mode until the secret showed 
up.

Secondary issue: the existing log line printed the full old and new 
token values in plaintext.

This PR:
- Only rewrites the `Authorization` header when `GetTenantToken()` 
  returns a non-empty token; otherwise keeps the original header 
  untouched and logs a warning instead.
- Removes the plaintext token logging.
- Adds `TestWithSaTokenSubstituteWithStubTenant` with a stub 
  `tenant.Interface`, covering three cases: non-empty token → header 
  replaced, empty token → original header preserved, 
  `WaitForCacheSync()` false → original header preserved.

Verified locally (WSL2, matching CI's Go 1.25.0 / golangci-lint v2.11.4): 
all clean — 0 test failures, 0 data races, 0 vet issues, 0 lint issues.

#### Which issue(s) this PR fixes:
Fixes #2761

#### Special notes for your reviewer:
When the tenant token is unavailable, requests now go out with the 
original kube-system token instead of an empty one. The tenant apiserver 
may still reject it (401/403) if RBAC doesn't map that identity, which is 
the same outcome as today during the missing-secret window — but we no 
longer actively destroy a token that could be valid (e.g., if the tenant 
apiserver is configured to accept the kube-system identity).

No other callers of `GetTenantToken`/`GetTenantNs` are affected by this 
change.

#### Does this PR introduce a user-facing change?
```release-note
fix(yurthub): stop overwriting valid kube-system service-account tokens with an empty bearer token in tenant mode when the tenant token secret is not yet available, which was cutting off all edge traffic until the secret appeared.
```

#### other Note