### PR TITLE
fix(autonomy): propagate retry errors instead of swallowing in updateNodeStatus

### DIFF
--- a/pkg/yurthub/proxy/autonomy/autonomy.go
+++ b/pkg/yurthub/proxy/autonomy/autonomy.go
@@ -94,14 +94,14 @@ func (ap *AutonomyProxy) updateNodeStatus(req *http.Request) (runtime.Object, er
 			break
 		} else if err != nil {
 			klog.ErrorS(err, "Error getting or updating node status, will retry")
+			continue
 		} else {
 			return retNode, nil
 		}
 	}
 	if retNode == nil {
-		return nil, fmt.Errorf("failed to get node")
+		return nil, fmt.Errorf("failed to get node status after %d retries", nodeStatusUpdateRetry)
 	}
-	klog.ErrorS(err, "failed to update node autonomy status")
 	return retNode, nil
 }
 


### PR DESCRIPTION
Fixes #2769

When updateNodeStatus exhausts all retries without a successful node
update, the function now returns the accumulated error instead of
silently returning a stale node object. This ensures the proxy caller
is informed of the failure rather than receiving potentially outdated
node status.