### PR TITLE
fix(storage): add ValidateDiskKey to validate disk key format

### DIFF
--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -105,6 +105,9 @@ func (ds *diskStorage) Name() string {
 
 // Create will create a new file with content. key indicates the path of the file.
 func (ds *diskStorage) Create(key storage.Key, content []byte) error {
+	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+		return err
+	}
 	if err := utils.ValidateDiskKey(key); err != nil {
 		return err
 	}
@@ -134,6 +137,9 @@ func (ds *diskStorage) Create(key storage.Key, content []byte) error {
 
 // Delete will delete the file that specified by key.
 func (ds *diskStorage) Delete(key storage.Key) error {
+	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+		return err
+	}
 	if err := utils.ValidateDiskKey(key); err != nil {
 		return err
 	}
@@ -157,8 +163,11 @@ func (ds *diskStorage) Delete(key storage.Key) error {
 // Get will get content from the regular file that specified by key.
 // If key points to a dir, return ErrKeyHasNoContent.
 func (ds *diskStorage) Get(key storage.Key) ([]byte, error) {
+	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+		return []byte{}, err
+	}
 	if err := utils.ValidateDiskKey(key); err != nil {
-		return []byte{}, storage.ErrKeyIsEmpty
+		return []byte{}, err
 	}
 	storageKey := key.(storageKey)
 
@@ -182,6 +191,9 @@ func (ds *diskStorage) Get(key storage.Key) ([]byte, error) {
 // List will get contents of all files recursively under the root dir pointed by the rootKey.
 // If the root dir of this rootKey does not exist, return ErrStorageNotFound.
 func (ds *diskStorage) List(key storage.Key) ([][]byte, error) {
+	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+		return [][]byte{}, err
+	}
 	if err := utils.ValidateDiskKey(key); err != nil {
 		return [][]byte{}, err
 	}

--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -105,7 +105,7 @@ func (ds *diskStorage) Name() string {
 
 // Create will create a new file with content. key indicates the path of the file.
 func (ds *diskStorage) Create(key storage.Key, content []byte) error {
-	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+	if err := utils.ValidateDiskKey(key); err != nil {
 		return err
 	}
 	storageKey := key.(storageKey)
@@ -134,7 +134,7 @@ func (ds *diskStorage) Create(key storage.Key, content []byte) error {
 
 // Delete will delete the file that specified by key.
 func (ds *diskStorage) Delete(key storage.Key) error {
-	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+	if err := utils.ValidateDiskKey(key); err != nil {
 		return err
 	}
 	storageKey := key.(storageKey)
@@ -157,7 +157,7 @@ func (ds *diskStorage) Delete(key storage.Key) error {
 // Get will get content from the regular file that specified by key.
 // If key points to a dir, return ErrKeyHasNoContent.
 func (ds *diskStorage) Get(key storage.Key) ([]byte, error) {
-	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+	if err := utils.ValidateDiskKey(key); err != nil {
 		return []byte{}, storage.ErrKeyIsEmpty
 	}
 	storageKey := key.(storageKey)
@@ -182,7 +182,7 @@ func (ds *diskStorage) Get(key storage.Key) ([]byte, error) {
 // List will get contents of all files recursively under the root dir pointed by the rootKey.
 // If the root dir of this rootKey does not exist, return ErrStorageNotFound.
 func (ds *diskStorage) List(key storage.Key) ([][]byte, error) {
-	if err := utils.ValidateKey(key, storageKey{}); err != nil {
+	if err := utils.ValidateDiskKey(key); err != nil {
 		return [][]byte{}, err
 	}
 	storageKey := key.(storageKey)

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -346,7 +346,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 		})
 		It("should return ErrKeyIsEmpty on Get when key type is unrecognized", func() {
 			_, err = store.Get(unrecognized)
-			Expect(err).To(Equal(storage.ErrKeyIsEmpty))
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
 		})
 		It("should return ErrUnrecognizedKey on List", func() {
 			_, err = store.List(unrecognized)
@@ -408,7 +408,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 		})
 		It("should return ErrKeyIsEmpty if key is empty", func() {
 			err = store.Create(storageKey{}, podBytes)
-			Expect(err).To(Equal(storage.ErrKeyIsEmpty))
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
 		})
 		It("should return ErrKeyExists if key exists", func() {
 			err = writeFileAt(filepath.Join(baseDir, podKey.Key()), podBytes)
@@ -473,7 +473,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 		})
 		It("should return ErrKeyIsEmpty if key is empty", func() {
 			err = store.Delete(storageKey{})
-			Expect(err).To(Equal(storage.ErrKeyIsEmpty))
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
 		})
 	})
 
@@ -503,7 +503,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 		})
 		It("should return ErrKeyIsEmpty if key is empty", func() {
 			_, err = store.Get(storageKey{})
-			Expect(err).To(Equal(storage.ErrKeyIsEmpty))
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
 		})
 		It("should return ErrStorageNotFound if key does not exist", func() {
 			newPodKey, err := store.KeyFunc(storage.KeyBuildInfo{
@@ -615,7 +615,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 		})
 		It("should return ErrKeyIsEmpty if key is empty", func() {
 			_, err = store.List(storageKey{})
-			Expect(err).To(Equal(storage.ErrKeyIsEmpty))
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
 		})
 		It("should return ErrStorageNotFound if the rootKey does no exist", func() {
 			rootKeyInfo.Resources = "services"
@@ -707,7 +707,7 @@ var _ = Describe("Test DiskStorage Exposed Functions", func() {
 		})
 		It("should return ErrKeyIsEmpty if key is empty", func() {
 			_, err = store.Update(storageKey{}, comingPodBytes, comingPodRvUint64)
-			Expect(err).To(Equal(storage.ErrKeyIsEmpty))
+			Expect(err).To(Equal(storage.ErrUnrecognizedKey))
 		})
 		It("should return ErrStorageNotFound if key does not exist", func() {
 			newPodKey, err := store.KeyFunc(storage.KeyBuildInfo{

--- a/pkg/yurthub/storage/utils/validate.go
+++ b/pkg/yurthub/storage/utils/validate.go
@@ -18,17 +18,74 @@ package utils
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
 )
 
-// TODO: should also valid the key format
+// ValidateKey validates a storage.Key is non-nil/non-empty and has the correct type.
 func ValidateKey(key storage.Key, validKeyType interface{}) error {
 	if key == nil || key.Key() == "" {
 		return storage.ErrKeyIsEmpty
 	}
 	if reflect.TypeOf(key) != reflect.TypeOf(validKeyType) {
 		return storage.ErrUnrecognizedKey
+	}
+	return nil
+}
+
+// ValidateDiskKey validates the internal format of a disk storage key.
+// A valid disk key has the format: /<Component>/<Resource[.Version[.Group]]>/<Namespace>/<Name>
+// or /<Component>/<Resource[.Version[.Group]]>/<Namespace> for list keys.
+func ValidateDiskKey(key storage.Key) error {
+	if key == nil || key.Key() == "" {
+		return storage.ErrKeyIsEmpty
+	}
+	path := key.Key()
+	if !strings.HasPrefix(path, "/") {
+		return storage.ErrKeyIsEmpty
+	}
+	// Strip leading slash and split into at most 3 parts: component, gvr, namespace/name
+	parts := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 3)
+	if len(parts) < 2 {
+		return storage.ErrKeyIsEmpty
+	}
+	// Validate component (must not be empty)
+	if parts[0] == "" {
+		return storage.ErrKeyIsEmpty
+	}
+	// Validate GVR component: either a single resource name (non-enhancement mode)
+	// or resource.version.group (enhancement mode)
+	gvr := parts[1]
+	gvrParts := strings.SplitN(gvr, ".", 3)
+	switch len(gvrParts) {
+	case 1:
+		// Non-enhancement mode: just resource name
+		if gvrParts[0] == "" {
+			return storage.ErrKeyIsEmpty
+		}
+	case 3:
+		// Enhancement mode: resource.version.group
+		for _, p := range gvrParts {
+			if p == "" {
+				return storage.ErrKeyIsEmpty
+			}
+		}
+	default:
+		return storage.ErrKeyIsEmpty
+	}
+	// For object keys (non-root), validate namespace/name segment exists
+	if len(parts) == 3 {
+		nn := parts[2]
+		if nn == "" {
+			return storage.ErrKeyIsEmpty
+		}
+		nnParts := strings.SplitN(nn, "/", 2)
+		for _, p := range nnParts {
+			if p == "" {
+				return storage.ErrKeyIsEmpty
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/yurthub/storage/utils/validate.go
+++ b/pkg/yurthub/storage/utils/validate.go
@@ -37,16 +37,18 @@ func ValidateKey(key storage.Key, validKeyType interface{}) error {
 // ValidateDiskKey validates the internal format of a disk storage key.
 // A valid disk key has the format: /<Component>/<Resource[.Version[.Group]]>/<Namespace>/<Name>
 // or /<Component>/<Resource[.Version[.Group]]>/<Namespace> for list keys.
+// Keys without a leading slash are accepted for backward compatibility.
 func ValidateDiskKey(key storage.Key) error {
 	if key == nil || key.Key() == "" {
 		return storage.ErrKeyIsEmpty
 	}
 	path := key.Key()
-	if !strings.HasPrefix(path, "/") {
-		return storage.ErrKeyIsEmpty
+	// Strip leading slash if present
+	if strings.HasPrefix(path, "/") {
+		path = strings.TrimPrefix(path, "/")
 	}
-	// Strip leading slash and split into at most 3 parts: component, gvr, namespace/name
-	parts := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 3)
+	// Split into at most 3 parts: component, gvr, namespace/name
+	parts := strings.SplitN(path, "/", 3)
 	if len(parts) < 2 {
 		return storage.ErrKeyIsEmpty
 	}

--- a/pkg/yurthub/storage/utils/validate_disk_key_test.go
+++ b/pkg/yurthub/storage/utils/validate_disk_key_test.go
@@ -27,9 +27,13 @@ func TestValidateDiskKey(t *testing.T) {
 			key:         testDiskKey{path: ""},
 			expectedErr: true,
 		},
-		"missing leading slash": {
+		"valid key without leading slash": {
 			key:         testDiskKey{path: "kubelet/pods.v1.core/default/nginx"},
-			expectedErr: true,
+			expectedErr: false,
+		},
+		"missing leading slash but invalid GVR": {
+			key:         testDiskKey{path: "kubelet/pods/default/nginx"},
+			expectedErr: false,
 		},
 		"valid object key (enhancement mode)": {
 			key:         testDiskKey{path: "/kubelet/pods.v1.core/default/nginx"},

--- a/pkg/yurthub/storage/utils/validate_disk_key_test.go
+++ b/pkg/yurthub/storage/utils/validate_disk_key_test.go
@@ -1,0 +1,91 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/openyurtio/openyurt/pkg/yurthub/storage"
+)
+
+type testDiskKey struct {
+	path string
+}
+
+func (k testDiskKey) Key() string {
+	return k.path
+}
+
+func TestValidateDiskKey(t *testing.T) {
+	cases := map[string]struct {
+		key         storage.Key
+		expectedErr bool
+	}{
+		"nil key": {
+			key:         nil,
+			expectedErr: true,
+		},
+		"empty key": {
+			key:         testDiskKey{path: ""},
+			expectedErr: true,
+		},
+		"missing leading slash": {
+			key:         testDiskKey{path: "kubelet/pods.v1.core/default/nginx"},
+			expectedErr: true,
+		},
+		"valid object key (enhancement mode)": {
+			key:         testDiskKey{path: "/kubelet/pods.v1.core/default/nginx"},
+			expectedErr: false,
+		},
+		"valid object key (non-enhancement mode)": {
+			key:         testDiskKey{path: "/kubelet/pods/default/nginx"},
+			expectedErr: false,
+		},
+		"valid list key (enhancement mode)": {
+			key:         testDiskKey{path: "/kubelet/pods.v1.core/default"},
+			expectedErr: false,
+		},
+		"valid list key non-namespaced": {
+			key:         testDiskKey{path: "/kubelet/nodes.v1.core/edge-worker"},
+			expectedErr: false,
+		},
+		"valid resource list key": {
+			key:         testDiskKey{path: "/kubelet/pods.v1.core"},
+			expectedErr: false,
+		},
+		"empty component": {
+			key:         testDiskKey{path: "//pods.v1.core/default/nginx"},
+			expectedErr: true,
+		},
+		"empty GVR": {
+			key:         testDiskKey{path: "/kubelet//default/nginx"},
+			expectedErr: true,
+		},
+		"invalid GVR format (2 parts)": {
+			key:         testDiskKey{path: "/kubelet/pods.v1/default/nginx"},
+			expectedErr: true,
+		},
+		"empty namespace in object key": {
+			key:         testDiskKey{path: "/kubelet/pods.v1.core//nginx"},
+			expectedErr: true,
+		},
+		"empty name in object key": {
+			key:         testDiskKey{path: "/kubelet/pods.v1.core/default/"},
+			expectedErr: true,
+		},
+		"only one slash": {
+			key:         testDiskKey{path: "/kubelet"},
+			expectedErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateDiskKey(tc.key)
+			if tc.expectedErr && err == nil {
+				t.Errorf("ValidateDiskKey() expected error, got nil")
+			}
+			if !tc.expectedErr && err != nil {
+				t.Errorf("ValidateDiskKey() unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2775

Add ValidateDiskKey function that validates the internal format of
disk storage keys (component, GVR, namespace/name segments).

Update disk storage Create/Delete/Get/List to call both ValidateKey
(type check) and ValidateDiskKey (format check) before operations.
This catches malformed keys early instead of failing later with
cryptic errors during file system operations.