### PR TITLE
fix(yurtnodeconversion): treat existing job as stale when desiredActi…

### DIFF
--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller.go
@@ -706,10 +706,14 @@ func jobAction(job *batchv1.Job) (string, error) {
 	}
 }
 
-// isStaleJobForAction detects that the reused Job still belongs to the previous
-// conversion direction while labels now require the opposite round
+// isStaleJobForAction detects that the existing Job belongs to an action
+// that no longer matches the desiredAction from the node's labels (including
+// when labels are removed and desiredAction is actionNone).
 func isStaleJobForAction(jobAction, desiredAction string) bool {
-	return jobAction != actionNone && desiredAction != actionNone && jobAction != desiredAction
+	if jobAction == actionNone {
+		return false
+	}
+	return jobAction != desiredAction
 }
 
 func isJobFinished(job *batchv1.Job) bool {

--- a/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
+++ b/pkg/yurtmanager/controller/yurtnodeconversion/yurt_node_conversion_controller_test.go
@@ -280,6 +280,51 @@ func TestReconcileDeleteStaleFinishedJob(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestReconcileDeleteStaleFinishedJobWhenNodePoolLabelRemoved(t *testing.T) {
+	// Node has no NodePool label and is not edge-worker (desiredAction is actionNone)
+	node := newNode("node-a", map[string]string{}, false, nil)
+	job := newConversionJobForTest(t, actionConvert, "node-a")
+	job.Status.Conditions = []batchv1.JobCondition{{
+		Type:   batchv1.JobComplete,
+		Status: corev1.ConditionTrue,
+	}}
+	job.Status.Succeeded = 1
+
+	r, cli := newReconcilerForTest(t, node, job)
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-a"}})
+	require.NoError(t, err)
+	assert.True(t, result.Requeue)
+
+	deletedJob := &batchv1.Job{}
+	err = cli.Get(context.Background(), types.NamespacedName{
+		Namespace: r.conversionJobNamespace(),
+		Name:      conversionJobName("node-a"),
+	}, deletedJob)
+	assert.Error(t, err)
+
+	// Node must NOT be labeled as edge worker
+	updatedNode := &corev1.Node{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, updatedNode))
+	assert.Empty(t, updatedNode.Labels[projectinfo.GetEdgeWorkerLabelKey()])
+}
+
+func TestReconcileKeepStaleRunningJobWhenNodePoolLabelRemoved(t *testing.T) {
+	// Node has no NodePool label and is not edge-worker (desiredAction is actionNone)
+	node := newNode("node-a", map[string]string{}, false, nil)
+	job := newConversionJobForTest(t, actionConvert, "node-a")
+
+	r, cli := newReconcilerForTest(t, node, job)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "node-a"}})
+	require.NoError(t, err)
+
+	// Node must NOT be labeled as edge worker while stale job is still running
+	updatedNode := &corev1.Node{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "node-a"}, updatedNode))
+	assert.Empty(t, updatedNode.Labels[projectinfo.GetEdgeWorkerLabelKey()])
+}
+
 func TestReconcileKeepRunningJobInProgress(t *testing.T) {
 	node := newNode("node-a", map[string]string{
 		projectinfo.GetNodePoolLabel(): "pool-a",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When we add a NodePool label to a node, OpenYurt starts a Job to convert it into an edge node. But if someone removes that label while the conversion Job is still running, OpenYurt did not notice that the Job was no longer needed.

Because of this, the Job would finish and mark the node as an edge worker anyway (`openyurt.io/is-edge-worker=true`). Then right after, OpenYurt would see that the node has no NodePool label and start another Job to revert it back! This caused an unnecessary loop (convert -> revert) that wasted time and restarted services.

This PR fixes the `isStaleJobForAction` function so it correctly sees that the Job is outdated when the label is removed (`desiredAction == actionNone`). It also adds unit tests to make sure this works properly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2763

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
/assign @your_reviewer
-->
All unit tests in `pkg/yurtmanager/controller/yurtnodeconversion` pass without any errors.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Fix a bug where removing the NodePool label during node conversion still finished converting the node and triggered an automatic revert cycle.
