### PR TITLE
fix: guard nil pointer on property not found and add missing return in GetPods

### DIFF
--- a/pkg/yurthub/otaupdate/ota.go
+++ b/pkg/yurthub/otaupdate/ota.go
@@ -92,6 +92,7 @@ func GetPods(store cachemanager.StorageWrapper) http.Handler {
 		if err != nil {
 			klog.Errorf("Encode pod list failed, %v", err)
 			util.WriteErr(w, "Encode pod list failed", http.StatusInternalServerError)
+			return
 		}
 		util.WriteJSONResponse(w, data)
 	})

--- a/pkg/yurtiotdock/controllers/device_controller.go
+++ b/pkg/yurtiotdock/controllers/device_controller.go
@@ -266,6 +266,7 @@ func (r *DeviceReconciler) reconcileDeviceProperties(d *iotv1alpha1.Device, devi
 				continue
 			}
 			klog.Errorf("DeviceName: %s, property read command not found", d.GetName())
+			continue
 		} else {
 			klog.V(4).Infof("DeviceName: %s, got the actual property state, {Name: %s, GetURL: %s, ActualValue: %s}",
 				d.GetName(), propertyName, actualProperty.GetURL, actualProperty.ActualValue)
@@ -273,9 +274,8 @@ func (r *DeviceReconciler) reconcileDeviceProperties(d *iotv1alpha1.Device, devi
 
 		if newDeviceStatus.DeviceProperties == nil {
 			newDeviceStatus.DeviceProperties = map[string]iotv1alpha1.ActualPropertyState{}
-		} else {
-			newDeviceStatus.DeviceProperties[propertyName] = *actualProperty
 		}
+		newDeviceStatus.DeviceProperties[propertyName] = *actualProperty
 
 		// 1.2. set the device attribute in the edge platform to the expected value
 		var actualValue string


### PR DESCRIPTION
Fixes #2779 and #2771

device_controller: add continue after NotFoundErr branch to prevent
dereferencing nil actualProperty which caused a panic in the
DeviceProperties map write.

otaupdate: add missing return after WriteErr in GetPods handler.
When EncodePods fails, the handler now returns instead of falling
through to WriteJSONResponse with nil data.