### PR TITLE
fix(yurthub): use storage's TableConvertor when implemented

### DIFF
--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy.go
@@ -89,7 +89,7 @@ func (sp *multiplexerProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reqScope, err := sp.getReqScope(gvr)
+	reqScope, err := sp.getReqScope(gvr, restStore)
 	if err != nil {
 		util.Err(errors.Wrapf(err, "failed to get req scope"), w, r)
 		return
@@ -101,10 +101,18 @@ func (sp *multiplexerProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	handlers.ListResource(lister, watcher, reqScope, forceWatch, minRequestTimeout).ServeHTTP(w, r)
 }
 
-func (sp *multiplexerProxy) getReqScope(gvr *schema.GroupVersionResource) (*handlers.RequestScope, error) {
+func (sp *multiplexerProxy) getReqScope(gvr *schema.GroupVersionResource, restStore rest.Storage) (*handlers.RequestScope, error) {
 	_, fqKindToRegister := sp.restMapperManager.KindFor(*gvr)
 	if fqKindToRegister.Empty() {
 		return nil, fmt.Errorf("gvk is not found for gvr: %v", *gvr)
+	}
+
+	// Use storage's custom TableConvertor if available
+	var tableConvertor rest.TableConvertor
+	if tc, ok := restStore.(rest.TableConvertor); ok {
+		tableConvertor = tc
+	} else {
+		tableConvertor = rest.NewDefaultTableConvertor(gvr.GroupResource())
 	}
 
 	return &handlers.RequestScope{
@@ -118,8 +126,7 @@ func (sp *multiplexerProxy) getReqScope(gvr *schema.GroupVersionResource) (*hand
 
 		EquivalentResourceMapper: runtime.NewEquivalentResourceRegistry(),
 
-		// TODO: Check for the interface on storage
-		TableConvertor: rest.NewDefaultTableConvertor(gvr.GroupResource()),
+		TableConvertor: tableConvertor,
 
 		// TODO: This seems wrong for cross-group subresources. It makes an assumption that a subresource and its parent are in the same group version. Revisit this.
 		Resource: *gvr,

--- a/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
+++ b/pkg/yurthub/proxy/multiplexer/multiplexerproxy_test.go
@@ -145,7 +145,7 @@ func TestGetReqScopeReturnsErrorForUnknownGVR(t *testing.T) {
 
 	sp := &multiplexerProxy{restMapperManager: restMapperManager}
 	unknownGVR := schema.GroupVersionResource{Group: "unknown.example.com", Version: "v1", Resource: "widgets"}
-	_, err = sp.getReqScope(&unknownGVR)
+	_, err = sp.getReqScope(&unknownGVR, nil)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Fixes #2781

The multiplexer proxy now checks if the rest.Storage implements
rest.TableConvertor and uses it when available. This allows
custom storage implementations to provide their own table
conversion logic instead of falling back to the default.