### PR TITLE
fix(yurttunnel): avoid reusing pooled bufio.Reader in getResponse

### DIFF
--- a/pkg/yurttunnel/server/interceptor.go
+++ b/pkg/yurttunnel/server/interceptor.go
@@ -171,8 +171,7 @@ func (ri *RequestInterceptor) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 func getResponse(r io.Reader) (*http.Response, []byte, error) {
 	rawResponse := bytes.NewBuffer(make([]byte, 0, 256))
 	// Save the bytes read while reading the response headers into the rawResponse buffer
-	br := newBufioReader(io.TeeReader(r, rawResponse))
-	defer putBufioReader(br)
+	br := bufio.NewReader(io.TeeReader(r, rawResponse))
 	resp, err := http.ReadResponse(br, nil)
 	if err != nil {
 		return nil, nil, err
@@ -272,7 +271,6 @@ func isChunked(response *http.Response) bool {
 // serverRequest serves the normal requests, e.g., kubectl logs
 func serveRequest(tunnelConn net.Conn, w http.ResponseWriter, r *http.Request) {
 	br := newBufioReader(tunnelConn)
-	defer putBufioReader(br)
 	tunnelHTTPResp, err := http.ReadResponse(br, r)
 	if err != nil {
 		klogAndHTTPError(w, http.StatusServiceUnavailable, "could not read response from the tunnel: %v", err)


### PR DESCRIPTION
Fixes #2774

The getResponse function reads HTTP response headers into a bufio.Reader
and returns the parsed *http.Response whose Body still reads from the
underlying reader. Using a pooled reader and returning it to the pool
via defer before the response body is fully consumed causes a data race
when another goroutine reuses the same pooled reader.

Create a fresh bufio.Reader instead of using the pool to eliminate the
race condition.