### PR TITLE
fix: guard nil ConfigMap.Data before assignment in two controllers

### DIFF
--- a/pkg/yurtmanager/controller/platformadmin/platform_admin_controller.go
+++ b/pkg/yurtmanager/controller/platformadmin/platform_admin_controller.go
@@ -717,6 +717,9 @@ func (r *ReconcilePlatformAdmin) writeFramework(ctx context.Context, platformAdm
 
 	// Creates configmap on behalf of the framework, which is called only once upon creation
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
 		cm.Data["framework"] = string(data)
 		return controllerutil.SetOwnerReference(platformAdmin, cm, r.Scheme())
 	})

--- a/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go
+++ b/pkg/yurtmanager/controller/raven/dns/gateway_dns_controller.go
@@ -153,6 +153,9 @@ func (r *ReconcileDNS) Reconcile(ctx context.Context, req reconcile.Request) (re
 		klog.Error(Format("could not list node, error %s", err.Error()))
 		return reconcile.Result{Requeue: true, RequeueAfter: 2 * time.Second}, err
 	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
 	cm.Data[util.ProxyNodesKey] = buildDNSRecords(&nodeList, enableProxy, proxyAddress)
 	err = r.updateDNS(cm)
 	if err != nil {


### PR DESCRIPTION
Fixes #2709, #2707

- gateway_dns_controller: initialize cm.Data when nil before writing
  DNS records, preventing a panic on ConfigMaps with no data field
- platform_admin_controller: initialize cm.Data when nil in the
  writeFramework CreateOrUpdate callback

ConfigMap.Data is optional in the Kubernetes API, so existing
ConfigMaps may have a nil Data map.